### PR TITLE
Add nokogiri CVE-2016-4658 and CVE-2016-5131

### DIFF
--- a/gems/nokogiri/CVE-2016-4658.yml
+++ b/gems/nokogiri/CVE-2016-4658.yml
@@ -27,7 +27,6 @@ patched_versions:
   - ">= 1.7.1"
 related:
   cve:
-    - 2016-4658
     - 2016-5131
   url:
     - https://github.com/sparklemotion/nokogiri/issues/1615

--- a/gems/nokogiri/CVE-2016-4658.yml
+++ b/gems/nokogiri/CVE-2016-4658.yml
@@ -1,0 +1,33 @@
+---
+gem: nokogiri
+cve: 2016-4658
+url: https://github.com/sparklemotion/nokogiri/issues/1615
+title: Nokogiri gem contains several vulnerabilities in libxml2 and libxslt
+date: 2017-03-11
+description: |
+  Nokogiri version 1.7.1 has been released, pulling in several upstream
+  patches to the vendored libxml2 to address the following CVEs:
+
+  CVE-2016-4658
+  CVSS v3 Base Score: 9.8 (Critical)
+  libxml2 in Apple iOS before 10, OS X before 10.12, tvOS before 10, and
+  watchOS before 3 allows remote attackers to execute arbitrary code or cause
+  a denial of service (memory corruption) via a crafted XML document.
+
+  CVE-2016-5131
+  CVSS v3 Base Score: 8.8 (HIGH)
+  Use-after-free vulnerability in libxml2 through 2.9.4, as used in Google
+  Chrome before 52.0.2743.82, allows remote attackers to cause a denial of
+  service or possibly have unspecified other impact via vectors related to
+  the XPointer range-to function.
+
+cvss_v3: 9.8
+
+patched_versions:
+  - ">= 1.7.1"
+related:
+  cve:
+    - 2016-4658
+    - 2016-5131
+  url:
+    - https://github.com/sparklemotion/nokogiri/issues/1615


### PR DESCRIPTION
This adds nokogiri CVE-2016-4658 and CVE-2016-5131.

https://groups.google.com/forum/#!topic/ruby-security-ann/R0dyurqxk8o