### PR TITLE
Adding CVE-2014-0156

### DIFF
--- a/gems/awesome_spawn/CVE-2014-0156.yml
+++ b/gems/awesome_spawn/CVE-2014-0156.yml
@@ -1,6 +1,6 @@
 ---
 gem: awesome_spawn
-cve: CVE-2014-0156
+cve: 2014-0156
 url: https://github.com/ManageIQ/awesome_spawn/commit/e524f85f1c6e292ef7d117d7818521307ac269ff
 title: OS command injection flaw in awesome_spawn
 date: 2014-03-28

--- a/gems/awesome_spawn/CVE-2014-0156.yml
+++ b/gems/awesome_spawn/CVE-2014-0156.yml
@@ -1,0 +1,19 @@
+---
+gem: awesome_spawn
+cve: CVE-2014-0156
+url: https://github.com/ManageIQ/awesome_spawn/commit/e524f85f1c6e292ef7d117d7818521307ac269ff
+title: OS command injection flaw in awesome_spawn
+date: 2014-03-28
+
+description: >-
+  Awesome spawn contains OS command injection vulnerability, which allows
+  execution of additional commands passed to Awesome spawn as arguments, e.g.
+  AwesomeSpawn.run('ls',:params => {'-l' => ";touch haxored"}). If untrusted
+  input was included in command arguments, attacker could use this flaw to
+  execute arbitrary command.
+  
+cvss_v2:  6.8
+
+patched_versions:
+  - "~> 1.2.0"
+  - ">= 1.3.0"


### PR DESCRIPTION
This is a PR to include CVE-2014-0156 OS command injection vulnerability in awesome_spawn.

The vulnerability was found by Jan Rusnacko, reported directly to upstream maintainer on 2014-03-28, CVE ID was assigned by Red Hat and the issue was fixed in commit https://github.com/ManageIQ/awesome_spawn/commit/e524f85f1c6e292ef7d117d7818521307ac269ff