### PR TITLE
CVE-2016-5697.yml

### DIFF
--- a/gems/ruby-saml/CVE-2016-5697.yml
+++ b/gems/ruby-saml/CVE-2016-5697.yml
@@ -1,0 +1,10 @@
+---
+gem: ruby-saml
+framework: rails
+cve: 2016-5697
+url: https://github.com/onelogin/ruby-saml
+title: XML Signature wrapping attack
+date: 2016-06-24
+description: Ruby-saml prior to version 1.3.0 is vulnerable to an XML signature wrapping attack. Ruby-saml users must update to 1.3.0 version which implements 3 extra validations to mitigate this kind of attack.
+cvss_v3: 6.1
+unaffected_versions: >= 1.3.0

--- a/gems/ruby-saml/CVE-2016-5697.yml
+++ b/gems/ruby-saml/CVE-2016-5697.yml
@@ -1,6 +1,5 @@
 ---
 gem: ruby-saml
-framework: rails
 cve: 2016-5697
 url: https://github.com/onelogin/ruby-saml
 title: XML Signature wrapping attack

--- a/gems/ruby-saml/CVE-2016-5697.yml
+++ b/gems/ruby-saml/CVE-2016-5697.yml
@@ -1,7 +1,7 @@
 ---
 gem: ruby-saml
 cve: 2016-5697
-url: https://github.com/onelogin/ruby-saml
+url: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5697
 title: |
   XML Signature wrapping attack
 date: 2016-06-24
@@ -10,4 +10,5 @@ description: |
   Ruby-saml users must update to 1.3.0 version which implements 3 extra validations to
   mitigate this kind of attack.
 cvss_v3: 6.1
-unaffected_versions: >= 1.3.0
+patched_versions:
+  - ">= 1.3.0"

--- a/gems/ruby-saml/CVE-2016-5697.yml
+++ b/gems/ruby-saml/CVE-2016-5697.yml
@@ -2,8 +2,12 @@
 gem: ruby-saml
 cve: 2016-5697
 url: https://github.com/onelogin/ruby-saml
-title: XML Signature wrapping attack
+title: |
+  XML Signature wrapping attack
 date: 2016-06-24
-description: Ruby-saml prior to version 1.3.0 is vulnerable to an XML signature wrapping attack. Ruby-saml users must update to 1.3.0 version which implements 3 extra validations to mitigate this kind of attack.
+description: |
+  Ruby-saml prior to version 1.3.0 is vulnerable to an XML signature wrapping attack.
+  Ruby-saml users must update to 1.3.0 version which implements 3 extra validations to
+  mitigate this kind of attack.
 cvss_v3: 6.1
 unaffected_versions: >= 1.3.0


### PR DESCRIPTION
Ruby-saml prior to version 1.3.0 is vulnerable to an XML signature wrapping attack. Ruby-saml users must update to 1.3.0 version which implements 3 extra validations to mitigate this kind of attack.