### PR TITLE
Add CVE-2017-0889

### DIFF
--- a/gems/paperclip/CVE-2017-0889.yml
+++ b/gems/paperclip/CVE-2017-0889.yml
@@ -1,0 +1,23 @@
+---
+gem: paperclip
+cve: 2017-0889
+url: https://github.com/thoughtbot/paperclip/pull/2435
+date: 2018-01-23
+title: |
+  Paperclip ruby gem suffers from a Server-Side Request Forgery (SSRF) vulnerability
+  in the Paperclip::UriAdapter and Paperclip::HttpUrlProxyAdapter class.
+description: |
+  Paperclip gem provides multiple ways a file can be uploaded to a web server.
+  The vulnerability affects two of Paperclip’s IO adapters that accept URLs as
+  attachment data (UriAdapter and HttpUrlProxyAdapter). When these adapters are
+  used, Paperclip acts as a proxy and downloads the file from the website URI
+  that is passed in. The library does not perform any validation to protect
+  against Server Side Request Forgery (SSRF) exploits by default. This may allow
+  a remote attacker to access information about internal network resources.
+cvss_v2: 7.5
+patched_versions:
+  - ">= 5.2.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-0889
+    - https://github.com/thoughtbot/paperclip/commit/4ebedfbd11d20d03ed03a1274ed281eee62715d4


### PR DESCRIPTION
GitHub reported a security vulnerability in the `paperclip` ruby gem of one project I've been currently involved in. `bundler-audit` is not detecting such vulnerability. This PR aims to add a new entry for the paperclip gem into `ruby-advisory-db`.

I'd also like to mention @rongutierrez for releasing a useful [blog post](https://medium.com/in-the-weeds/all-about-paperclips-cve-2017-0889-server-side-request-forgery-ssrf-vulnerability-8cb2b1c96fe8) providing details on the vulnerability as well as recommended actions. 