### PR TITLE
Add Spree Ruby gem advisory

### DIFF
--- a/gems/spree/OSVDB-119205.yml
+++ b/gems/spree/OSVDB-119205.yml
@@ -1,0 +1,20 @@
+---
+gem: spree
+osvdb: 119205
+url: http://osvdb.org/show/osvdb/119205
+title: Spree Ruby Gem contains a flaw in the API
+date: 2015-03-05
+description: |
+  Spree contains a flaw in the API as HTTP requests do not require
+  multiple steps, explicit confirmation, or a unique token when
+  performing certain sensitive actions. By tricking a user into
+  following a specially crafted link, a context-dependent attacker
+  can perform a Cross-Site Request Forgery (CSRF / XSRF) attack
+  causing the victim to disclose potentially sensitive information
+  to attackers.
+cvss_v2:
+patched_versions:
+  - ~> 2.2.10
+  - ~> 2.3.8
+  - ~> 2.4.5
+  - ">= 3.0.0.rc4"


### PR DESCRIPTION
Please double check, especially the versions ;-)

Issue Ref.: https://github.com/rubysec/ruby-advisory-db/issues/132
http://osvdb.org/show/osvdb/119205
https://spreecommerce.com/blog/security-updates-2015-3-3
https://rubygems.org/gems/spree/versions