### PR TITLE
Add CVE-2015-9096 fixed versions.

### DIFF
--- a/rubies/ruby/CVE-2015-9096.yml
+++ b/rubies/ruby/CVE-2015-9096.yml
@@ -17,3 +17,4 @@ description: |
   (Terada, p. 4) can be applied to without any modification.
 patched_versions:
   - ">= 2.4.0"
+  - ">= 2.3.5"

--- a/rubies/ruby/CVE-2015-9096.yml
+++ b/rubies/ruby/CVE-2015-9096.yml
@@ -17,4 +17,4 @@ description: |
   (Terada, p. 4) can be applied to without any modification.
 patched_versions:
   - ">= 2.4.0"
-  - ">= 2.3.5"
+  - "~> 2.3.5"


### PR DESCRIPTION
CVE-2015-9096 was fixed with Ruby 2.3.5, too. But Ruby 2.2 series was not fixed.

* Ruby 2.3: fixed https://github.com/ruby/ruby/pull/1647
* Ruby 2.2: not fixed https://github.com/ruby/ruby/pull/1648

