### PR TITLE
Removing patched version for Redcloth Gem

### DIFF
--- a/gems/RedCloth/CVE-2012-6684.yml
+++ b/gems/RedCloth/CVE-2012-6684.yml
@@ -13,8 +13,6 @@ description: |
   script code in a user's browser session within the trust relationship between
   their browser and the server.
 cvss_v2: 4.3
-patched_versions:
-  - ">= 4.3.0"
 related:
   url:
     - https://github.com/jgarber/redcloth/commit/2f6dab4d6aea5cee778d2f37a135637fe3f1573c


### PR DESCRIPTION
Patched version is wrong as version 4.3.2 still has XSS issues, There is no currently patched version.