### PR TITLE
Add OSVDB-118481 and make some changes to OSVDB-101179 for nokogiri

### DIFF
--- a/gems/nokogiri/OSVDB-101179.yml
+++ b/gems/nokogiri/OSVDB-101179.yml
@@ -1,12 +1,18 @@
 ---
 gem: nokogiri
+platform: jruby
 cve: 2013-6460
 osvdb: 101179
-url: http://www.osvdb.org/show/osvdb/101179
-title: Nokogiri Gem for JRuby Crafted XML Document Handling Infinite Loop Remote DoS
+url: http://osvdb.org/show/osvdb/101179
+title: |
+  Nokogiri Gem for JRuby Crafted XML Document Handling Infinite Loop Remote DoS
 date: 2013-12-14
-description: Nokogiri Gem for JRuby contains a flaw that may allow a remote denial of service. The issue is triggered when handling a specially crafted XML document, which can result in an infinite loop. This may allow a context-dependent attacker to crash the server.
-cvss_v2:
+description: |
+  Nokogiri Gem for JRuby contains a flaw that may allow a remote denial of
+  service. The issue is triggered when handling a specially crafted XML
+  document, which can result in an infinite loop. This may allow a
+  context-dependent attacker to crash the server.
+cvss_v2: 4.3
 patched_versions: 
-  - ~> 1.5.11
+  - "~> 1.5.11"
   - ">= 1.6.1"

--- a/gems/nokogiri/OSVDB-118481.yml
+++ b/gems/nokogiri/OSVDB-118481.yml
@@ -1,0 +1,15 @@
+---
+gem: nokogiri
+platform: jruby
+osvdb: 118481
+url: https://github.com/sparklemotion/nokogiri/pull/1087
+title: |
+  Nokogiri Gem for JRuby XML Document Root Element Handling Memory Consumption
+  Remote DoS
+date: 2014-04-30
+description: |
+  Nokogiri Gem for JRuby contains a flaw that is triggered when handling a root
+  element in an XML document. This may allow a remote attacker to cause a
+  consumption of memory resources.
+patched_versions:
+  - ">= 1.6.3"


### PR DESCRIPTION
OSVDB-118481 was ridiculously difficult to track down. Had to search through nokogiri commits and changelogs to figure out what it was referring to. Doesn't seem like a CVE was requested either.