### PR TITLE
Rails `5.1.0.alpha` bases on `5.0.0.rc1`

### DIFF
--- a/gems/actionpack/CVE-2015-7576.yml
+++ b/gems/actionpack/CVE-2015-7576.yml
@@ -8,109 +8,109 @@ url: "https://groups.google.com/forum/#!topic/rubyonrails-security/ANv0HDHEC3k"
 title: Timing attack vulnerability in basic authentication in Action Controller.
 
 description: |
-    There is a timing attack vulnerability in the basic authentication support 
-    in Action Controller. This vulnerability has been assigned the CVE 
-    identifier CVE-2015-7576. 
+    There is a timing attack vulnerability in the basic authentication support
+    in Action Controller. This vulnerability has been assigned the CVE
+    identifier CVE-2015-7576.
 
-    Versions Affected:  All. 
-    Not affected:       None. 
-    Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1 
+    Versions Affected:  All.
+    Not affected:       None.
+    Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1
 
-    Impact 
-    ------ 
-    Due to the way that Action Controller compares user names and passwords in 
-    basic authentication authorization code, it is possible for an attacker to 
-    analyze the time taken by a response and intuit the password. 
+    Impact
+    ------
+    Due to the way that Action Controller compares user names and passwords in
+    basic authentication authorization code, it is possible for an attacker to
+    analyze the time taken by a response and intuit the password.
 
-    For example, this string comparison: 
+    For example, this string comparison:
 
-      "foo" == "bar" 
+      "foo" == "bar"
 
-    is possibly faster than this comparison: 
+    is possibly faster than this comparison:
 
-      "foo" == "fo1" 
+      "foo" == "fo1"
 
-    Attackers can use this information to attempt to guess the username and 
-    password used in the basic authentication system. 
+    Attackers can use this information to attempt to guess the username and
+    password used in the basic authentication system.
 
-    You can tell you application is vulnerable to this attack by looking for 
-    `http_basic_authenticate_with` method calls in your application. 
+    You can tell you application is vulnerable to this attack by looking for
+    `http_basic_authenticate_with` method calls in your application.
 
-    All users running an affected release should either upgrade or use one of 
-    the workarounds immediately. 
+    All users running an affected release should either upgrade or use one of
+    the workarounds immediately.
 
-    Releases 
-    -------- 
-    The FIXED releases are available at the normal locations. 
+    Releases
+    --------
+    The FIXED releases are available at the normal locations.
 
-    Workarounds 
-    ----------- 
-    If you can't upgrade, please use the following monkey patch in an initializer 
-    that is loaded before your application: 
+    Workarounds
+    -----------
+    If you can't upgrade, please use the following monkey patch in an initializer
+    that is loaded before your application:
 
-    ``` 
-    $ cat config/initializers/basic_auth_fix.rb 
-    module ActiveSupport 
-      module SecurityUtils 
-        def secure_compare(a, b) 
-          return false unless a.bytesize == b.bytesize 
+    ```
+    $ cat config/initializers/basic_auth_fix.rb
+    module ActiveSupport
+      module SecurityUtils
+        def secure_compare(a, b)
+          return false unless a.bytesize == b.bytesize
 
-          l = a.unpack "C#{a.bytesize}" 
+          l = a.unpack "C#{a.bytesize}"
 
-          res = 0 
-          b.each_byte { |byte| res |= byte ^ l.shift } 
-          res == 0 
-        end 
-        module_function :secure_compare 
+          res = 0
+          b.each_byte { |byte| res |= byte ^ l.shift }
+          res == 0
+        end
+        module_function :secure_compare
 
-        def variable_size_secure_compare(a, b) 
-          secure_compare(::Digest::SHA256.hexdigest(a), ::Digest::SHA256.hexdigest(b)) 
-        end 
-        module_function :variable_size_secure_compare 
-      end 
-    end 
+        def variable_size_secure_compare(a, b)
+          secure_compare(::Digest::SHA256.hexdigest(a), ::Digest::SHA256.hexdigest(b))
+        end
+        module_function :variable_size_secure_compare
+      end
+    end
 
