### PR TITLE
Add advisories for libxml2 and libxslt vulnerabilties patched in Nokogiri

### DIFF
--- a/gems/nokogiri/CVE-2015-1819.yml
+++ b/gems/nokogiri/CVE-2015-1819.yml
@@ -39,7 +39,8 @@ description: |
   uninitialized value(s)" and unsafe memory access. This issue does not have a
   CVE assigned yet. See related URLs for details. Patched in v1.6.7.rc4.
 patched_versions:
-  - ">= 1.6.6.4"
+  - "~> 1.6.6.4"
+  - ">= 1.6.7.rc4"
 related:
   cve:
     - 2015-7941

--- a/gems/nokogiri/CVE-2015-1819.yml
+++ b/gems/nokogiri/CVE-2015-1819.yml
@@ -1,0 +1,43 @@
+---
+gem: nokogiri
+cve: 2015-1819
+url: https://github.com/sparklemotion/nokogiri/issues/1374
+title: Nokogiri gem contains several vulnerabilities in libxml2 and libxslt
+date: 2015-04-14
+description: |
+  Several vulnerabilities were discovered in the libxml2 and libxslt libraries
+  that the Nokogiri gem depends on.
+
+  CVE-2015-1819
+  A denial of service flaw was found in the way libxml2 parsed XML
+  documents. This flaw could cause an application that uses libxml2 to use an
+  excessive amount of memory.
+
+  CVE-2015-7941
+  libxml2 does not properly stop parsing invalid input, which allows
+  context-dependent attackers to cause a denial of service (out-of-bounds read
+  and libxml2 crash) via crafted specially XML data.
+
+  CVE-2015-7942
+  The xmlParseConditionalSections function in parser.c in libxml2
+  does not properly skip intermediary entities when it stops parsing invalid
+  input, which allows context-dependent attackers to cause a denial of service
+  (out-of-bounds read and crash) via crafted XML data.
+
+  CVE-2015-7995
+  The xsltStylePreCompute function in preproc.c in libxslt 1.1.28 does not
+  check whether the parent node is an element, which allows attackers to cause
+  a denial of service using a specially crafted XML document.
+
+  CVE-2015-8035
+  The xz_decomp function in xzlib.c in libxml2 2.9.1 does not
+  properly detect compression errors, which allows context-dependent attackers
+  to cause a denial of service (process hang) via crafted XML data.
+patched_versions:
+  - ">= 1.6.7.rc4"
+related:
+  cve:
+    - 2015-7941
+    - 2015-7942
+    - 2015-7995
+    - 2015-8035

--- a/gems/nokogiri/CVE-2015-1819.yml
+++ b/gems/nokogiri/CVE-2015-1819.yml
@@ -33,11 +33,19 @@ description: |
   The xz_decomp function in xzlib.c in libxml2 2.9.1 does not
   properly detect compression errors, which allows context-dependent attackers
   to cause a denial of service (process hang) via crafted XML data.
+
+  Another vulnerability was discoverd in libxml2 that could cause parsing
+  of unclosed comments to result in "conditional jump or move depends on
+  uninitialized value(s)" and unsafe memory access. This issue does not have a
+  CVE assigned yet. See related URLs for details. Patched in v1.6.7.rc4.
 patched_versions:
-  - ">= 1.6.7.rc4"
+  - ">= 1.6.6.4"
 related:
   cve:
     - 2015-7941
     - 2015-7942
     - 2015-7995
     - 2015-8035
+  url:
+    - https://github.com/sparklemotion/nokogiri/pull/1376
+    - https://github.com/sparklemotion/nokogiri/commit/8f3de6d88d0da11fb62a45daa61b85ce71b4af59


### PR DESCRIPTION
Adds advisories for vulnerabilities in libxml2 and libxslt libraries that have recently been patched in Nokogiri.

Mentioned in release notes for Nokogiri v1.6.7.rc4: https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.rdoc#167rc4--2015-11-22