### PR TITLE
Recurly CVE-2017-0905

### DIFF
--- a/gems/recurly/CVE-2017-0905.yml
+++ b/gems/recurly/CVE-2017-0905.yml
@@ -1,0 +1,35 @@
+---
+gem: recurly
+cve: 2017-0905
+url: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0905
+date: 2017-11-09
+title: |
+  SSRF vulnerability in Resource#find.
+
+description: |
+  If you are using the #find method on any of the classes that are derived from
+  the Resource class and you are passing user input into that method, a
+  malicious user can force the http client to reach out to a server under their
+  control. This can lead to leakage of your private API key.
+
+  Because of the severity of impact, we are recommending that all users upgrade
+  to a patched version. We have provided a non-breaking patch for every 2.X
+  version of the client.
+
+patched_versions:
+  - ~> 2.0.13
+  - ~> 2.1.11
+  - ~> 2.2.5
+  - ~> 2.3.10
+  - ~> 2.4.11
+  - ~> 2.5.3
+  - ~> 2.6.3
+  - ~> 2.7.8
+  - ~> 2.8.2
+  - ~> 2.9.2
+  - ~> 2.10.4
+  - ~> 2.11.3
+
+related:
+  url:
+    - https://github.com/recurly/recurly-client-ruby/commit/1bb0284d6e668b8b3d31167790ed6db1f6ccc4be

--- a/gems/recurly/CVE-2017-0905.yml
+++ b/gems/recurly/CVE-2017-0905.yml
@@ -4,7 +4,7 @@ cve: 2017-0905
 url: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0905
 date: 2017-11-09
 title: |
-  SSRF vulnerability in Resource#find.
+  SSRF vulnerability in Recurly gem's Resource#find.
 
 description: |
   If you are using the #find method on any of the classes that are derived from


### PR DESCRIPTION
SSRF vulnerability in Resource#find method of the `recurly` gem.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-0905