### PR TITLE
Add dragonfly ruby gem advisory

### DIFF
--- a/gems/dragonfly/OSVDB-110439.yml
+++ b/gems/dragonfly/OSVDB-110439.yml
@@ -1,0 +1,17 @@
+---
+gem: dragonfly
+osvdb: 110439
+url: http://osvdb.org/show/osvdb/110439
+title: Dragonfly Gem Remote Code Execution
+date: 2014-08-25
+
+description: |
+  Dragonfly Gem for Ruby contains a flaw in Uploading & Processing that is due
+  to the gem failing to restrict arbitrary commands to imagemagicks convert.
+  This may allow a remote attacker to gain read/write access to the filesystem
+  and execute arbitrary commands.
+
+cvss_v2:
+
+patched_versions:
+  - ">= 1.0.7"


### PR DESCRIPTION
Please double check. I choosed version 1.0.7 as fixed cause of the latest updates -> https://github.com/markevans/dragonfly/blob/master/History.md.

BUT iam not sure if we can call 1.0.7 a fixed version cause of this post http://seclists.org/fulldisclosure/2014/Aug/68:

"...many websites out there will still disable the verification... Note that this vulnerability is still exploitable if the attacker is unable to upload images, by using the generators to "draw" arbitrary images by imagemagick commands..."
