### PR TITLE
Add / modify advisories for spree

### DIFF
--- a/gems/spree/OSVDB-119205.yml
+++ b/gems/spree/OSVDB-119205.yml
@@ -1,18 +1,16 @@
 ---
 gem: spree
 osvdb: 119205
-url: http://osvdb.org/show/osvdb/119205
-title: Spree Ruby Gem contains a flaw in the API
+url: https://spreecommerce.com/blog/security-updates-2015-3-3
+title: Spree API Information Disclosure CSRF
 date: 2015-03-05
 description: |
-  Spree contains a flaw in the API as HTTP requests do not require
-  multiple steps, explicit confirmation, or a unique token when
-  performing certain sensitive actions. By tricking a user into
-  following a specially crafted link, a context-dependent attacker
-  can perform a Cross-Site Request Forgery (CSRF / XSRF) attack
-  causing the victim to disclose potentially sensitive information
-  to attackers.
-cvss_v2:
+  Spree contains a flaw in the API as HTTP requests do not require multiple
+  steps, explicit confirmation, or a unique token when performing certain
+  sensitive actions. By tricking a user into following a specially crafted
+  link, a context-dependent attacker can perform a Cross-Site Request Forgery
+  (CSRF / XSRF) attack causing the victim to disclose potentially sensitive
+  information to attackers.
 patched_versions:
   - ~> 2.2.10
   - ~> 2.3.8

--- a/gems/spree/OSVDB-125699.yml
+++ b/gems/spree/OSVDB-125699.yml
@@ -1,0 +1,18 @@
+---
+gem: spree
+osvdb: 125699
+url: https://spreecommerce.com/blog/security-updates-2015-7-28
+title: |
+  Spree RABL templates rendering allows Arbitrary Code Execution and File
+  Disclosure
+date: 2015-07-28
+description: |
+  Spree contains a flaw where the rendering of arbitrary RABL templates allows
+  for execution arbitrary files on the host system, as well as disclosing the
+  existence of files on the system. This is a different issue than
+  OSVDB-125701.
+patched_versions:
+  - ~> 2.2.13
+  - ~> 2.3.12
+  - ~> 2.4.9
+  - ">= 3.0.3"

--- a/gems/spree/OSVDB-125701.yml
+++ b/gems/spree/OSVDB-125701.yml
@@ -1,0 +1,17 @@
+---
+gem: spree
+osvdb: 125701
+url: https://spreecommerce.com/blog/security-updates-2015-7-20
+title: |
+  Spree RABL templates rendering allows Arbitrary Code Execution and File
+  Disclosure
+date: 2015-07-20
+description: |
+  Spree contains a flaw where the rendering of arbitrary RABL templates allows
+  for execution arbitrary files on the host system, as well as disclosing the
+  existence of files on the system.
+patched_versions:
+  - ~> 2.2.12
+  - ~> 2.3.11
+  - ~> 2.4.8
+  - ">= 3.0.2"

--- a/gems/spree/OSVDB-125712.yml
+++ b/gems/spree/OSVDB-125712.yml
@@ -1,0 +1,16 @@
+---
+gem: spree
+osvdb: 125712
+url: https://spreecommerce.com/blog/security-issue-all-versions
+title: |
+  Product Scopes could allow for unauthenticated remote command execution
+date: 2012-07-02
+description: |
+  Product Scopes could allow for unauthenticated remote command execution.
+  This was corrected by removing conditions_any scope and use ARel query
+  building instead.
+patched_versions:
+  - ~> 0.11.4
+  - ~> 0.70.6
+  - ~> 1.0.5
+  - ">= 1.1.2"

--- a/gems/spree/OSVDB-125713.yml
+++ b/gems/spree/OSVDB-125713.yml
@@ -1,0 +1,15 @@
+---
+gem: spree
+osvdb: 125713
+url: https://spreecommerce.com/blog/security-issue-all-versions
+title: |
+  Potential XSS vulnerability related to the analytics dashboard
+date: 2012-07-02
+description: |
+  Spree has a flaw in its analytics dashboard where keywords are not escaped,
+  leading to potential XSS.
+patched_versions:
+  - ~> 0.11.4
+  - ~> 0.70.6
+  - ~> 1.0.5
+  - ">= 1.1.2"

