### PR TITLE
Add CVE-2017-15412 for nokogiri

### DIFF
--- a/gems/nokogiri/CVE-2017-15412.yml
+++ b/gems/nokogiri/CVE-2017-15412.yml
@@ -3,7 +3,7 @@ gem: nokogiri
 cve: 2017-15412
 url: https://github.com/sparklemotion/nokogiri/issues/1714
 title: Nokogiri gem, via libxml, is affected by DoS vulnerabilities
-date: 2018-02-29
+date: 2018-01-29
 description: |
   The version of libxml2 packaged with Nokogiri contains a
   vulnerability. Nokogiri has mitigated these issue by upgrading to

--- a/gems/nokogiri/CVE-2017-15412.yml
+++ b/gems/nokogiri/CVE-2017-15412.yml
@@ -1,0 +1,21 @@
+---
+gem: nokogiri
+cve: 2017-15412
+url: https://github.com/sparklemotion/nokogiri/issues/1714
+title: Nokogiri gem, via libxml, is affected by DoS vulnerabilities
+date: 2018-02-29
+description: |
+  The version of libxml2 packaged with Nokogiri contains a
+  vulnerability. Nokogiri has mitigated these issue by upgrading to
+  libxml 2.9.6.
+
+  It was discovered that libxml2 incorrecty handled certain files. An attacker
+  could use this issue with specially constructed XML data to cause libxml2 to
+  consume resources, leading to a denial of service.
+
+patched_versions:
+  - ">= 1.8.2"
+related:
+  url:
+    - https://usn.ubuntu.com/usn/usn-3424-1/
+    - https://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-15412.html

--- a/gems/nokogiri/CVE-2017-15412.yml
+++ b/gems/nokogiri/CVE-2017-15412.yml
@@ -17,5 +17,5 @@ patched_versions:
   - ">= 1.8.2"
 related:
   url:
-    - https://usn.ubuntu.com/usn/usn-3424-1/
+    - https://usn.ubuntu.com/usn/usn-3513-1/
     - https://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-15412.html


### PR DESCRIPTION
> CVE-2017-15412 was addressed in libxml v2.9.6, which Nokogiri's latest release (v1.8.1) has not yet vendored. Upgrading Nokogiri to distribute libxml v2.9.6 or later is necessary to address this vulnerability.

https://github.com/sparklemotion/nokogiri/issues/1714