### PR TITLE
Add cve-2012-6134 for omniauth-oauth2 gem

### DIFF
--- a/gems/omniauth-oauth2/CVE-2012-6134.yml
+++ b/gems/omniauth-oauth2/CVE-2012-6134.yml
@@ -1,0 +1,23 @@
+---
+gem: omniauth-oauth2
+cve: 2012-6134
+url: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-6134
+title: Cross-site request forgery (CSRF) vulnerability in the omniauth-oauth2 gem prior to version 1.1.1
+date: 2013-02-13
+
+description: |
+  Cross-site request forgery (CSRF) vulnerability in the omniauth-oauth2
+  gem prior to version 1.1.1 allows remote attackers to hijack the
+  authentication of users for requests that modify session state.
+  Note that the CVE lists version 1.1.1 and earlier as vulnerable, which
+  is not correct: version 1.1.1 is the first patched version according
+  to https://github.com/intridea/omniauth-oauth2/commit/451f7ecad175e3f91a890a6b363b39889e727b68
+cvss_v2: 6.8
+
+patched_versions:
+  - ">= 1.1.1"
+
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-6134
+    - https://github.com/intridea/omniauth-oauth2/pull/25


### PR DESCRIPTION
See https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-6134 and also discussion on PR thread to see confirmation that the first patched version is actually 1.1.1, despite what the CVE says:
https://github.com/intridea/omniauth-oauth2/pull/25.