### PR TITLE
Fix patched version for omniauth-oauth2 gem

### DIFF
--- a/gems/omniauth-oauth2/OSVDB-90264.yml
+++ b/gems/omniauth-oauth2/OSVDB-90264.yml
@@ -13,4 +13,4 @@ description: |
 cvss_v2: 6.8
 
 patched_versions:
-  - ">= 1.1.1"
+  - ">= 1.1.2"


### PR DESCRIPTION
I just played around with https://hakiri.io today. Seems they don't use the ruby-advisory-db, cause they produced another result for the omniauth-oauth2 gem. CVE says "vulnerability in the omniauth-oauth2 gem 1.1.1 and earlier".

Maybe someone else can check this:
https://github.com/intridea/omniauth-oauth2/pull/25
https://github.com/intridea/omniauth-oauth2/commit/451f7ecad175e3f91a890a6b363b39889e727b68

Did they fix version 1.1.1 without tagging a new version?
