### PR TITLE
CVE-2015-9096 for Ruby SMTP injection. Migrate Mail OSVDB-131677 to CVE-2015-9097.

### DIFF
--- a/gems/mail/OSVDB-131677.yml
+++ b/gems/mail/OSVDB-131677.yml
@@ -1,23 +1,26 @@
 ---
 gem: mail
+cve: 2015-9097
 osvdb: 131677
-url: http://www.mbsd.jp/Whitepaper/smtpi.pdf
-title: Mail Gem for Ruby vulnerable to SMTP Injection via recipient email addresses
+url: https://hackerone.com/reports/137631
+title: SMTP command injection
 date: 2015-12-09
 description: |
-  Because the Mail Gem for Ruby does not validate or impose a length limit on
-  email address fields, an attacker can modify messages sent with the gem via a
-  specially-crafted recipient email address.
+  Because Mail does not disallow CRLF in email addresses, an attacker can
+  inject SMTP commands in specially crafted email addresses passed to
+  RCPT TO and MAIL FROM.
 
-  Applications that validate email address format are not affected by this
-  vulnerability.
+  Not affected by this vulnerability:
+    * Ruby 2.4.0+ with a fix for CVE-2015-9096.
+    * Applications that do not use SMTP delivery.
+    * Applications that validate email addresses to not include CRLF.
 
-  The recipient attack is described in Terada, Takeshi. "SMTP Injection via
-  Recipient Email Addresses." 2015. The attacks described in the paper (Terada,
-  p. 4) can be applied to the library without any modification.
+  The injection attack is described in Terada, Takeshi. "SMTP Injection via
+  Recipient Email Addresses." 2015. The attacks described in the paper
+  (Terada, p. 4) can be applied to the library without any modification.
 patched_versions:
 - ">= 2.5.5"
 related:
-  url: 
-    - https://hackerone.com/reports/137631
-    - https://github.com/mikel/mail/pull/1097  
+  url:
+    - http://www.mbsd.jp/Whitepaper/smtpi.pdf
+    - https://github.com/mikel/mail/pull/1097

--- a/rubies/ruby/CVE-2015-9096.yml
+++ b/rubies/ruby/CVE-2015-9096.yml
@@ -1,0 +1,19 @@
+---
+engine: ruby
+cve: 2015-9096
+url: https://hackerone.com/reports/137631
+title: SMTP command injection
+date: 2015-12-09
+description: |
+  Net::SMTP is vulnerable to SMTP command injection via CRLF sequences
+  in a RCPT TO or MAIL FROM command, as demonstrated by CRLF sequences
+  immediately before and after a DATA substring.
+
+  Applications that validate email address format are not affected by this
+  vulnerability.
+
+  The injection attack is described in Terada, Takeshi. "SMTP Injection via
+  Recipient Email Addresses." 2015. The attacks described in the paper
+  (Terada, p. 4) can be applied to without any modification.
+patched_versions:
+  - ">= 2.4.0"


### PR DESCRIPTION
Add CVE-2015-9096 for Ruby Net::SMTP command injection.

Migrate Mail OSVDB-131677 to CVE-2015-9097.

/cc @unak @shugo @reedloden @phillmv