-    module ActionController 
-      class Base 
-        def self.http_basic_authenticate_with(options = {}) 
-          before_action(options.except(:name, :password, :realm)) do 
-            authenticate_or_request_with_http_basic(options[:realm] || "Application") do |name, password| 
-              # This comparison uses & so that it doesn't short circuit and 
-              # uses `variable_size_secure_compare` so that length information 
-              # isn't leaked. 
-              ActiveSupport::SecurityUtils.variable_size_secure_compare(name, options[:name]) & 
-                ActiveSupport::SecurityUtils.variable_size_secure_compare(password, options[:password]) 
-            end 
-          end 
-        end 
-      end 
-    end 
-    ``` 
+    module ActionController
+      class Base
+        def self.http_basic_authenticate_with(options = {})
+          before_action(options.except(:name, :password, :realm)) do
+            authenticate_or_request_with_http_basic(options[:realm] || "Application") do |name, password|
+              # This comparison uses & so that it doesn't short circuit and
+              # uses `variable_size_secure_compare` so that length information
+              # isn't leaked.
+              ActiveSupport::SecurityUtils.variable_size_secure_compare(name, options[:name]) &
+                ActiveSupport::SecurityUtils.variable_size_secure_compare(password, options[:password])
+            end
+          end
+        end
+      end
+    end
+    ```
 
 
-    Patches 
-    ------- 
-    To aid users who aren't able to upgrade immediately we have provided patches for 
-    the two supported release series. They are in git-am format and consist of a 
-    single changeset. 
+    Patches
+    -------
+    To aid users who aren't able to upgrade immediately we have provided patches for
+    the two supported release series. They are in git-am format and consist of a
+    single changeset.
 
-    * 4-1-basic_auth.patch - Patch for 4.1 series 
-    * 4-2-basic_auth.patch - Patch for 4.2 series 
-    * 5-0-basic_auth.patch - Patch for 5.0 series 
+    * 4-1-basic_auth.patch - Patch for 4.1 series
+    * 4-2-basic_auth.patch - Patch for 4.2 series
+    * 5-0-basic_auth.patch - Patch for 5.0 series
 
-    Please note that only the 4.1.x and 4.2.x series are supported at present. Users 
-    of earlier unsupported releases are advised to upgrade as soon as possible as we 
-    cannot guarantee the continued availability of security fixes for unsupported 
-    releases. 
+    Please note that only the 4.1.x and 4.2.x series are supported at present. Users
+    of earlier unsupported releases are advised to upgrade as soon as possible as we
+    cannot guarantee the continued availability of security fixes for unsupported
+    releases.
 
-    Credits 
-    ------- 
+    Credits
+    -------
 
-    Thank you to Daniel Waterworth for reporting the problem and working with us to 
+    Thank you to Daniel Waterworth for reporting the problem and working with us to
     fix it.
 
 patched_versions:
-  - "~> 5.0.0.beta1.1"
+  - ">= 5.0.0.beta1.1"
   - "~> 4.2.5, >= 4.2.5.1"
   - "~> 4.1.14, >= 4.1.14.1"
   - "~> 3.2.22.1"

--- a/gems/actionpack/CVE-2016-0751.yml
+++ b/gems/actionpack/CVE-2016-0751.yml
@@ -8,64 +8,64 @@ url: "https://groups.google.com/forum/#!topic/rubyonrails-security/9oLY_FCzvoc"
 title: Possible Object Leak and Denial of Service attack in Action Pack
 
 description: |
-  There is a possible object leak which can lead to a denial of service 
-  vulnerability in Action Pack. This vulnerability has been 
-  assigned the CVE identifier CVE-2016-0751. 
+  There is a possible object leak which can lead to a denial of service
+  vulnerability in Action Pack. This vulnerability has been
+  assigned the CVE identifier CVE-2016-0751.
 
-  Versions Affected:  All. 
-  Not affected:       None. 
-  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1 
+  Versions Affected:  All.
+  Not affected:       None.
+  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1
 
-  Impact 
-  ------ 
-  A carefully crafted accept header can cause a global cache of mime types to 
-  grow indefinitely which can lead to a possible denial of service attack in 
-  Action Pack. 
+  Impact
+  ------
+  A carefully crafted accept header can cause a global cache of mime types to
+  grow indefinitely which can lead to a possible denial of service attack in
+  Action Pack.
 
-  All users running an affected release should either upgrade or use one of the 
-  workarounds immediately. 
+  All users running an affected release should either upgrade or use one of the
+  workarounds immediately.
 
-  Releases 
-  -------- 
-  The FIXED releases are available at the normal locations. 
+  Releases
+  --------
+  The FIXED releases are available at the normal locations.
 
