### PR TITLE
Add MRI Ruby CVE: 2017-17742

### DIFF
--- a/rubies/ruby/CVE-2017-17742.yml
+++ b/rubies/ruby/CVE-2017-17742.yml
@@ -1,0 +1,22 @@
+---
+engine: ruby
+cve: 2017-17742
+url: https://www.ruby-lang.org/en/news/2018/03/28/http-response-splitting-in-webrick-cve-2017-17742/
+title: HTTP response splitting in WEBrick
+date: 2018-03-28
+description: |
+  There is an HTTP response splitting vulnerability in WEBrick bundled with Ruby.
+
+  If a script accepts an external input and outputs it without modification as
+  a part of HTTP responses, an attacker can use newline characters to deceive
+  the clients that the HTTP response header is stopped at there, and can inject
+  fake HTTP responses after the newline characters to show malicious contents
+  to the clients.
+
+  All users running an affected release should upgrade immediately.
+patched_versions:
+  - "~> 2.2.10"
+  - "~> 2.3.7"
+  - "~> 2.4.4"
+  - "~> 2.5.1"
+  - "> 2.6.0-preview1"


### PR DESCRIPTION
This adds https://www.ruby-lang.org/en/news/2018/03/28/http-response-splitting-in-webrick-cve-2017-17742/

It seems like the CVE details are not publicly available yet - I followed the link in the ruby-lang.org link above to http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17742 but there are no details there so I don't know what the CVSS scores are.