### PR TITLE
Handle two renamed gems

### DIFF
--- a/gems/bcrypt/OSVDB-62067.yml
+++ b/gems/bcrypt/OSVDB-62067.yml
@@ -1,0 +1,17 @@
+---
+gem: bcrypt
+platform: jruby
+osvdb: 62067
+url: http://www.mindrot.org/files/jBCrypt/internat.adv
+title: bcrypt-ruby Gem for Ruby incorrect encoding of non US-ASCII characters (JRuby only)
+date: 2010-02-01
+description: |
+  bcrypt-ruby Gem for Ruby suffered from a bug related to character
+  encoding that substantially reduced the entropy of hashed passwords
+  containing non US-ASCII characters. An incorrect encoding step
+  transparently replaced such characters by '?' prior to hashing. In the
+  worst case of a password consisting solely of non-US-ASCII characters,
+  this would cause its hash to be equivalent to all other such passwords
+  of the same length. This issue only affects the JRuby implementation.
+patched_versions:
+  - ">= 2.1.4"

--- a/gems/dragonfly/OSVDB-96798.yml
+++ b/gems/dragonfly/OSVDB-96798.yml
@@ -1,5 +1,5 @@
 ---
-gem: fog-dragonfly
+gem: dragonfly
 cve: 2013-5671
 osvdb: 96798
 url: http://osvdb.org/show/osvdb/96798
@@ -10,3 +10,5 @@ description: |
   failing to properly sanitize input passed via the imagemagickutils.rb script.
   This may allow a remote attacker to execute arbitrary commands.
 cvss_v2: 7.5
+patched_versions:
+  - ">= 0.8.4"

--- a/gems/fog-dragonfly/OSVDB-110439.yml
+++ b/gems/fog-dragonfly/OSVDB-110439.yml
@@ -1,0 +1,11 @@
+---
+gem: fog-dragonfly
+osvdb: 110439
+url: http://osvdb.org/show/osvdb/110439
+title: Dragonfly Gem for Ruby Image Uploading & Processing Remote Command Execution
+date: 2014-08-25
+description: |
+  Dragonfly Gem for Ruby contains a flaw in Uploading & Processing that is due
+  to the gem failing to restrict arbitrary commands to imagemagicks convert.
+  This may allow a remote attacker to gain read/write access to the filesystem
+  and execute arbitrary commands.

--- a/gems/fog-dragonfly/OSVDB-90647.yml
+++ b/gems/fog-dragonfly/OSVDB-90647.yml
@@ -1,0 +1,14 @@
+---
+gem: fog-dragonfly
+cve: 2013-1756
+osvdb: 90647
+url: http://www.osvdb.org/show/osvdb/90647
+title: Dragonfly Gem for Ruby Crafted Request Parsing Remote Code Execution
+date: 2013-02-19
+description: |
+  Dragonfly Gem for Ruby contains a flaw that is triggered during the parsing
+  of a specially crafted request. This may allow a remote attacker to execute
+  arbitrary code.
+cvss_v2: 7.5
+unaffected_versions:
+  - "< 0.7.0"

--- a/gems/fog-dragonfly/OSVDB-97854.yml
+++ b/gems/fog-dragonfly/OSVDB-97854.yml
@@ -1,0 +1,10 @@
+---
+gem: fog-dragonfly
+osvdb: 97854
+url: http://osvdb.org/show/osvdb/97854
+title: Dragonfly Gem for Ruby on Windows Shell Escaping Weakness
+date: 2011-09-01
+description: |
+  Dragonfly Gem for Ruby contains a flaw that is due to the program failing to
+  properly escape a shell that contains injected characters. This may allow a
+  context-dependent attacker to potentially execute arbitrary commands.


### PR DESCRIPTION
As per #170, add directories for both old and new versions of a gem name. For the old version, I leave `patched_versions` blank where appropriate.