### PR TITLE
Update OSVDB-98835.yml

### DIFF
--- a/gems/cocaine/OSVDB-98835.yml
+++ b/gems/cocaine/OSVDB-98835.yml
@@ -10,6 +10,6 @@ description: Cocaine Gem for Ruby contains a flaw that is due to the method
   object, a context-dependent attacker can execute arbitrary commands.
 cvss_v2: 6.8
 unaffected_versions:
-  - ~> 0.3.0
+  - < 0.4.0
 patched_versions: 
   - '>= 0.5.3'


### PR DESCRIPTION
According to the CVE, only cocaine 0.4.x and 0.5.1, 0.5.2 are affected.
