### PR TITLE
Remove `warning: constant ::Fixnum is deprecated`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ bundle exec rspec
     framework: rails
     cve: 2014-3514
     url: https://groups.google.com/forum/#!msg/rubyonrails-security/M4chq5Sb540/CC1Fh0Y_NWwJ
-    title: Data Injection Vulnerability in Active Record 
+    title: Data Injection Vulnerability in Active Record
     date: 2014-08-18
 
     description: >-
@@ -27,14 +27,14 @@ bundle exec rspec
       protection. Applications which pass user-controlled values to
       create_with could allow attackers to set arbitrary attributes on
       models.
-      
+
     cvss_v2: 8.7
 
     unaffected_versions:
       - "< 4.0.0"
 
     patched_versions:
-      - ~> 4.0.9 
+      - ~> 4.0.9
       - ">= 4.1.5"
 ```
 ### Schema
@@ -43,7 +43,7 @@ bundle exec rspec
 * `framework` \[String\] (optional): Name of framework gem belongs to.
 * `platform` \[String\] (optional): If this vulnerability is platform-specific, name of platform this vulnerability affects (e.g. JRuby)
 * `cve` \[String\]: CVE id.
-* `osvdb` \[Fixnum\]: OSVDB id.
+* `osvdb` \[Integer\]: OSVDB id.
 * `url` \[String\]: The URL to the full advisory.
 * `title` \[String\]: The title of the advisory.
 * `date` \[Date\]: Disclosure date of the advisory.

--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ Each advisory file contains the advisory information in [YAML] format:
     url: http://osvdb.org/show/osvdb/89026
     title: |
       Ruby on Rails params_parser.rb Action Pack Type Casting Parameter Parsing
-      Remote Code Execution 
-    
+      Remote Code Execution
+
     description: |
       Ruby on Rails contains a flaw in params_parser.rb of the Action Pack.
       The issue is triggered when a type casting error occurs during the parsing
       of parameters. This may allow a remote attacker to potentially execute
       arbitrary code.
-    
+
     cvss_v2: 10.0
-    
+
     patched_versions:
       - ~> 2.3.15
       - ~> 3.0.19
@@ -55,7 +55,7 @@ Each advisory file contains the advisory information in [YAML] format:
 * `framework` \[String\] (optional): Name of framework gem belongs to.
 * `platform` \[String\] (optional): If this vulnerability is platform-specific, name of platform this vulnerability affects (e.g. JRuby)
 * `cve` \[String\]: CVE id.
-* `osvdb` \[Fixnum\]: OSVDB id.
+* `osvdb` \[Integer\]: OSVDB id.
 * `url` \[String\]: The URL to the full advisory.
 * `title` \[String\]: The title of the advisory.
 * `date` \[Date\]: Disclosure date of the advisory.

--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -59,8 +59,8 @@ shared_examples_for 'Advisory' do |path|
     describe "osvdb" do
       subject { advisory['osvdb'] }
 
-      it "may be nil or a Fixnum" do
-        expect(subject).to be_kind_of(Fixnum).or(be_nil)
+      it "may be nil or a Integer" do
+        expect(subject).to be_kind_of(Integer).or(be_nil)
       end
 
        it "should be id in filename if filename is OSVDB-XXX" do
@@ -139,7 +139,7 @@ shared_examples_for 'Advisory' do |path|
           advisory['patched_versions'].each do |version|
             describe version do
               subject { version.split(', ') }
-              
+
               it "should contain valid RubyGem version requirements" do
                 expect {
                 Gem::Requirement.new(*subject)
@@ -163,7 +163,7 @@ shared_examples_for 'Advisory' do |path|
         advisory['unaffected_versions'].each do |version|
           describe version do
             subject { version.split(', ') }
-            
+
             it "should contain valid RubyGem version requirements" do
               expect {
                 Gem::Requirement.new(*subject)


### PR DESCRIPTION
This removes a deprecation warning introduced by Ruby 2.4.0 that appears when running specs.

This fix works, because `Integer` exists in older versions of Ruby too and is a superclass of `Fixnum`.