### PR TITLE
ActionView and ActiveRecord 4.2.8 are patched for these vulnerabilities

### DIFF
--- a/gems/actionview/CVE-2016-6316.yml
+++ b/gems/actionview/CVE-2016-6316.yml
@@ -51,5 +51,6 @@ unaffected_versions:
 
 # "~> 3.2.22.3" is found in gems/actionpack/CVE-2016-6316.yml
 patched_versions:
-  - ~> 4.2.7.1
+  - "~> 4.2.7.1"
+  - "~> 4.2.8"
   - ">= 5.0.0.1"

--- a/gems/activerecord/CVE-2016-6317.yml
+++ b/gems/activerecord/CVE-2016-6317.yml
@@ -70,4 +70,4 @@ unaffected_versions:
   - ">= 5.0.0"
 
 patched_versions:
-  - ~> 4.2.7.1
+  - ">= 4.2.7.1"


### PR DESCRIPTION
`bundle-audit` was failing like so, because it didn't consider 4.2.8 as having patches for these 2 vulnerabilities:

```sh
Updating ruby-advisory-db ...
Cloning into '/root/.local/share/ruby-advisory-db'...
Updated ruby-advisory-db
ruby-advisory-db: 282 advisories
Name: actionview
Version: 4.2.8
Advisory: CVE-2016-6316
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/I-VWr034ouk
Title: Possible XSS Vulnerability in Action View
Solution: upgrade to ~> 4.2.7.1, >= 5.0.0.1

Name: activerecord
Version: 4.2.8
Advisory: CVE-2016-6317
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/rgO20zYW33s
Title: Unsafe Query Generation Risk in Active Record
Solution: upgrade to ~> 4.2.7.1

Vulnerabilities found!
```

Based on https://github.com/rubysec/ruby-advisory-db/blob/master/gems/activerecord/CVE-2015-7577.yml#L104-L107, I _think_ this patch should do it, and allow actionview 4.2.7.1, 4.2.8 and 5.0.0.1, but not 5.0.0.