-  Workarounds 
-  ----------- 
-  This attack can be mitigated by a proxy that only allows known mime types in 
-  the Accept header. 
+  Workarounds
+  -----------
+  This attack can be mitigated by a proxy that only allows known mime types in
+  the Accept header.
 
-  Placing the following code in an initializer will also mitigate the issue: 
+  Placing the following code in an initializer will also mitigate the issue:
 
-  ```ruby 
-  require 'action_dispatch/http/mime_type' 
+  ```ruby
+  require 'action_dispatch/http/mime_type'
 
-  Mime.const_set :LOOKUP, Hash.new { |h,k| 
-    Mime::Type.new(k) unless k.blank? 
-  } 
-  ``` 
+  Mime.const_set :LOOKUP, Hash.new { |h,k|
+    Mime::Type.new(k) unless k.blank?
+  }
+  ```
 
-  Patches 
-  ------- 
-  To aid users who aren't able to upgrade immediately we have provided patches for 
-  the two supported release series. They are in git-am format and consist of a 
-  single changeset. 
+  Patches
+  -------
+  To aid users who aren't able to upgrade immediately we have provided patches for
+  the two supported release series. They are in git-am format and consist of a
+  single changeset.
 
-  * 5-0-mime_types_leak.patch - Patch for 5.0 series 
-  * 4-2-mime_types_leak.patch - Patch for 4.2 series 
-  * 4-1-mime_types_leak.patch - Patch for 4.1 series 
-  * 3-2-mime_types_leak.patch - Patch for 3.2 series 
+  * 5-0-mime_types_leak.patch - Patch for 5.0 series
+  * 4-2-mime_types_leak.patch - Patch for 4.2 series
+  * 4-1-mime_types_leak.patch - Patch for 4.1 series
+  * 3-2-mime_types_leak.patch - Patch for 3.2 series
 
-  Please note that only the 4.1.x and 4.2.x series are supported at present. Users 
-  of earlier unsupported releases are advised to upgrade as soon as possible as we 
-  cannot guarantee the continued availability of security fixes for unsupported 
-  releases. 
+  Please note that only the 4.1.x and 4.2.x series are supported at present. Users
+  of earlier unsupported releases are advised to upgrade as soon as possible as we
+  cannot guarantee the continued availability of security fixes for unsupported
+  releases.
 
-  Credits 
-  ------- 
+  Credits
+  -------
   Aaron Patterson <3<3
 
 patched_versions:
-  - "~> 5.0.0.beta1.1"
+  - ">= 5.0.0.beta1.1"
   - "~> 4.2.5, >= 4.2.5.1"
   - "~> 4.1.14, >= 4.1.14.1"
   - "~> 3.2.22.1"

--- a/gems/actionpack/CVE-2016-0752.yml
+++ b/gems/actionpack/CVE-2016-0752.yml
@@ -7,82 +7,82 @@ url: "https://groups.google.com/forum/#!topic/rubyonrails-security/335P1DcLG00"
 
 title: Possible Information Leak Vulnerability in Action View
 description: |
-  There is a possible directory traversal and information leak vulnerability in 
-  Action View. This vulnerability has been assigned the CVE identifier 
-  CVE-2016-0752. 
+  There is a possible directory traversal and information leak vulnerability in
+  Action View. This vulnerability has been assigned the CVE identifier
+  CVE-2016-0752.
 
-  Versions Affected:  All. 
-  Not affected:       None. 
-  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1 
+  Versions Affected:  All.
+  Not affected:       None.
+  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1
 
-  Impact 
-  ------ 
-  Applications that pass unverified user input to the `render` method in a 
-  controller may be vulnerable to an information leak vulnerability. 
+  Impact
+  ------
+  Applications that pass unverified user input to the `render` method in a
+  controller may be vulnerable to an information leak vulnerability.
 
-  Impacted code will look something like this: 
+  Impacted code will look something like this:
 
-  ```ruby 
-  def index 
-    render params[:id] 
-  end 
-  ``` 
+  ```ruby
+  def index
+    render params[:id]
+  end
+  ```
 
-  Carefully crafted requests can cause the above code to render files from 
-  unexpected places like outside the application's view directory, and can 
-  possibly escalate this to a remote code execution attack. 
+  Carefully crafted requests can cause the above code to render files from
+  unexpected places like outside the application's view directory, and can
+  possibly escalate this to a remote code execution attack.
 
-  All users running an affected release should either upgrade or use one of the 
-  workarounds immediately. 
+  All users running an affected release should either upgrade or use one of the
+  workarounds immediately.
 
