### PR TITLE
Add DB file generation task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 require 'yaml'
+require 'nokogiri'
+require 'open-uri'
 
 namespace :lint do
   begin
@@ -17,6 +19,39 @@ namespace :lint do
 
       unless advisory['cve']
         puts "Missing CVE: #{path}"
+      end
+    end
+  end
+end
+
+config = YAML.load(File.read("./config.yml"))
+namespace :db do
+  # TODO: sleep after each generation
+  desc "generate files"
+  task :update => config.select {|k,attrs| attrs["exec"]}.keys.map { |name| "db:update:#{name}"}
+
+  namespace :update do
+    config.each do |name, attrs|
+      next unless attrs["exec"]
+      desc "generate #{name} files"
+      task name do
+        doc = open(attrs["url"]) { |f| Nokogiri::XML(f) }
+        doc.xpath(attrs["entry_condition"]).each do |elem|
+          h = attrs["base_attributes"].merge(attrs["attribute_conditions"].map {|k, conds|
+            if conds.kind_of?(Array)
+              # FIXME
+              [k, elem.xpath(conds[0]).first.xpath(conds[1]).to_s]
+            else
+              [k, elem.xpath(conds).first.content]
+            end
+          }.to_h)
+          path = File.join(attrs["path"], "CVE-" + h["cve"] + ".yml")
+          if !File.exists?(path)
+            File.open(path, "w") do |f|
+              f.write(h.to_yaml)
+            end
+          end
+        end
       end
     end
   end

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,86 @@
+ruby:
+  # TODO: from CVE DB if possible
+  url: https://www.ruby-lang.org/en/feeds/news.rss
+  entry_condition: '//item[contains(title, "CVE")]'
+  path: rubies/ruby/
+  base_attributes:
+    engine: ruby
+  attribute_conditions:
+    cve: ['title/text()', 'substring-after(substring-before(., ":"), "CVE-")']
+    url: link
+    title: ['title/text()', 'substring-after(., ": ")']
+    date: pubDate
+    description: description
+  exec: true
+
+rails_base: &rails_base
+  url: "https://groups.google.com/forum/feed/rubyonrails-security/msgs/rss.xml?num=15"
+  attribute_conditions:
+    cve: ['title/text()', 'substring-after(substring-before(., "]"), "CVE-")']
+    url: link
+    title: ['title/text()', 'substring-after(., "] ")']
+    # TODO: fix date format
+    date: pubDate
+    description: description
+  exec: false
+
+activerecord:
+  <<: *rails_base
+  entry_condition: '//item[contains(title, "Active Record")]'
+  path: gems/activerecord/
+  base_attributes:
+    # TODO: move to rails_base
+    framework: rails
+    gem: activerecord
+  exec: true
+
+actionpack:
+  <<: *rails_base
+  entry_condition: '//item[contains(title, "Action Pack")]'
+  path: gems/actionpack/
+  base_attributes:
+    # TODO: move to rails_base
+    framework: rails
+    gem: actionpack
+  exec: true
+
+actionview:
+  <<: *rails_base
+  entry_condition: '//item[contains(title, "Action View")]'
+  path: gems/actionview/
+  base_attributes:
+    # TODO: move to rails_base
+    framework: rails
+    gem: actionview
+  exec: true
+
+activesupport:
+  <<: *rails_base
+  entry_condition: '//item[contains(title, "Active Support")]'
+  path: gems/activesupport/
+  base_attributes:
+    # TODO: move to rails_base
+    framework: rails
+    gem: activesupport
+  exec: true
+
+activemodel:
+  <<: *rails_base
+  entry_condition: '//item[contains(title, "Active Model")]'
+  path: gems/activemodel/
+  base_attributes:
+    # TODO: move to rails_base
+    framework: rails
+    gem: activemodel
+  exec: true
+
+# TODO: move to actionpack
+actioncontroller:
+  <<: *rails_base
+  entry_condition: '//item[contains(title, "Action Controller")]'
+  path: gems/actionpack/
+  base_attributes:
+    # TODO: move to rails_base
+    framework: rails
+    gem: actionpack
+  exec: true


### PR DESCRIPTION
I want to add gems/*.yml more easily. As a trial, I add rake tasks to fetch information from RSS and create yaml file in ruby/rails.

```
$ rake db:update         # check and create all
$ rake db:update:ruby # check and create only ruby file
$ rake db:update:...
```

This commit still have several bugs and many TODO. For example, date format is invalid. And still need human checking. But first YAML file creation task is easier if merged.
