### PR TITLE
Fixing OSVDB-90587's patched versions

### DIFF
--- a/rubies/ruby/OSVDB-90587.yml
+++ b/rubies/ruby/OSVDB-90587.yml
@@ -13,4 +13,4 @@ description: |
 cvss_v2: 5.0
 patched_versions:
   - ~> 1.9.3.392
-  - ~> 2.0.0.0
+  - ">= 2.0.0.0"


### PR DESCRIPTION
The current advisory uses `~>` to explicitly flag only two versions as patched. This causes automated tools to flag Ruby 2.1.0+ as vulnerable.

[The advisory](http://www.osvdb.org/show/osvdb/90587) states "Upgrade to version 1.9.3-p392, or higher, to address this vulnerability." Ruby 2.0.0.0 was released after 1.9.3-p392, so a simple `>=` is adequate to cover all newer versions.
