### PR TITLE
Add CVE-2017-16932 for nokogiri

### DIFF
--- a/gems/nokogiri/CVE-2017-16932.yml
+++ b/gems/nokogiri/CVE-2017-16932.yml
@@ -1,0 +1,21 @@
+---
+gem: nokogiri
+cve: 2017-16932
+url: https://github.com/sparklemotion/nokogiri/issues/1714
+title: Nokogiri gem, via libxml, is affected by DoS vulnerabilities
+date: 2018-01-29
+description: |
+  The version of libxml2 packaged with Nokogiri contains a
+  vulnerability. Nokogiri has mitigated these issue by upgrading to
+  libxml 2.9.5.
+
+  Wei Lei discovered that libxml2 incorrecty handled certain parameter
+  entities. An attacker could use this issue with specially constructed XML
+  data to cause libxml2 to consume resources, leading to a denial of service.
+
+patched_versions:
+  - ">= 1.8.1"
+related:
+  url:
+    - https://usn.ubuntu.com/usn/usn-3504-1/
+    - https://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-16932.html


### PR DESCRIPTION
> CVE-2017-16932 was addressed in libxml 2.9.5, and so Nokogiri v1.8.1 (released 2017-09-19) has already addressed this vulnerability.

https://github.com/sparklemotion/nokogiri/issues/1714