### PR TITLE
Add todays cves

### DIFF
--- a/gems/actionpack/CVE-2015-7576.yml
+++ b/gems/actionpack/CVE-2015-7576.yml
@@ -1,0 +1,22 @@
+---
+gem: actionpack
+framework: rails
+cve: 2015-7576
+url: https://groups.google.com/forum/#!topic/rubyonrails-security/ANv0HDHEC3k
+title: Timing attack vulnerability in basic authentication in Action Controller
+date: 2016-01-25
+
+description: |
+  There is a timing attack vulnerability in the basic authentication support
+  in Action Controller. Due to the way that Action Controller compares user
+  names and passwords in basic authentication authorization code, it is
+  possible for an attacker to analyze the time taken by a response and
+  intuit the password.
+  Attackers can use this information to attempt to guess the username and
+  password used in the basic authentication system.
+
+patched_versions:
+  - ~> 3.2.22.1
+  - ~> 4.1.14.1
+  - ~> 4.2.5.1
+  - 5.0.0.beta1.1

--- a/gems/actionpack/CVE-2015-7581.yml
+++ b/gems/actionpack/CVE-2015-7581.yml
@@ -1,0 +1,22 @@
+---
+gem: actionpack
+framework: rails
+cve: 2015-7581
+url: https://groups.google.com/forum/#!topic/rubyonrails-security/dthJ5wL69JE
+title: Object leak vulnerability for wildcard controller routes in Action Pack
+date: 2016-01-25
+
+description: |
+  Users that have a route that contains the string ":controller" are susceptible
+  to objects being leaked globally which can lead to unbounded memory growth.
+  To identify if your application is vulnerable, look for routes that contain
+  ":controller".
+
+
+unaffected_versions:
+  - "<= 4.0.0"
+  - ">= 5.0.0.beta1"
+
+patched_versions:
+  - ~> 4.1.14.1
+  - ~> 4.2.5.1

--- a/gems/actionpack/CVE-2016-0751.yml
+++ b/gems/actionpack/CVE-2016-0751.yml
@@ -1,0 +1,19 @@
+---
+gem: actionpack
+framework: rails
+cve: 2016-0751
+url: https://groups.google.com/forum/#!topic/rubyonrails-security/9oLY_FCzvoc
+title: Possible Object Leak and Denial of Service attack in Action Pack
+date: 2016-01-25
+
+description: |
+  There is a possible object leak which can lead to a denial of service
+  vulnerability in Action Pack. A carefully crafted accept header can
+  cause a global cache of mime types to grow indefinitely which can lead
+  to a possible denial of service attack in Action Pack.
+
+patched_versions:
+  - ~> 3.2.22.1
+  - ~> 4.1.14.1
+  - ~> 4.2.5.1
+  - 5.0.0.beta1.1

--- a/gems/actionview/CVE-2016-0752.yml
+++ b/gems/actionview/CVE-2016-0752.yml
@@ -1,0 +1,18 @@
+---
+gem: actionview
+framework: rails
+cve: 2016-0752
+url: https://groups.google.com/forum/#!topic/rubyonrails-security/335P1DcLG00
+title: Possible Information Leak Vulnerability in Action View
+date: 2016-01-25
+
+description: |
+  There is a possible directory traversal and information leak vulnerability in
+  Action View. Applications that pass unverified user input to the `render`
+  method in a controller may be vulnerable to an information leak vulnerability.
+
+patched_versions:
+  - ~> 3.2.22.1
+  - ~> 4.1.14.1
+  - ~> 4.2.5.1
+  - 5.0.0.beta1.1

--- a/gems/activemodel/CVE-2016-0753.yml
+++ b/gems/activemodel/CVE-2016-0753.yml
@@ -1,0 +1,21 @@
+---
+gem: actionmodel
+framework: rails
+cve: 2016-0753
+url: https://groups.google.com/forum/#!topic/rubyonrails-security/335P1DcLG00
+title: Possible Input Validation Circumvention in Active Model
+date: 2016-01-25
+
+description: |
+  Code that uses Active Model based models (including Active Record models) and
+  does not validate user input before passing it to the model can be subject to
+  an attack where specially crafted input will cause the model to skip
+  validations.
+
+unaffected_versions:
+  - "< 4.0.13"
+
+patched_versions:
+  - ~> 4.1.14.1
+  - ~> 4.2.5.1
+  - 5.0.0.beta1.1

--- a/gems/activerecord/CVE-2015-7577.yml
+++ b/gems/activerecord/CVE-2015-7577.yml
@@ -1,0 +1,21 @@
+---
+gem: activerecord
+framework: rails
+cve: 2015-7577
+url: https://groups.google.com/forum/#!topic/rubyonrails-security/cawsWcQ6c8g
+title: Nested attributes rejection proc bypass in Active Record
+date: 2016-01-25
+
+description: |
+  There is a vulnerability in how the nested attributes feature in Active Record
+  handles updates in combination with destroy flags when destroying records is
+  disabled.
+
+unaffected_versions:
+  - "< 3.1.0"
+
+patched_versions:
+  - ~> 3.2.22.1
+  - ~> 4.1.14.1
+  - ~> 4.2.5.1
+  - 5.0.0.beta1.1

--- a/gems/rails-html-sanitizer/CVE-2015-7578.yml
+++ b/gems/rails-html-sanitizer/CVE-2015-7578.yml
@@ -1,0 +1,15 @@
+---
+gem: rails-html-sanitizer
+framework: rails
+cve: 2015-7578
+url: https://groups.google.com/forum/#!topic/rubyonrails-security/uh--W4TDwmI
+title: Possible XSS vulnerability in rails-html-sanitizer
+date: 2016-01-25
+
+description: |
+  There is a possible XSS vulnerability in rails-html-sanitizer. Certain
+  attributes are not removed from tags when they are sanitized, and these
+  attributes can lead to an XSS attack on target applications.
+
+patched_versions:
+  - ~> 1.0.3

--- a/gems/rails-html-sanitizer/CVE-2015-7579.yml
+++ b/gems/rails-html-sanitizer/CVE-2015-7579.yml
@@ -1,0 +1,20 @@
+---
+gem: rails-html-sanitizer
+framework: rails
+cve: 2015-7579
+url: https://groups.google.com/forum/#!topic/rubyonrails-security/OU9ugTZcbjc
+title: XSS vulnerability in rails-html-sanitizer
+date: 2016-01-25
+
+description: |
+  Due to the way that `Rails::Html::FullSanitizer` is implemented, if an attacker
+  passes an already escaped HTML entity to the input of Action View's `strip_tags`
+  these entities will be unescaped what may cause a XSS attack if used in combination
+  with `raw` or `html_safe`.
+
+unaffected_versions:
+  - "1.0.0"
+  - "1.0.1"
+
+patched_versions:
+  - ~> 1.0.3


### PR DESCRIPTION
Adds the 8 CVEs that came out on [rubyonrails-security](https://groups.google.com/forum/#!forum/rubyonrails-security).

Please double check the contents since I'm very tired and could have fat-fingered the data entry :sleepy: 

Adds:
- CVE-2015-7581
- CVE-2015-7578
- CVE-2016-0753
- CVE-2016-0752
- CVE-2015-7579
- CVE-2015-7577
- CVE-2016-0751
- CVE-2015-7576