-  Releases 
-  -------- 
-  The FIXED releases are available at the normal locations. 
+  Releases
+  --------
+  The FIXED releases are available at the normal locations.
 
-  Workarounds 
-  ----------- 
-  A workaround to this issue is to not pass arbitrary user input to the `render` 
-  method.  Instead, verify that data before passing it to the `render` method. 
+  Workarounds
+  -----------
+  A workaround to this issue is to not pass arbitrary user input to the `render`
+  method.  Instead, verify that data before passing it to the `render` method.
 
-  For example, change this: 
+  For example, change this:
 
-  ```ruby 
-  def index 
-    render params[:id] 
-  end 
-  ``` 
+  ```ruby
+  def index
+    render params[:id]
+  end
+  ```
 
-  To this: 
+  To this:
 
-  ```ruby 
-  def index 
-    render verify_template(params[:id]) 
-  end 
+  ```ruby
+  def index
+    render verify_template(params[:id])
+  end
 
-  private 
-  def verify_template(name) 
-    # add verification logic particular to your application here 
-  end 
-  ``` 
+  private
+  def verify_template(name)
+    # add verification logic particular to your application here
+  end
+  ```
 
-  Patches 
-  ------- 
-  To aid users who aren't able to upgrade immediately we have provided patches for 
-  the two supported release series. They are in git-am format and consist of a 
-  single changeset. 
+  Patches
+  -------
+  To aid users who aren't able to upgrade immediately we have provided patches for
+  the two supported release series. They are in git-am format and consist of a
+  single changeset.
 
-  * 3-2-render_data_leak.patch - Patch for 3.2 series 
-  * 4-1-render_data_leak.patch - Patch for 4.1 series 
-  * 4-2-render_data_leak.patch - Patch for 4.2 series 
-  * 5-0-render_data_leak.patch - Patch for 5.0 series 
+  * 3-2-render_data_leak.patch - Patch for 3.2 series
+  * 4-1-render_data_leak.patch - Patch for 4.1 series
+  * 4-2-render_data_leak.patch - Patch for 4.2 series
+  * 5-0-render_data_leak.patch - Patch for 5.0 series
 
-  Please note that only the 4.1.x and 4.2.x series are supported at present. Users 
-  of earlier unsupported releases are advised to upgrade as soon as possible as we 
-  cannot guarantee the continued availability of security fixes for unsupported 
-  releases. 
+  Please note that only the 4.1.x and 4.2.x series are supported at present. Users
+  of earlier unsupported releases are advised to upgrade as soon as possible as we
+  cannot guarantee the continued availability of security fixes for unsupported
+  releases.
 
-  Credits 
-  ------- 
+  Credits
+  -------
   Thanks John Poulin for reporting this!
 
 unaffected_versions:
@@ -90,7 +90,7 @@ unaffected_versions:
   - ">= 4.1.0"
 
 patched_versions:
-  - "~> 5.0.0.beta1.1"
+  - ">= 5.0.0.beta1.1"
   - "~> 4.2.5, >= 4.2.5.1"
   - "~> 4.1.14, >= 4.1.14.1"
   - "~> 3.2.22.1"

--- a/gems/actionview/CVE-2016-0752.yml
+++ b/gems/actionview/CVE-2016-0752.yml
@@ -7,86 +7,86 @@ url: "https://groups.google.com/forum/#!topic/rubyonrails-security/335P1DcLG00"
 
 title: Possible Information Leak Vulnerability in Action View
 description: |
-  There is a possible directory traversal and information leak vulnerability in 
-  Action View. This vulnerability has been assigned the CVE identifier 
-  CVE-2016-0752. 
+  There is a possible directory traversal and information leak vulnerability in
+  Action View. This vulnerability has been assigned the CVE identifier
+  CVE-2016-0752.
 
-  Versions Affected:  All. 
-  Not affected:       None. 
-  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1 
+  Versions Affected:  All.
+  Not affected:       None.
+  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1
 
-  Impact 
-  ------ 
-  Applications that pass unverified user input to the `render` method in a 
-  controller may be vulnerable to an information leak vulnerability. 
+  Impact
+  ------
+  Applications that pass unverified user input to the `render` method in a
+  controller may be vulnerable to an information leak vulnerability.
 
-  Impacted code will look something like this: 
+  Impacted code will look something like this:
 
