### PR TITLE
Add CVE-2016-4442 for rack-mini-profiler

### DIFF
--- a/gems/rack-mini-profiler/CVE-2016-4442.yml
+++ b/gems/rack-mini-profiler/CVE-2016-4442.yml
@@ -1,0 +1,14 @@
+---
+gem: rack-mini-profiler
+cve: 2016-4442
+url: https://github.com/MiniProfiler/rack-mini-profiler/commit/4273771d65f1a7411e3ef5843329308d0e2d257c
+title: Information Disclosure to unauthorized users
+date: 2016-05-18
+description: >-
+  Carefully crafted requests can expose information about
+  strings and objects allocated during the request for unauthorised
+  users.
+
+patched_versions:
+  - ">= 0.10.1"
+  

--- a/gems/rack-mini-profiler/CVE-2016-4442.yml
+++ b/gems/rack-mini-profiler/CVE-2016-4442.yml
@@ -2,7 +2,7 @@
 gem: rack-mini-profiler
 cve: 2016-4442
 url: https://github.com/MiniProfiler/rack-mini-profiler/commit/4273771d65f1a7411e3ef5843329308d0e2d257c
-title: Information Disclosure to unauthorized users
+title: rack-mini-profiler may disclose information to unauthorized users
 date: 2016-05-18
 description: >-
   Carefully crafted requests can expose information about
@@ -11,4 +11,7 @@ description: >-
 
 patched_versions:
   - ">= 0.10.1"
-  
+
+related:
+  url:
+    - http://seclists.org/oss-sec/2016/q2/516


### PR DESCRIPTION
Although this was published on http://seclists.org/oss-sec/2016/q2/516, there is no description available (yet) at https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4442.