### PR TITLE
Adding OSVDB-121500 for i18n

### DIFF
--- a/gems/i18n/OSVDB-121500.yml
+++ b/gems/i18n/OSVDB-121500.yml
@@ -1,0 +1,11 @@
+---
+gem: i18n
+osvdb: 121500
+url: http://osvdb.org/show/osvdb/121500
+title: i18n Gem for Ruby lib/i18n/core_ext/hash.rb Hash#slice() Function Hash Handling DoS
+date: 2014-09-27
+description: |
+  i18n Gem for Ruby contains a flaw in the Hash#slice() function in
+  lib/i18n/core_ext/hash.rb that is triggered when calling a hash when
+  :some_key is in keep_keys but not in the hash. This may allow an attacker
+  to cause the program to crash.


### PR DESCRIPTION
**NOT READY FOR MERGING**

http://osvdb.org/show/osvdb/121500

This refers to https://github.com/svenfuchs/i18n/pull/289, which hasn't yet made it to a released version of `i18n`. Perhaps somebody could poke them to get that done so we can add the advisory to the db.