### PR TITLE
Specify patched versions of spree gems from old vulnerabilities

### DIFF
--- a/gems/spree/OSVDB-91216.yml
+++ b/gems/spree/OSVDB-91216.yml
@@ -1,4 +1,4 @@
---- 
+---
 gem: spree
 cve: 2013-1656
 osvdb: 91216
@@ -7,4 +7,5 @@ title: Spree promotion_actions_controller.rb promotion_action Parameter Arbitrar
 date: 2013-02-21
 description: Spree contains a flaw that is triggered when handling input passed via the 'promotion_action' parameter to promotion_actions_controller.rb. This may allow a remote authenticated attacker to instantiate arbitrary Ruby objects and potentially execute arbitrary commands.
 cvss_v2: 4.3
-patched_versions: 
+patched_versions:
+  - ">= v2.0.0"

--- a/gems/spree/OSVDB-91217.yml
+++ b/gems/spree/OSVDB-91217.yml
@@ -1,4 +1,4 @@
---- 
+---
 gem: spree
 cve: 2013-1656
 osvdb: 91217
@@ -7,4 +7,5 @@ title: Spree payment_methods_controller.rb payment_method Parameter Arbitrary Ru
 date: 2013-02-21
 description: Spree contains a flaw that is triggered when handling input passed via the 'payment_method' parameter to payment_methods_controller.rb. This may allow a remote authenticated attacker to instantiate arbitrary Ruby objects and potentially execute arbitrary commands.
 cvss_v2: 4.3
-patched_versions: 
+patched_versions:
+  - ">= v2.0.0"

--- a/gems/spree/OSVDB-91218.yml
+++ b/gems/spree/OSVDB-91218.yml
@@ -1,4 +1,4 @@
---- 
+---
 gem: spree
 cve: 2013-1656
 osvdb: 91218
@@ -7,4 +7,5 @@ title: Spree promotions_controller.rb calculator_type Parameter Arbitrary Ruby O
 date: 2013-02-21
 description: Spree contains a flaw that is triggered when handling input passed via the 'calculator_type' parameter to promotions_controller.rb. This may allow a remote authenticated attacker to instantiate arbitrary Ruby objects and potentially execute arbitrary commands.
 cvss_v2: 4.3
-patched_versions: 
+patched_versions:
+  - ">= v2.0.0"

--- a/gems/spree/OSVDB-91219.yml
+++ b/gems/spree/OSVDB-91219.yml
@@ -1,4 +1,4 @@
---- 
+---
 gem: spree
 cve: 2013-1656
 osvdb: 91219
@@ -7,4 +7,5 @@ title: Spree promotion_rules_controller.rb promotion_rule Parameter Arbitrary Ru
 date: 2013-02-21
 description: Spree contains a flaw that is triggered when handling input passed via the 'promotion_rule' parameter to promotion_rules_controller.rb. This may allow a remote authenticated attacker to instantiate arbitrary Ruby objects and potentially execute arbitrary commands.
 cvss_v2: 4.3
-patched_versions: 
+patched_versions:
+  - ">= v2.0.0"


### PR DESCRIPTION
I noticed these don't list the patched versions yet. After a bit of searching, I found the following sources:

http://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed - which links the relevant commit https://github.com/spree/spree/commit/70092eb55b8be8fe5d21a7658b62da658612fba7

The changes in that commit appear to cover, or at least look to be aimed at addressing all the described vulnerabilities in these particular reports.

Although I wasn't able to find changelogs to verify that this was the first released version including these fixes, the time of the 2.0.0 release co-incides a few days prior to the date the blog post linked above was published, and `git tag --contains 70092eb55b8be8fe5d21a7658b62da658612fba7` reports that the tags v2.0.0 and above include this commit.
