### PR TITLE
Fixed wrong detection of rubocop vulnerability.

### DIFF
--- a/gems/rubocop/CVE-2017-8418.yml
+++ b/gems/rubocop/CVE-2017-8418.yml
@@ -13,7 +13,7 @@ description: |
 cvss_v2: 2.1
 
 patched_versions:
-  - ~> 0.49.0
+  - ">= 0.49.0"
 
 related:
   url:


### PR DESCRIPTION
See output `Version` vs `Solution`:

```
Name: rubocop
Version: 0.51.0
Advisory: CVE-2017-8418
Criticality: Low
URL: https://github.com/bbatsov/rubocop/issues/4336
Title: RuboCop: insecure use of /tmp
Solution: upgrade to ~> 0.49.0

Vulnerabilities found!
```