### PR TITLE
Add current version for recurly

### DIFF
--- a/gems/recurly/CVE-2017-0905.yml
+++ b/gems/recurly/CVE-2017-0905.yml
@@ -29,6 +29,7 @@ patched_versions:
   - ~> 2.9.2
   - ~> 2.10.4
   - ~> 2.11.3
+  - ">= 2.12.0"
 
 related:
   url:


### PR DESCRIPTION
Current and future releases are fixed. https://github.com/recurly/recurly-client-ruby/commit/1bb0284d6e668b8b3d31167790ed6db1f6ccc4be