### PR TITLE
Add missing argument to `bundle` to execute advisories rake task

### DIFF
--- a/scripts/post-advisories.sh
+++ b/scripts/post-advisories.sh
@@ -13,6 +13,6 @@ git clone $REPO $DIR
 cd $DIR
 
 bundle install --jobs=3 --retry=3
-bundle exec advisories
+bundle exec rake advisories
 
 git push -q


### PR DESCRIPTION
Forgot to include `rake` in the command.