### PR TITLE
Add Rubocop CVE-2017-8418

### DIFF
--- a/gems/rubocop/CVE-2017-8418.yml
+++ b/gems/rubocop/CVE-2017-8418.yml
@@ -1,0 +1,20 @@
+---
+gem: rubocop
+cve: 2017-8418
+url: https://github.com/bbatsov/rubocop/issues/4336
+date: 2017-05-01
+title: |
+  RuboCop: insecure use of /tmp
+
+description: |
+  RuboCop 0.48.1 and earlier does not use /tmp in safe way, allowing local
+  users to exploit this to tamper with cache files belonging to other users.
+
+cvss_v2: 2.1
+
+patched_versions:
+  - ~> 0.49.0
+
+related:
+  url:
+    - http://www.openwall.com/lists/oss-security/2017/05/01/14


### PR DESCRIPTION
RuboCop 0.48.1 and earlier does not use /tmp in safe way,
allowing local users to exploit this to tamper with cache
files belonging to other users.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418
https://github.com/bbatsov/rubocop/issues/4336