### PR TITLE
add rubyzip directory traversal advisory

### DIFF
--- a/gems/rubyzip/CVE-2017-5946.yml
+++ b/gems/rubyzip/CVE-2017-5946.yml
@@ -1,0 +1,14 @@
+---
+gem: rubyzip
+cve: 2017-5946
+url: https://github.com/rubyzip/rubyzip/issues/315
+title: Directory traversal vulnerability in rubyzip
+date: 2017-02-27
+description: |
+  The Zip::File component in the rubyzip gem before 1.2.1 for Ruby has a directory
+  traversal vulnerability. If a site allows uploading of .zip files, an attacker
+  can upload a malicious file that uses "../" pathname substrings to write arbitrary
+  files to the filesystem.
+cvss_v3: 6.1
+patched_versions:
+  - ">= 1.2.1"


### PR DESCRIPTION
This PR adds rubyzip directory traversal vulnerability to advisories list.

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-5946

@reedloden @mveytsman