### PR TITLE
multiple nokogiri vulnerabilities via libxml2

### DIFF
--- a/gems/nokogiri/CVE-2015-5312.yml
+++ b/gems/nokogiri/CVE-2015-5312.yml
@@ -1,0 +1,92 @@
+---
+gem: nokogiri
+cve: 2015-5312
+url: https://groups.google.com/forum/#!topic/ruby-security-ann/aSbgDiwb24s
+title: Nokogiri gem contains several vulnerabilities in libxml2
+date: 2015-12-15
+
+description: |
+  Nokogiri version 1.6.7.1 has been released, pulling in several upstream
+  patches to the vendored libxml2 to address the following CVEs:
+
+  CVE-2015-5312
+  CVSS v2 Base Score: 7.1 (HIGH)
+  The xmlStringLenDecodeEntities function in parser.c in libxml2
+  before 2.9.3 does not properly prevent entity expansion, which
+  allows context-dependent attackers to cause a denial of
+  service (CPU consumption) via crafted XML data, a different
+  vulnerability than CVE-2014-3660.
+
+  CVE-2015-7497
+  CVSS v2 Base Score: 5.0 (MEDIUM)
+  Heap-based buffer overflow in the xmlDictComputeFastQKey
+  function in dict.c in libxml2 before 2.9.3 allows
+  context-dependent attackers to cause a denial of service via
+  unspecified vectors.
+
+  CVE-2015-7498
+  CVSS v2 Base Score: 5.0 (MEDIUM)
+  Heap-based buffer overflow in the xmlParseXmlDecl function in
+  parser.c in libxml2 before 2.9.3 allows context-dependent
+  attackers to cause a denial of service via unspecified vectors
+  related to extracting errors after an encoding conversion
+  failure.
+
+  CVE-2015-7499
+  CVSS v2 Base Score: 5.0 (MEDIUM)
+  Heap-based buffer overflow in the xmlGROW function in parser.c
+  in libxml2 before 2.9.3 allows context-dependent attackers to
+  obtain sensitive process memory information via unspecified
+  vectors.
+
+  CVE-2015-7500
+  CVSS v2 Base Score: 5.0 (MEDIUM)
+  The xmlParseMisc function in parser.c in libxml2 before 2.9.3
+  allows context-dependent attackers to cause a denial of
+  service (out-of-bounds heap read) via unspecified vectors
+  related to incorrect entities boundaries and start tags.
+
+  CVE-2015-8241
+  CVSS v2 Base Score: 6.4 (MEDIUM)
+  The xmlNextChar function in libxml2 2.9.2 does not properly
+  check the state, which allows context-dependent attackers to
+  cause a denial of service (heap-based buffer over-read and
+  application crash) or obtain sensitive information via crafted
+  XML data.
+
+  CVE-2015-8242
+  CVSS v2 Base Score: 5.8 (MEDIUM)
+  The xmlSAX2TextNode function in SAX2.c in the push interface in
+  the HTML parser in libxml2 before 2.9.3 allows
+  context-dependent attackers to cause a denial of
+  service (stack-based buffer over-read and application crash) or
+  obtain sensitive information via crafted XML data.
+
+  CVE-2015-8317
+  CVSS v2 Base Score: 5.0 (MEDIUM)
+  The xmlParseXMLDecl function in parser.c in libxml2 before
+  2.9.3 allows context-dependent attackers to obtain sensitive
+  information via an (1) unterminated encoding value or (2)
+  incomplete XML declaration in XML data, which triggers an
+  out-of-bounds heap read.
+
+cvss_v2: 7.1
+
+unaffected_versions:
+  - "< 1.6.0"
+
+patched_versions:
+  - ">= 1.6.7.1"
+
+related:
+  cve:
+    - 2015-7497
+    - 2015-7498
+    - 2015-7499
+    - 2015-7500
+    - 2015-8241
+    - 2015-8242
+    - 2015-8317
+  url:
+    - https://github.com/sparklemotion/nokogiri/pull/1378
+    - https://github.com/sparklemotion/nokogiri/commit/4205af1a2a546f79d1b48df2ad8b27299c0099c5


### PR DESCRIPTION
Nokogiri gem version 1.6.7.1 updates the vendored libxml2 to version 1.9.3 - fixing multiple vulnerabilities.

I've included the link to the ruby-sec-ann announcement, and followed the same format as a prior Nokogiri release with multiple vulnerabilities, by having one entry, and using the `related` field for the other CVE's.