### PR TITLE
Update patched versions for mail gem vulnerability OSVDB-131677

### DIFF
--- a/gems/mail/OSVDB-131677.yml
+++ b/gems/mail/OSVDB-131677.yml
@@ -16,4 +16,4 @@ description: |
   Recipient Email Addresses." 2015. The attacks described in the paper (Terada,
   p. 4) can be applied to the library without any modification.
 patched_versions:
-- ">= 2.6.0"
+- ">= 2.5.5"


### PR DESCRIPTION
See 

https://github.com/mikel/mail/pull/1097

and 

https://hackerone.com/reports/137631

The vulnerability seems to have actually been addressed by versions 2.5.5 and 2.6.6. Please verify that my `patched_versions` specifiers reflect this correctly.