### PR TITLE
Use actual advisory URL for sup vulnerabilties

### DIFF
--- a/gems/sup/CVE-2013-4478.yml
+++ b/gems/sup/CVE-2013-4478.yml
@@ -2,7 +2,7 @@
 gem: sup
 cve: 2013-4478
 osvdb: 99074
-url: http://osvdb.org/show/osvdb/99074
+url: http://www.phenoelit.org/stuff/whatsup.txt
 title:  Sup MUA Email Attachment Content Type Handling Arbitrary Command Execution
 date: 2013-10-29
 description: Sup MUA contains a flaw that is triggered when handling email

--- a/gems/sup/CVE-2013-4479.yml
+++ b/gems/sup/CVE-2013-4479.yml
@@ -2,7 +2,7 @@
 gem: sup
 cve: 2013-4479
 osvdb: 99074
-url: http://osvdb.org/show/osvdb/99074
+url: http://www.phenoelit.org/stuff/whatsup.txt
 title:  Sup MUA Email Attachment Content Type Handling Arbitrary Command Execution
 date: 2013-10-29
 description: Sup MUA contains a flaw that is triggered when handling email


### PR DESCRIPTION
Think this just makes more sense, and it has way more information than the OSVDB entry.