### PR TITLE
Ruby >= 2.3.0 has been patched for CVE-2015-1855

### DIFF
--- a/rubies/ruby/CVE-2015-1855.yml
+++ b/rubies/ruby/CVE-2015-1855.yml
@@ -14,4 +14,4 @@ description: |
 patched_versions:
   - ~> 2.0.0.645
   - ~> 2.1.6
-  - ~> 2.2.2
+  - ">= 2.2.2"


### PR DESCRIPTION
CVE-2015-1855 was patched for Ruby 2.2.2 and all future versions of Ruby. That means in addition to `~> 2.2.2` being patched, `>= 2.3.0` is patched as well.