--- a/gems/spree/OSVDB-69098.yml
+++ b/gems/spree/OSVDB-69098.yml
@@ -1,0 +1,19 @@
+---
+gem: spree
+cve: 2010-3978
+osvdb: 69098
+url: https://spreecommerce.com/blog/json-hijacking-vulnerability
+title: |
+  Spree Multiple Script JSON Request Validation Weakness Remote Information
+  Disclosure
+date: 2010-11-02
+description: |
+  Spree contains a flaw that may lead to an unauthorized information
+  disclosure. The issue is triggered when the application exchanges data using
+  the JSON service without validating requests, which will disclose sensitive
+  user and order information to a context-dependent attacker when a logged-in
+  user visits a crafted website.
+cvss_v2: 5.0
+patched_versions:
+  - ~> 0.11.2
+  - ">= 0.30.0"

--- a/gems/spree/OSVDB-73751.yml
+++ b/gems/spree/OSVDB-73751.yml
@@ -1,0 +1,11 @@
+---
+gem: spree
+osvdb: 73751
+url: https://spreecommerce.com/blog/security-fixes
+title: Spree Content Controller Unspecified Arbitrary File Disclosure
+date: 2011-04-19
+description: |
+  Spree Gem for Ruby would allow a user to request a specially crafted URL and
+  expose arbitrary files on the server
+patched_versions:
+  - ">= 0.50.1"

--- a/gems/spree/OSVDB-76011.yml
+++ b/gems/spree/OSVDB-76011.yml
@@ -1,0 +1,15 @@
+---
+gem: spree
+osvdb: 76011
+url: https://spreecommerce.com/blog/remote-command-product-group
+title: |
+  Spree Search ProductScope Class search[send][] Parameter Arbitrary Command
+  Execution
+date: 2011-10-05
+description: |
+  The ProductScope class fails to properly sanitize user-supplied input via the
+  'search[send][]' parameter resulting in arbitrary command execution. With a
+  specially crafted request, a remote attacker can potentially cause arbitrary
+  command execution.
+patched_versions:
+  - ">= 0.60.2"

--- a/gems/spree/OSVDB-81505.yml
+++ b/gems/spree/OSVDB-81505.yml
@@ -1,0 +1,14 @@
+---
+gem: spree
+cve: 2008-7310
+osvdb: 81505
+url: https://spreecommerce.com/blog/security-vulnerability-mass-assignment
+title: |
+  Spree Hash Restriction Weakness URL Parsing Order State Value Manipulation
+date: 2008-09-22
+description: |
+  Spree contains a hash restriction weakness that occurs when parsing a
+  modified URL. This may allow an attacker to manipulate order state values.
+cvss_v2: 5.0
+patched_versions:
+  - ">= 0.3.0"

--- a/gems/spree/OSVDB-81506.yml
+++ b/gems/spree/OSVDB-81506.yml
@@ -1,0 +1,16 @@
+---
+gem: spree
+cve: 2008-7311
+osvdb: 81506
+url: https://spreecommerce.com/blog/security-vulernability-session-cookie-store
+title: |
+  Spree Hardcoded config.action_controller_session Hash Value Cryptographic
+  Protection Weakness
+date: 2008-08-12
+description: |
+  Spree contains a hardcoded flaw related to the
+  config.action_controller_session hash value. This may allow an attacker to
+  more easily bypass cryptographic protection.
+cvss_v2: 5.0
+patched_versions:
+  - ">= 0.3.0"

--- a/gems/spree/OSVDB-90865.yml
+++ b/gems/spree/OSVDB-90865.yml
@@ -1,0 +1,20 @@
+---
+gem: spree
+cve: 2013-2506
+osvdb: 90865
+url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+title: |
+  Spree app/models/spree/user.rb Mass Role Assignment Remote Privilege
+  Escalation
+date: 2013-02-21
+description: |
+  Spree contains a flaw that leads to unauthorized privileges being gained. The
+  issue is triggered as certain input related to mass role assignment in
+  app/models/spree/user.rb is not properly verified before being used to update
+  a user. This may allow a remote attacker to assign arbitrary roles and gain
+  elevated administrative privileges.
+cvss_v2: 4.0
+patched_versions:
+  - ~> 1.1.6
+  - ~> 1.2.0
+  - ">= 1.3.0"

--- a/gems/spree/OSVDB-91216.yml
+++ b/gems/spree/OSVDB-91216.yml
@@ -2,14 +2,16 @@
 gem: spree
 cve: 2013-1656
 osvdb: 91216
-url: http://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
-title: Spree Gem Contains Arbitrary Ruby Object Instantiation Command Execution in Admin View
+url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+title: |
+  Spree promotion_actions_controller.rb promotion_action Parameter Arbitrary
+  Ruby Object Instantiation Command Execution
 date: 2013-02-21
