### PR TITLE
Add advisory for espeak-ruby

### DIFF
--- a/gems/espeak-ruby/RUBYSEC-2016-0001.yaml
+++ b/gems/espeak-ruby/RUBYSEC-2016-0001.yaml
@@ -9,3 +9,6 @@ description: |
   the strings that are passed as arguments to the speak, save, bytes
   and bytes_wav methods in the lib/espeak/speech.rb library.
 
+patched_versions:
+  - '>= 1.0.3'
+

--- a/gems/espeak-ruby/RUBYSEC-2016-0001.yaml
+++ b/gems/espeak-ruby/RUBYSEC-2016-0001.yaml
@@ -1,0 +1,11 @@
+gem: espeak-ruby
+url: https://github.com/dejan/espeak-ruby/issues/7
+title: espeak-ruby Gem for Ruby Arbitrary Command Execution
+date: 2016-04-13
+
+description: |
+  espeak-ruby passes user modifiable strings directly to a shell
+  command. An attacker can execute malicious commands by modifying
+  the strings that are passed as arguments to the speak, save, bytes
+  and bytes_wav methods in the lib/espeak/speech.rb library.
+


### PR DESCRIPTION
- Ancient bug
- ~~No response from vendor~~ Now patched in version 1.0.3
- No CVE