-  ```ruby 
-  def index 
-    render params[:id] 
-  end 
-  ``` 
+  ```ruby
+  def index
+    render params[:id]
+  end
+  ```
 
-  Carefully crafted requests can cause the above code to render files from 
-  unexpected places like outside the application's view directory, and can 
-  possibly escalate this to a remote code execution attack. 
+  Carefully crafted requests can cause the above code to render files from
+  unexpected places like outside the application's view directory, and can
+  possibly escalate this to a remote code execution attack.
 
-  All users running an affected release should either upgrade or use one of the 
-  workarounds immediately. 
+  All users running an affected release should either upgrade or use one of the
+  workarounds immediately.
 
-  Releases 
-  -------- 
-  The FIXED releases are available at the normal locations. 
+  Releases
+  --------
+  The FIXED releases are available at the normal locations.
 
-  Workarounds 
-  ----------- 
-  A workaround to this issue is to not pass arbitrary user input to the `render` 
-  method.  Instead, verify that data before passing it to the `render` method. 
+  Workarounds
+  -----------
+  A workaround to this issue is to not pass arbitrary user input to the `render`
+  method.  Instead, verify that data before passing it to the `render` method.
 
-  For example, change this: 
+  For example, change this:
 
-  ```ruby 
-  def index 
-    render params[:id] 
-  end 
-  ``` 
+  ```ruby
+  def index
+    render params[:id]
+  end
+  ```
 
-  To this: 
+  To this:
 
-  ```ruby 
-  def index 
-    render verify_template(params[:id]) 
-  end 
+  ```ruby
+  def index
+    render verify_template(params[:id])
+  end
 
-  private 
-  def verify_template(name) 
-    # add verification logic particular to your application here 
-  end 
-  ``` 
+  private
+  def verify_template(name)
+    # add verification logic particular to your application here
+  end
+  ```
 
-  Patches 
-  ------- 
-  To aid users who aren't able to upgrade immediately we have provided patches for 
-  the two supported release series. They are in git-am format and consist of a 
-  single changeset. 
+  Patches
+  -------
+  To aid users who aren't able to upgrade immediately we have provided patches for
+  the two supported release series. They are in git-am format and consist of a
+  single changeset.
 
-  * 3-2-render_data_leak.patch - Patch for 3.2 series 
-  * 4-1-render_data_leak.patch - Patch for 4.1 series 
-  * 4-2-render_data_leak.patch - Patch for 4.2 series 
-  * 5-0-render_data_leak.patch - Patch for 5.0 series 
+  * 3-2-render_data_leak.patch - Patch for 3.2 series
+  * 4-1-render_data_leak.patch - Patch for 4.1 series
+  * 4-2-render_data_leak.patch - Patch for 4.2 series
+  * 5-0-render_data_leak.patch - Patch for 5.0 series
 
-  Please note that only the 4.1.x and 4.2.x series are supported at present. Users 
-  of earlier unsupported releases are advised to upgrade as soon as possible as we 
-  cannot guarantee the continued availability of security fixes for unsupported 
-  releases. 
+  Please note that only the 4.1.x and 4.2.x series are supported at present. Users
+  of earlier unsupported releases are advised to upgrade as soon as possible as we
+  cannot guarantee the continued availability of security fixes for unsupported
+  releases.
 
-  Credits 
-  ------- 
+  Credits
+  -------
   Thanks John Poulin for reporting this!
 
 # "~> 3.2.22.1" is found in gems/actionpack/CVE-2016-0752.yml
 patched_versions:
-  - "~> 5.0.0.beta1.1"
+  - ">= 5.0.0.beta1.1"
   - "~> 4.2.5, >= 4.2.5.1"
   - "~> 4.1.14, >= 4.1.14.1"

--- a/gems/activemodel/CVE-2016-0753.yml
+++ b/gems/activemodel/CVE-2016-0753.yml
@@ -5,88 +5,88 @@ cve: 2016-0753
 date: 2016-01-25
 url: "https://groups.google.com/forum/#!topic/rubyonrails-security/6jQVC1geukQ"
 
-title: Possible Input Validation Circumvention in Active Model 
+title: Possible Input Validation Circumvention in Active Model
 
 description: |
-  There is a possible input validation circumvention vulnerability in Active 
-  Model. This vulnerability has been assigned the CVE identifier CVE-2016-0753. 
+  There is a possible input validation circumvention vulnerability in Active
+  Model. This vulnerability has been assigned the CVE identifier CVE-2016-0753.
 
