### PR TITLE
Add CVE-2016-6582 for doorkeeper

### DIFF
--- a/gems/doorkeeper/CVE-2016-6582.yml
+++ b/gems/doorkeeper/CVE-2016-6582.yml
@@ -7,30 +7,30 @@ url: https://github.com/doorkeeper-gem/doorkeeper/commit/fb938051777a3c9cb071e96
 title: Doorkeeper gem does not revoke tokens & uses wrong auth/auth method
 
 description: |
-	Doorkeeper failed to implement OAuth 2.0 Token Revocation (RFC 7009) in the
-	following ways:
+  Doorkeeper failed to implement OAuth 2.0 Token Revocation (RFC 7009) in the
+  following ways:
 
-	1. Public clients making valid, unauthenticated calls to revoke a token
-	   would not have their token revoked
-	2. Requests were not properly authenticating the *client credentials* but
-	   were, instead, looking at the access token in a second location
-	3. Because of 2, the requests were also not authorizing confidential
-	   clients' ability to revoke a given token. It should only revoke tokens
-	   that belong to it.
+  1. Public clients making valid, unauthenticated calls to revoke a token
+     would not have their token revoked
+  2. Requests were not properly authenticating the *client credentials* but
+     were, instead, looking at the access token in a second location
+  3. Because of 2, the requests were also not authorizing confidential
+     clients' ability to revoke a given token. It should only revoke tokens
+     that belong to it.
 
-	The security implication is: OAuth 2.0 clients who "log out" a user expect
-	to have the corresponding access & refresh tokens revoked, preventing an
-	attacker who may have already hijacked the session from continuing to
-	impersonate the victim. Because of the bug described above, this is not the
-	case. As far as OWASP is concerned, this counts as broken authentication
-	design.
+  The security implication is: OAuth 2.0 clients who "log out" a user expect
+  to have the corresponding access & refresh tokens revoked, preventing an
+  attacker who may have already hijacked the session from continuing to
+  impersonate the victim. Because of the bug described above, this is not the
+  case. As far as OWASP is concerned, this counts as broken authentication
+  design.
 
-	MITRE has assigned CVE-2016-6582 due to the security issues raised. An
-	attacker, thanks to 1, can replay a hijacked session after a victim logs
-	out/revokes their token. Additionally, thanks to 2 & 3, an attacker via a
-	compromised confidential client could "grief" other clients by revoking
-	their tokens (albeit this is an exceptionally narrow attack with little
-	value).
+  MITRE has assigned CVE-2016-6582 due to the security issues raised. An
+  attacker, thanks to 1, can replay a hijacked session after a victim logs
+  out/revokes their token. Additionally, thanks to 2 & 3, an attacker via a
+  compromised confidential client could "grief" other clients by revoking
+  their tokens (albeit this is an exceptionally narrow attack with little
+  value).
 
 unaffected_versions:
   - "< 1.2.0"

--- a/gems/doorkeeper/CVE-2016-6582.yml
+++ b/gems/doorkeeper/CVE-2016-6582.yml
@@ -1,0 +1,39 @@
+---
+gem: doorkeeper
+cve: 2016-6582
+date: 2016-08-18
+url: https://github.com/doorkeeper-gem/doorkeeper/commit/fb938051777a3c9cb071e96fc66458f8f615bd53
+
+title: Doorkeeper gem does not revoke tokens & uses wrong auth/auth method
+
+description: |
+	Doorkeeper failed to implement OAuth 2.0 Token Revocation (RFC 7009) in the
+	following ways:
+
+	1. Public clients making valid, unauthenticated calls to revoke a token
+	   would not have their token revoked
+	2. Requests were not properly authenticating the *client credentials* but
+	   were, instead, looking at the access token in a second location
+	3. Because of 2, the requests were also not authorizing confidential
+	   clients' ability to revoke a given token. It should only revoke tokens
+	   that belong to it.
+
+	The security implication is: OAuth 2.0 clients who "log out" a user expect
+	to have the corresponding access & refresh tokens revoked, preventing an
+	attacker who may have already hijacked the session from continuing to
+	impersonate the victim. Because of the bug described above, this is not the
+	case. As far as OWASP is concerned, this counts as broken authentication
+	design.
+
+	MITRE has assigned CVE-2016-6582 due to the security issues raised. An
+	attacker, thanks to 1, can replay a hijacked session after a victim logs
+	out/revokes their token. Additionally, thanks to 2 & 3, an attacker via a
+	compromised confidential client could "grief" other clients by revoking
+	their tokens (albeit this is an exceptionally narrow attack with little
+	value).
+
+unaffected_versions:
+  - "< 1.2.0"
+
+patched_versions:
+  - ">= 4.2.0"


### PR DESCRIPTION
URL is a placeholder to the GitHub commit diff of the fix until mailing lists moderate the public disclosure.