### PR TITLE
Added will_paginate 3.0.5 bugfix & security release

### DIFF
--- a/gems/will_paginate/3.0.4.yml
+++ b/gems/will_paginate/3.0.4.yml
@@ -1,0 +1,10 @@
+---
+gem: will_paginate
+cve: ""
+url: https://groups.google.com/forum/#!topic/will_paginate/Dguinf-5Sbw
+title: will_paginate v3.0.5 fixes a security vulnerability in Rails apps
+date: 2013-09-19
+description: important security fix that prevents XSS in generated pagination
+  links
+patched_versions:
+  - ">= 3.0.5"


### PR DESCRIPTION
A few months ago the autor of will_paginate publishes a new release stating that it fixes a XSS vulnerability. I would like to add the matching Ruby Advisory DB entry.

Please see https://groups.google.com/forum/#!topic/will_paginate/Dguinf-5Sbw

There is no CVE or OSVDB identifier yet. How do you manage this circumstance? I've set CVE to an empty string in order to pass the tests as a quick fix and reported the vulnerability to OSVDB.

Thanks
Joerg
