### PR TITLE
yajl-ruby CVE-2017-16516

### DIFF
--- a/gems/yajl-ruby/CVE-2017-16516.yml
+++ b/gems/yajl-ruby/CVE-2017-16516.yml
@@ -7,7 +7,14 @@ title: |
 date: 2017-11-03
 
 description: |
-  In the yajl-ruby gem 1.3.0 for Ruby, when a crafted JSON file is supplied to Yajl::Parser.new.parse, the whole ruby process crashes with a SIGABRT in the yajl_string_decode function in yajl_encode.c. This results in the whole ruby process terminating and potentially a denial of service.
+  In the yajl-ruby gem 1.3.0 for Ruby, when a crafted JSON file is supplied to
+  Yajl::Parser.new.parse, the whole ruby process crashes with a SIGABRT in the 
+  yajl_string_decode function in yajl_encode.c. This results in the whole ruby 
+  process terminating and potentially a denial of service.
 
 patched_versions:
   - ">= 1.3.1"
+
+related:
+  url:
+    - https://github.com/brianmario/yajl-ruby/issues/176

--- a/gems/yajl-ruby/CVE-2017-16516.yml
+++ b/gems/yajl-ruby/CVE-2017-16516.yml
@@ -1,0 +1,13 @@
+---
+gem: yajl-ruby
+cve: 2017-16516
+url: https://nvd.nist.gov/vuln/detail/CVE-2017-16516
+title: |
+  SIGABRT - process aborted
+date: 2017-11-03
+
+description: |
+  In the yajl-ruby gem 1.3.0 for Ruby, when a crafted JSON file is supplied to Yajl::Parser.new.parse, the whole ruby process crashes with a SIGABRT in the yajl_string_decode function in yajl_encode.c. This results in the whole ruby process terminating and potentially a denial of service.
+
+patched_versions:
+  - ">= 1.3.1"

--- a/gems/yajl-ruby/CVE-2017-16516.yml
+++ b/gems/yajl-ruby/CVE-2017-16516.yml
@@ -3,7 +3,7 @@ gem: yajl-ruby
 cve: 2017-16516
 url: https://nvd.nist.gov/vuln/detail/CVE-2017-16516
 title: |
-  SIGABRT - process aborted
+  Flaw in yajl-ruby gem may cause a DoS
 date: 2017-11-03
 
 description: |


### PR DESCRIPTION
This adds a recent high-severity CVE for `yajl-ruby`.