-description: >  
-  Spree contains several instances of passing user controlled
-  parameters to String#constantize. This may allow an attacker to
-  instantiate arbitrary Ruby objects and potentially execute arbitrary
-  commands. This flaw exists in the admin-accessible controllers.
+description: |
+  Spree contains a flaw that is triggered when handling input passed via the
+  'promotion_action' parameter to promotion_actions_controller.rb. This may
+  allow a remote authenticated attacker to instantiate arbitrary Ruby objects
+  and potentially execute arbitrary commands.
 cvss_v2: 4.3
 patched_versions:
   - ">= 2.0.0"

--- a/gems/spree/OSVDB-91217.yml
+++ b/gems/spree/OSVDB-91217.yml
@@ -1,0 +1,17 @@
+---
+gem: spree
+cve: 2013-1656
+osvdb: 91217
+url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+title: |
+  Spree payment_methods_controller.rb payment_method Parameter Arbitrary Ruby
+  Object Instantiation Command Execution
+date: 2013-02-21
+description: |
+  Spree contains a flaw that is triggered when handling input passed via the
+  'payment_method' parameter to payment_methods_controller.rb. This may allow
+  a remote authenticated attacker to instantiate arbitrary Ruby objects and
+  potentially execute arbitrary commands.
+cvss_v2: 4.3
+patched_versions:
+  - ">= 2.0.0"

--- a/gems/spree/OSVDB-91218.yml
+++ b/gems/spree/OSVDB-91218.yml
@@ -1,0 +1,17 @@
+---
+gem: spree
+cve: 2013-1656
+osvdb: 91218
+url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+title: |
+  Spree promotions_controller.rb calculator_type Parameter Arbitrary Ruby
+  Object Instantiation Command Execution
+date: 2013-02-21
+description: |
+  Spree contains a flaw that is triggered when handling input passed via the
+  'calculator_type' parameter to promotions_controller.rb. This may allow a
+  remote authenticated attacker to instantiate arbitrary Ruby objects and
+  potentially execute arbitrary commands.
+cvss_v2: 4.3
+patched_versions:
+  - ">= 2.0.0"

--- a/gems/spree/OSVDB-91219.yml
+++ b/gems/spree/OSVDB-91219.yml
@@ -1,0 +1,17 @@
+---
+gem: spree
+cve: 2013-1656
+osvdb: 91219
+url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+title: |
+  Spree promotion_rules_controller.rb promotion_rule Parameter Arbitrary Ruby
+  Object Instantiation Command Execution
+date: 2013-02-21
+description: |
+  Spree contains a flaw that is triggered when handling input passed via the
+  'promotion_rule' parameter to promotion_rules_controller.rb. This may allow
+  a remote authenticated attacker to instantiate arbitrary Ruby objects and
+  potentially execute arbitrary commands.
+cvss_v2: 4.3
+patched_versions:
+  - ">= 2.0.0"

--- a/gems/spree_auth/OSVDB-90865.yml
+++ b/gems/spree_auth/OSVDB-90865.yml
@@ -1,0 +1,18 @@
+---
+gem: spree_auth
+cve: 2013-2506
+osvdb: 90865
+url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+title: |
+  Spree app/models/spree/user.rb Mass Role Assignment Remote Privilege
+  Escalation
+date: 2013-02-21
+description: |
+  Spree contains a flaw that leads to unauthorized privileges being gained. The
+  issue is triggered as certain input related to mass role assignment in
+  app/models/spree/user.rb is not properly verified before being used to update
+  a user. This may allow a remote attacker to assign arbitrary roles and gain
+  elevated administrative privileges.
+cvss_v2: 4.0
+patched_versions:
+  - ">= 1.1.6"

--- a/gems/spree_auth_devise/OSVDB-90865.yml
+++ b/gems/spree_auth_devise/OSVDB-90865.yml
@@ -1,0 +1,20 @@
+---
+gem: spree_auth_devise
+cve: 2013-2506
+osvdb: 90865
+url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+title: |
+  Spree app/models/spree/user.rb Mass Role Assignment Remote Privilege
+  Escalation
+date: 2013-02-21
+description: |
+  Spree contains a flaw that leads to unauthorized privileges being gained. The
+  issue is triggered as certain input related to mass role assignment in
+  app/models/spree/user.rb is not properly verified before being used to update
+  a user. This may allow a remote attacker to assign arbitrary roles and gain
+  elevated administrative privileges.
+cvss_v2: 4.0
+patched_versions:
+  - ~> 1.1.6
+  - ~> 1.2.0
+  - ">= 1.3.0"


### PR DESCRIPTION
Add a bunch of advisories for `spree`, as well as modify two existing ones.

Note that `spree` is a bit weird in that it's really split into a bunch of different gems. These gems all keep the same version for the release. Some of this fixes cross these sub-gem boundaries, so hard to keep track of things. I made the decision to just keep everything tied to the `spree` gem itself, even though some other sub-gems are affected.