### PR TITLE
Patched version of colorscore for CVE-2015-7541

### DIFF
--- a/gems/colorscore/CVE-2015-7541.yml
+++ b/gems/colorscore/CVE-2015-7541.yml
@@ -17,4 +17,5 @@ description: |
   To resolve this issue, the aforementioned variables (especially `image_path`)
   must be sanitized for shell metacharacters.
 
-  Currently, no fix for this issue exists.
+patched_versions: 
+  - '>= 0.0.5'


### PR DESCRIPTION
Patched in https://github.com/quadule/colorscore/commit/570b5e854cecddd44d2047c44126aed951b61718