### PR TITLE
Separate OSVDB-102613 into CVE-2014-1831 and CVE-2014-1832

### DIFF
--- a/gems/passenger/CVE-2014-1831.yml
+++ b/gems/passenger/CVE-2014-1831.yml
@@ -1,6 +1,6 @@
 ---
 gem: passenger
-cve: 2014-1832
+cve: 2014-1831
 osvdb: 102613
 url: http://osvdb.org/show/osvdb/102613
 title: Phusion Passenger Server Instance Directory Creation Local Symlink File Overwrite
@@ -10,4 +10,4 @@ description: Phusion Passenger contains a flaw as the program creates the server
   the directory to cause the program to unexpectedly overwrite an arbitrary file.
 cvss_v2: 2.1
 patched_versions:
-  - ">= 4.0.38"
+  - ">= 4.0.37"

--- a/gems/passenger/CVE-2014-1832.yml
+++ b/gems/passenger/CVE-2014-1832.yml
@@ -1,0 +1,13 @@
+---
+gem: passenger
+cve: 2014-1832
+osvdb: 102613
+url: http://osvdb.org/show/osvdb/102613
+title: Phusion Passenger Server Instance Directory Creation Local Symlink File Overwrite
+date: 2014-01-29
+description: Phusion Passenger contains a flaw as the program creates the server instance
+  directory insecurely. It is possible for a local attacker to use a symlink attack against
+  the directory to cause the program to unexpectedly overwrite an arbitrary file.
+cvss_v2: 2.1
+patched_versions:
+  - ">= 4.0.38"


### PR DESCRIPTION
OSVDB-102613 is really two separate CVEs for similar (but slightly different) issues, so split it so we have a record of both CVEs.