### PR TITLE
Add reference to OSVDB-123859 to redcarpet's CVE-2015-5147

### DIFF
--- a/gems/redcarpet/CVE-2015-5147.yml
+++ b/gems/redcarpet/CVE-2015-5147.yml
@@ -1,15 +1,16 @@
 ---
 gem: redcarpet
 cve: 2015-5147
-title: redcarpet Gem for Ruby html.c header_anchor() Function Stack Overflow
+osvdb: 123859
 url: http://seclists.org/oss-sec/2015/q2/818
+title: redcarpet Gem for Ruby html.c header_anchor() Function Stack Overflow
 date: 2015-06-22
 description: |
   redcarpet Gem for Ruby contains a flaw that allows a stack overflow.
   This flaw exists because the header_anchor() function in html.c uses
   variable length arrays (VLA) without any range checking. This may
   allow a remote attacker to execute arbitrary code.
-cvss_v2:
+cvss_v2: 7.5
 unaffected_versions:
   - "< 3.3.0"
 patched_versions:


### PR DESCRIPTION
OSVDB has assigned OSVDB-123859 to this (though it doesn't show up on their website due to technical problems).

Also add CVSSv2 base score from NVD.