### PR TITLE
Fix CVE-2018-7212 to refer to rack-protection with correct fix versions

### DIFF
--- a/gems/rack-protection/CVE-2018-7212.yml
+++ b/gems/rack-protection/CVE-2018-7212.yml
@@ -1,11 +1,12 @@
 ---
-gem: sinatra
+gem: rack-protection
 cve: 2018-7212
 url: https://github.com/sinatra/sinatra/pull/1379
 title: Path traversal is possible via backslash characters on Windows.
 date: 2018-02-18
 description: |
-  An issue was discovered in Sinatra 2.x before 2.0.1 on Windows. Path traversal
+  An issue was discovered in rack-protecion 2.x before 2.0.1 on Windows. Path traversal
   is possible via backslash characters.
 patched_versions:
   - ">= 2.0.1"
+  - "~> 1.5.4"

--- a/gems/rack-protection/CVE-2018-7212.yml
+++ b/gems/rack-protection/CVE-2018-7212.yml
@@ -5,7 +5,7 @@ url: https://github.com/sinatra/sinatra/pull/1379
 title: Path traversal is possible via backslash characters on Windows.
 date: 2018-02-18
 description: |
-  An issue was discovered in rack-protecion 2.x before 2.0.1 on Windows. Path traversal
+  An issue was discovered in rack-protection 2.x before 2.0.1 on Windows. Path traversal
   is possible via backslash characters.
 patched_versions:
   - ">= 2.0.1"


### PR DESCRIPTION
CVE-2018-7212 is in rack-protection which is in the same Github repo as Sinatra as of version 2.0.0. The fix was also backported to rack-protection 1.5.4 in this branch:
https://github.com/sinatra/rack-protection/commits/stable-1.5

Fixes #330 