### PR TITLE
CVE reference fix for rack-cache

### DIFF
--- a/gems/rack-cache/OSVDB-83077.yml
+++ b/gems/rack-cache/OSVDB-83077.yml
@@ -1,6 +1,6 @@
 --- 
 gem: rack-cache
-cve: 2012-267
+cve: 2012-2671
 osvdb: 83077
 url: http://osvdb.org/83077
 title: rack-cache Rubygem Sensitive HTTP Header Caching Weakness


### PR DESCRIPTION
Fixed CVE reference for rack-cache vulnerability (reference: http://cve.mitre.org/cgi-bin/cvename.cgi?name=2012-2671)
