### PR TITLE
Add OSVDB-115891 for activeresource

### DIFF
--- a/gems/activeresource/OSVDB-115891.yml
+++ b/gems/activeresource/OSVDB-115891.yml
@@ -1,0 +1,8 @@
+--- 
+gem: activeresource
+framework: rails
+osvdb: 115891
+url: http://www.osvdb.org/show/osvdb/115891
+title: Active Resource (ARes) Gem for Ruby lib/active_resource/base.rb Thread Object Instantiation Unspecified Issue
+date: 2014-09-24
+description: Active Resource (ARes) Gem for Ruby contains an unspecified flaw in lib/active_resource/base.rb that is triggered when instantiating thread objects, which may allow an attacker to have an unspecified impact. No further details have been provided by the vendor.


### PR DESCRIPTION
I'm adding this here for now so it doesn't get forgotten, but I ran across http://osvdb.org/show/osvdb/115891 being mentioned in https://github.com/thesp0nge/dawnscanner/issues/112, which talks about some unspecified activeresource vulnerability.

After lots of digging, I found https://github.com/rails/activeresource/issues/143 (and subsequent PR to fix in https://github.com/rails/activeresource/pull/144). However, doesn't look like the PR ever landed, so this still might be a real issue? I've left patched_versions blank for now.

Since the OSVDB entry and various GitHub issue/PRs are all public, keeping this public as well, but would be good to involve activeresource devs (rails devs, I guess) to see if this is a real issue or not. I'll poke security@rubyonrails about this.
