### PR TITLE
Until 4.1, rails is not affected by CVE-2015-3226

### DIFF
--- a/gems/activesupport/CVE-2015-3226.yml
+++ b/gems/activesupport/CVE-2015-3226.yml
@@ -45,7 +45,7 @@ description: |
     end 
 
 unaffected_versions:
-  - "~> 4.0.0"
+  - "< 4.1.0"
 
 patched_versions:
   - ">= 4.2.2"


### PR DESCRIPTION
According to https://groups.google.com/forum/#!searchin/rubyonrails-core/CVE-2015-3226/rubyonrails-core/qBUqVlXERag/kuH3wQk1kxUJ, all versions until rails 4.1 are not affected.