### PR TITLE
Add gitlab-grit gem

### DIFF
--- a/gems/gitlab-grit/OSVDB-99370.yml
+++ b/gems/gitlab-grit/OSVDB-99370.yml
@@ -1,0 +1,14 @@
+---
+gem: gitlab-grit
+cve: 2013-4489
+osvdb: 99370
+url: http://www.osvdb.org/show/osvdb/99370
+title: GitLab Grit Gem for Ruby contains a flaw
+date: 2013-11-04
+description: GitLab Grit Gem for Ruby contains a flaw in the app/contexts/search_context.rb script.
+  The issue is triggered when input passed via the code search box is not properly sanitized,
+  which allows strings to be evaluated by the Bourne shell. This may allow a remote attacker to
+  execute arbitrary commands.
+cvss_v2:
+patched_versions: 
+  - '>= 2.6.1'


### PR DESCRIPTION
Not 100% sure if this is correct. RubyGems https://rubygems.org/gems/gitlab-grit shows the new version 2.6.1. Within the original Repository https://github.com/gitlabhq/grit i didn't see any entry. Within this commit https://github.com/gitlabhq/gitlabhq/commit/1040e88e5645fc3dccf55b418bfbf04d307f3d8b one can see that http://gitlab.org updated the gitlab_git gem which depends on the new gitlab-grit gem for security reasons.
