### PR TITLE
Update CVE 2013-1877 to 2013-2616

### DIFF
--- a/gems/mini_magick/OSVDB-91231.yml
+++ b/gems/mini_magick/OSVDB-91231.yml
@@ -1,6 +1,6 @@
 ---
 gem: mini_magick
-cve: 2013-1877
+cve: 2013-2616
 osvdb: 91231
 url: http://osvdb.org/show/osvdb/91231
 title: MiniMagick Gem for Ruby URI Handling Arbitrary Command Injection


### PR DESCRIPTION
According to http://cve.mitre.org/cgi-bin/cvename.cgi?name=2013-1877:

> *\* REJECT *\* DO NOT USE THIS CANDIDATE NUMBER. ConsultIDs: CVE-2013-2616. Reason: This candidate is a duplicate of CVE-2013-2616. Notes: All CVE users should reference CVE-2013-2616 instead of this candidate. All references and descriptions in this candidate have been removed to prevent accidental usage.

New CVE reference is http://cve.mitre.org/cgi-bin/cvename.cgi?name=2013-2616
