### PR TITLE
Fix OSVDB scraper to work with CloudFlare's protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 gem 'rspec', '3.3.0'
 gem 'rake'
+
+group :development do
+  gem 'pry'
+  gem 'nokogiri'
+end

--- a/lib/cf_scrape.py
+++ b/lib/cf_scrape.py
@@ -1,0 +1,5 @@
+import cfscrape
+import sys
+
+scraper = cfscrape.create_scraper() # returns a requests.Session object
+print scraper.get(sys.argv[1]).content


### PR DESCRIPTION
Add a Python script `lib/cf_scrape.py` that uses `cfscrape` (https://github.com/Anorov/cloudflare-scrape) in order to scrape OSVDB's advisory pages.

Rename `lib/scrape.rb` to `lib/osvdb_scrape.rb` and update it to work with separate Python script, as well as support just passing the ID directly.

Fixes #174.