### PR TITLE
Add redis-store 1.3.0 unsafe load vulnerability

### DIFF
--- a/gems/redis-store/CVE-2017-1000248.yml
+++ b/gems/redis-store/CVE-2017-1000248.yml
@@ -1,18 +1,17 @@
 ---
 gem: redis-store
 cve: 2017-1000248
-url: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1000248
+url: https://github.com/redis-store/redis-store/commit/ce13252c26fcc40ed4935c9abfeb0ee0761e5704
 date: 2017-11-16
 title: |
   Unsafe objects can be loaded from Redis
 
 description: |
-  Redis-store <=v1.3.0 allows unsafe objects to be loaded from redis
+  Redis-store <=v1.3.0 allows unsafe objects to be loaded from Redis via the use of the Marshal serializer.
 
 patched_versions:
-  - ~> 1.4.0
-  - ~> 1.4.1
+  - ">= 1.4.0"
 
 related:
   url:
-    - https://github.com/redis-store/redis-store/commit/ce13252c26fcc40ed4935c9abfeb0ee0761e5704
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1000248

--- a/gems/redis-store/CVE-2017-1000248.yml
+++ b/gems/redis-store/CVE-2017-1000248.yml
@@ -1,0 +1,18 @@
+---
+gem: redis-store
+cve: 2017-1000248
+url: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-1000248
+date: 2017-11-16
+title: |
+  Unsafe objects can be loaded from Redis
+
+description: |
+  Redis-store <=v1.3.0 allows unsafe objects to be loaded from redis
+
+patched_versions:
+  - ~> 1.4.0
+  - ~> 1.4.1
+
+related:
+  url:
+    - https://github.com/redis-store/redis-store/commit/ce13252c26fcc40ed4935c9abfeb0ee0761e5704


### PR DESCRIPTION
Covers [CVE-2017-1000248](https://nvd.nist.gov/vuln/detail/CVE-2017-1000248)