### PR TITLE
Correct patched versions for omniauth-oauth2

### DIFF
--- a/gems/omniauth-oauth2/OSVDB-90264.yml
+++ b/gems/omniauth-oauth2/OSVDB-90264.yml
@@ -2,7 +2,7 @@
 gem: omniauth-oauth2
 cve: 2012-6134
 osvdb: 90264
-url: http://www.osvdb.org/show/osvdb/90264
+url: http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-6134
 title: Ruby on Rails omniauth-oauth2 Gem CSRF vulnerability
 date: 2012-09-08
 
@@ -13,4 +13,4 @@ description: |
 cvss_v2: 6.8
 
 patched_versions:
-  - ">= 1.1.1"
+  - "> 1.1.1"


### PR DESCRIPTION
The CVE claims that versions through 1.1.1 are affected. Neither
announcement seems entirely complete but the CVE seems better since it
includes specific versions.