-  Versions Affected:  4.1.0 and newer 
-  Not affected:       4.0.13 and older 
-  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1 
+  Versions Affected:  4.1.0 and newer
+  Not affected:       4.0.13 and older
+  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1
 
-  Impact 
-  ------ 
-  Code that uses Active Model based models (including Active Record models) and 
-  does not validate user input before passing it to the model can be subject to 
-  an attack where specially crafted input will cause the model to skip 
-  validations. 
+  Impact
+  ------
+  Code that uses Active Model based models (including Active Record models) and
+  does not validate user input before passing it to the model can be subject to
+  an attack where specially crafted input will cause the model to skip
+  validations.
 
-  Vulnerable code will look something like this: 
+  Vulnerable code will look something like this:
 
-  ```ruby 
-  SomeModel.new(unverified_user_input) 
-  ``` 
+  ```ruby
+  SomeModel.new(unverified_user_input)
+  ```
 
-  Rails users using Strong Parameters are generally not impacted by this issue 
-  as they are encouraged to whitelist parameters and must specifically opt-out 
-  of input verification using the `permit!` method to allow mass assignment. 
+  Rails users using Strong Parameters are generally not impacted by this issue
+  as they are encouraged to whitelist parameters and must specifically opt-out
+  of input verification using the `permit!` method to allow mass assignment.
 
-  For example, a vulnerable Rails application will have code that looks like 
-  this: 
+  For example, a vulnerable Rails application will have code that looks like
+  this:
 
-  ```ruby 
-  def create 
-    params.permit! # allow all parameters 
-    @user = User.new params[:users] 
-  end 
-  ``` 
+  ```ruby
+  def create
+    params.permit! # allow all parameters
+    @user = User.new params[:users]
+  end
+  ```
 
-  Active Model and Active Record objects are not equipped to handle arbitrary 
-  user input.  It is up to the application to verify input before passing it to 
-  Active Model models.  Rails users already have Strong Parameters in place to 
-  handle white listing, but applications using Active Model and Active Record 
-  outside of a Rails environment may be impacted. 
+  Active Model and Active Record objects are not equipped to handle arbitrary
+  user input.  It is up to the application to verify input before passing it to
+  Active Model models.  Rails users already have Strong Parameters in place to
+  handle white listing, but applications using Active Model and Active Record
+  outside of a Rails environment may be impacted.
 
-  All users running an affected release should either upgrade or use one of the 
-  workarounds immediately. 
+  All users running an affected release should either upgrade or use one of the
+  workarounds immediately.
 
-  Releases 
-  -------- 
-  The FIXED releases are available at the normal locations. 
+  Releases
+  --------
+  The FIXED releases are available at the normal locations.
 
-  Workarounds 
-  ----------- 
-  There are several workarounds depending on the application.  Inside a Rails 
-  application, stop using `permit!`.  Outside a Rails application, either use 
-  Hash#slice to select the parameters you need, or integrate Strong Parameters 
-  with your application. 
+  Workarounds
+  -----------
+  There are several workarounds depending on the application.  Inside a Rails
+  application, stop using `permit!`.  Outside a Rails application, either use
+  Hash#slice to select the parameters you need, or integrate Strong Parameters
+  with your application.
 
-  Patches 
-  ------- 
-  To aid users who aren't able to upgrade immediately we have provided patches for 
-  the two supported release series. They are in git-am format and consist of a 
-  single changeset. 
+  Patches
+  -------
+  To aid users who aren't able to upgrade immediately we have provided patches for
+  the two supported release series. They are in git-am format and consist of a
+  single changeset.
 
-  * 4-1-validation_skip.patch - Patch for 4.1 series 
-  * 4-2-validation_skip.patch - Patch for 4.2 series 
-  * 5-0-validation_skip.patch - Patch for 5.0 series 
+  * 4-1-validation_skip.patch - Patch for 4.1 series
+  * 4-2-validation_skip.patch - Patch for 4.2 series
+  * 5-0-validation_skip.patch - Patch for 5.0 series
 
-  Please note that only the 4.1.x and 4.2.x series are supported at present. Users 
-  of earlier unsupported releases are advised to upgrade as soon as possible as we 
-  cannot guarantee the continued availability of security fixes for unsupported 
-  releases. 
+  Please note that only the 4.1.x and 4.2.x series are supported at present. Users
+  of earlier unsupported releases are advised to upgrade as soon as possible as we
+  cannot guarantee the continued availability of security fixes for unsupported
+  releases.
 
