### PR TITLE
Add RubyGems's vulnerabilities fixed by 2.6.13.

### DIFF
--- a/libraries/rubygems/CVE-2017-0899.yml
+++ b/libraries/rubygems/CVE-2017-0899.yml
@@ -1,0 +1,11 @@
+---
+library: rubygems
+cve: 2017-0899
+url: http://blog.rubygems.org/2017/08/27/2.6.13-released.html
+title: |
+  an ANSI escape sequence vulnerability.
+date: 2017-08-27
+description: |
+  an ANSI escape sequence vulnerability.
+patched_versions:
+  - ">= 2.6.13"

--- a/libraries/rubygems/CVE-2017-0900.yml
+++ b/libraries/rubygems/CVE-2017-0900.yml
@@ -1,0 +1,11 @@
+---
+library: rubygems
+cve: 2017-0900
+url: http://blog.rubygems.org/2017/08/27/2.6.13-released.html
+title: |
+  A DoS vulnerability in the query command.
+date: 2017-08-27
+description: |
+  A DoS vulnerability in the query command.
+patched_versions:
+  - ">= 2.6.13"

--- a/libraries/rubygems/CVE-2017-0901.yml
+++ b/libraries/rubygems/CVE-2017-0901.yml
@@ -1,0 +1,11 @@
+---
+library: rubygems
+cve: 2017-0901
+url: http://blog.rubygems.org/2017/08/27/2.6.13-released.html
+title: |
+  A vulnerability in the gem installer that allowed a malicious gem to overwrite arbitrary files.
+date: 2017-08-27
+description: |
+  A vulnerability in the gem installer that allowed a malicious gem to overwrite arbitrary files.
+patched_versions:
+  - ">= 2.6.13"

--- a/libraries/rubygems/CVE-2017-0902.yml
+++ b/libraries/rubygems/CVE-2017-0902.yml
@@ -1,0 +1,11 @@
+---
+library: rubygems
+cve: 2017-0902
+url: http://blog.rubygems.org/2017/08/27/2.6.13-released.html
+title: |
+  A DNS request hijacking vulnerability.
+date: 2017-08-27
+description: |
+  A DNS request hijacking vulnerability.
+patched_versions:
+  - ">= 2.6.13"


### PR DESCRIPTION
Add RubyGems's CVEs fixed by 2.6.13. See http://blog.rubygems.org/2017/08/27/2.6.13-released.html
CVE numbers was referenced from https://www.ruby-lang.org/en/news/2017/08/29/multiple-vulnerabilities-in-rubygems/.