### PR TITLE
Set correct patched versions for (archive tar) minitar gems

### DIFF
--- a/gems/archive-tar-minitar/CVE-2016-10173.yml
+++ b/gems/archive-tar-minitar/CVE-2016-10173.yml
@@ -13,5 +13,4 @@ description: |
 
   Credit: ecneladis
 patched_versions:
-  #This version is unreleased as os 2017-01-31
-  - ">= 0.60"
+  - ">= 0.6.1"

--- a/gems/minitar/CVE-2016-10173.yml
+++ b/gems/minitar/CVE-2016-10173.yml
@@ -13,4 +13,4 @@ description: |
 
   Credit: ecneladis
 patched_versions:
-  - ">= 0.6"
+  - ">= 0.6.1"


### PR DESCRIPTION
This sets the correct patched version for `archive-tar-minitar` to `0.6.1` (instead of `0.60`). I took the liberty to set the patched version to `0.6.1`, and not `0.6.0`, because the latter had some issues (https://github.com/halostatue/minitar/issues/23 and https://github.com/halostatue/minitar/issues/24), which triggered a new release shortly thereafter. I'm not sure why the seemingly broken `0.6.0` hasn't been pulled from RubyGems.