### PR TITLE
Fixing CVE-2015-7551's patched versions

### DIFF
--- a/rubies/ruby/CVE-2015-7551.yml
+++ b/rubies/ruby/CVE-2015-7551.yml
@@ -14,5 +14,6 @@ patched_versions:
   - ~> 2.0.0.648
   - ~> 2.1.8
   - ~> 2.2.4
+  - ">= 2.3.0"
 unaffected_versions:
   - ~> 1.9.1.129


### PR DESCRIPTION
Per https://www.ruby-lang.org/en/news/2015/12/16/unsafe-tainted-string-usage-in-fiddle-and-dl-cve-2015-7551/, Ruby 2.3.0 preview 1 and preview 2 are vulnerable, but 2.3.0 is not (revisions prior to trunk revision 53153 are vulnerable. 2.3.0 is revision 53290). Adding a patched_version line for 2.3.0+. This is consistent with existing advisories (patch versions are represented using "x.y.z.patch.1", and 2.3.0 is >= 2.3.0.patch.2).