### PR TITLE
Update CVE-2015-3226.yml

### DIFF
--- a/gems/activesupport/CVE-2015-3226.yml
+++ b/gems/activesupport/CVE-2015-3226.yml
@@ -45,6 +45,7 @@ description: |
     end 
 
 unaffected_versions:
+  - "~> 3.2.22"
   - "~> 4.0.0"
 
 patched_versions:


### PR DESCRIPTION
Rails 3.2.x was not affected by this CVE

See:
https://groups.google.com/forum/#!topic/rubyonrails-core/qBUqVlXERag