-  Credits 
-  ------- 
-  Thanks to: 
+  Credits
+  -------
+  Thanks to:
 
-  [John Backus](https://github.com/backus) from BlockScore for reporting this! 
+  [John Backus](https://github.com/backus) from BlockScore for reporting this!
 
 unaffected_versions:
   - "<= 4.0.13"
 
 patched_versions:
-  - "~> 5.0.0.beta1.1"
+  - ">= 5.0.0.beta1.1"
   - "~> 4.2.5, >= 4.2.5.1"
   - "~> 4.1.14, >= 4.1.14.1"

--- a/gems/activerecord/CVE-2015-7577.yml
+++ b/gems/activerecord/CVE-2015-7577.yml
@@ -5,103 +5,103 @@ cve: 2015-7577
 date: 2016-01-25
 url: https://groups.google.com/forum/#!topic/rubyonrails-security/cawsWcQ6c8g
 
-title: Nested attributes rejection proc bypass in Active Record 
+title: Nested attributes rejection proc bypass in Active Record
 
 description: |
-  There is a vulnerability in how the nested attributes feature in Active Record 
-  handles updates in combination with destroy flags when destroying records is 
-  disabled. This vulnerability has been assigned the CVE identifier CVE-2015-7577. 
+  There is a vulnerability in how the nested attributes feature in Active Record
+  handles updates in combination with destroy flags when destroying records is
+  disabled. This vulnerability has been assigned the CVE identifier CVE-2015-7577.
 
-  Versions Affected:  3.1.0 and newer 
-  Not affected:       3.0.x and older 
-  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1 
+  Versions Affected:  3.1.0 and newer
+  Not affected:       3.0.x and older
+  Fixed Versions:     5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1
 
-  Impact 
-  ------ 
-  When using the nested attributes feature in Active Record you can prevent the 
-  destruction of associated records by passing the `allow_destroy: false` option 
-  to the `accepts_nested_attributes_for` method. However due to a change in the 
-  commit [a9b4b5d][1] the `_destroy` flag prevents the `:reject_if` proc from 
-  being called because it assumes that the record will be destroyed anyway. 
+  Impact
+  ------
+  When using the nested attributes feature in Active Record you can prevent the
+  destruction of associated records by passing the `allow_destroy: false` option
+  to the `accepts_nested_attributes_for` method. However due to a change in the
+  commit [a9b4b5d][1] the `_destroy` flag prevents the `:reject_if` proc from
+  being called because it assumes that the record will be destroyed anyway.
 
-  However this isn't true if `:allow_destroy` is false so this leads to changes 
-  that would have been rejected being applied to the record. Attackers could use 
-  this do things like set attributes to invalid values and to clear all of the 
-  attributes amongst other things. The severity will be dependent on how the 
-  application has used this feature. 
+  However this isn't true if `:allow_destroy` is false so this leads to changes
+  that would have been rejected being applied to the record. Attackers could use
+  this do things like set attributes to invalid values and to clear all of the
+  attributes amongst other things. The severity will be dependent on how the
+  application has used this feature.
 
-  All users running an affected release should either upgrade or use one of 
-  the workarounds immediately. 
+  All users running an affected release should either upgrade or use one of
+  the workarounds immediately.
 
-  Releases 
-  -------- 
-  The FIXED releases are available at the normal locations. 
+  Releases
+  --------
+  The FIXED releases are available at the normal locations.
 
-  Workarounds 
-  ----------- 
-  If you can't upgrade, please use the following monkey patch in an initializer 
-  that is loaded before your application: 
+  Workarounds
+  -----------
+  If you can't upgrade, please use the following monkey patch in an initializer
+  that is loaded before your application:
 
-  ``` 
-  $ cat config/initializers/nested_attributes_bypass_fix.rb 
-  module ActiveRecord 
-    module NestedAttributes 
-      private 
+  ```
+  $ cat config/initializers/nested_attributes_bypass_fix.rb
+  module ActiveRecord
+    module NestedAttributes
+      private
 
-      def reject_new_record?(association_name, attributes) 
-        will_be_destroyed?(association_name, attributes) || call_reject_if(association_name, attributes) 
-      end 
+      def reject_new_record?(association_name, attributes)
+        will_be_destroyed?(association_name, attributes) || call_reject_if(association_name, attributes)
+      end
 
-      def call_reject_if(association_name, attributes) 
-        return false if will_be_destroyed?(association_name, attributes) 
+      def call_reject_if(association_name, attributes)
+        return false if will_be_destroyed?(association_name, attributes)
 
-        case callback = self.nested_attributes_options[association_name][:reject_if] 
-        when Symbol 
-          method(callback).arity == 0 ? send(callback) : send(callback, attributes) 
-        when Proc 
-          callback.call(attributes) 
-        end 
-      end 
+        case callback = self.nested_attributes_options[association_name][:reject_if]
+        when Symbol
+          method(callback).arity == 0 ? send(callback) : send(callback, attributes)
+        when Proc
+          callback.call(attributes)
+        end
+      end
 
-      def will_be_destroyed?(association_name, attributes) 
-        allow_destroy?(association_name) && has_destroy_flag?(attributes) 
-      end 
+      def will_be_destroyed?(association_name, attributes)
+        allow_destroy?(association_name) && has_destroy_flag?(attributes)
+      end
 
-      def allow_destroy?(association_name) 
-        self.nested_attributes_options[association_name][:allow_destroy] 
-      end 
-    end 
-  end 
-  ``` 
+      def allow_destroy?(association_name)
+        self.nested_attributes_options[association_name][:allow_destroy]
+      end
+    end
+  end
+  ```
 
-  Patches 
-  ------- 
-  To aid users who aren't able to upgrade immediately we have provided patches for 
-  the two supported release series. They are in git-am format and consist of a 
-  single changeset. 
+  Patches
+  -------
+  To aid users who aren't able to upgrade immediately we have provided patches for
+  the two supported release series. They are in git-am format and consist of a
+  single changeset.
 
-  * 3-2-nested-attributes-reject-if-bypass.patch - Patch for 3.2 series 
-  * 4-1-nested-attributes-reject-if-bypass.patch - Patch for 4.1 series 
-  * 4-2-nested-attributes-reject-if-bypass.patch - Patch for 4.2 series 
-  * 5-0-nested-attributes-reject-if-bypass.patch - Patch for 5.0 series 
+  * 3-2-nested-attributes-reject-if-bypass.patch - Patch for 3.2 series
+  * 4-1-nested-attributes-reject-if-bypass.patch - Patch for 4.1 series
+  * 4-2-nested-attributes-reject-if-bypass.patch - Patch for 4.2 series
+  * 5-0-nested-attributes-reject-if-bypass.patch - Patch for 5.0 series
 
-  Please note that only the 4.1.x and 4.2.x series are supported at present. Users 
-  of earlier unsupported releases are advised to upgrade as soon as possible as we 
-  cannot guarantee the continued availability of security fixes for unsupported 
-  releases. 
+  Please note that only the 4.1.x and 4.2.x series are supported at present. Users
+  of earlier unsupported releases are advised to upgrade as soon as possible as we
+  cannot guarantee the continued availability of security fixes for unsupported
+  releases.
 
-  Credits 
-  ------- 
-  Thank you to Justin Coyne for reporting the problem and working with us to fix it. 
+  Credits
+  -------
+  Thank you to Justin Coyne for reporting the problem and working with us to fix it.
 
-  [1]: https://github.com/rails/rails/commit/a9b4b5da7c216e4464eeb9dbd0a39ea258d64325 
+  [1]: https://github.com/rails/rails/commit/a9b4b5da7c216e4464eeb9dbd0a39ea258d64325
 
 unaffected_versions:
   - "~> 3.0.0"
   - "< 3.0.0"
 
 patched_versions:
-  - "~> 5.0.0.beta1.1"
+  - ">= 5.0.0.beta1.1"
   - "~> 4.2.5, >= 4.2.5.1"
   - "~> 4.1.14, >= 4.1.14.1"
   - "~> 3.2.22.1"


### PR DESCRIPTION
Rails `5.1.0.alpha` was released yesterday and `bundler:audit` reports some issues that were already fixed in `5.0.0.beta1.1`.

Since `5.1.0.alpha` bases on `5.0.0.rc1` (see: https://github.com/rails/rails/commit/8ecc5ab1d88532a239f17c7520ed922c7579b01c) I am pretty sure that we can change the entries in the list of `patched_versions` from `~> 5.0.0.beta1.1` to `>= 5.0.0.beta1.1` to include Rails `5.1.0`.

I suggest [files?w=1](284/files?w=1) to review changed files.