### PR TITLE
Add missing ruby CVEs which prompted ruby release on 2018-03-28

### DIFF
--- a/rubies/ruby/CVE-2018-6914.yml
+++ b/rubies/ruby/CVE-2018-6914.yml
@@ -1,0 +1,27 @@
+---
+engine: ruby
+cve: 2018-6914
+url: https://www.ruby-lang.org/en/news/2018/03/28/unintentional-file-and-directory-creation-with-directory-traversal-cve-2018-6914/
+title: Unintentional file and directory creation with directory traversal in tempfile and tmpdir
+date: 2018-03-28
+description: |
+  There is an unintentional directory creation vulnerability in tmpdir library
+  bundled with Ruby. And there is also an unintentional file creation
+  vulnerability in tempfile library bundled with Ruby, because it uses tmpdir
+  internally
+
+  `Dir.mktmpdir` method introduced by tmpdir library accepts the prefix and the
+  suffix of the directory which is created as the first parameter. The prefix can
+  contain relative directory specifiers `../`, so this method can be used to
+  target any directory. So, if a script accepts an external input as the prefix,
+  and the targeted directory has inappropriate permissions or the ruby process
+  has inappropriate privileges, the attacker can create a directory or a file at
+  any directory.
+
+  All users running an affected release should upgrade immediately.
+patched_versions:
+  - "~> 2.2.10"
+  - "~> 2.3.7"
+  - "~> 2.4.4"
+  - "~> 2.5.1"
+  - "> 2.6.0-preview1"

--- a/rubies/ruby/CVE-2018-8777.yml
+++ b/rubies/ruby/CVE-2018-8777.yml
@@ -1,0 +1,21 @@
+---
+engine: ruby
+cve: 2018-8777
+url: https://www.ruby-lang.org/en/news/2018/03/28/large-request-dos-in-webrick-cve-2018-8777/
+title: DoS by large request in WEBrick
+date: 2018-03-28
+description: |
+  There is a out-of-memory DoS vulnerability with a large request in WEBrick
+  bundled with Ruby
+
+  If an attacker sends a large request which contains huge HTTP headers,
+  WEBrick try to process it on memory, so the request causes the out-of-memory
+  DoS attack.
+
+  All users running an affected release should upgrade immediately.
+patched_versions:
+  - "~> 2.2.10"
+  - "~> 2.3.7"
+  - "~> 2.4.4"
+  - "~> 2.5.1"
+  - "> 2.6.0-preview1"

--- a/rubies/ruby/CVE-2018-8778.yml
+++ b/rubies/ruby/CVE-2018-8778.yml
@@ -1,0 +1,20 @@
+---
+engine: ruby
+cve: 2018-8778
+url: https://www.ruby-lang.org/en/news/2018/03/28/buffer-under-read-unpack-cve-2018-8778/
+title: Buffer under-read in String#unpack
+date: 2018-03-28
+description: |
+  `String#unpack` receives format specifiers as its parameter, and can be
+  specified the position of parsing the data by the specifier `@`. If a big
+  number is passed with `@`, the number is treated as the negative value, and
+  out-of-buffer read is occurred. So, if a script accepts an external input as
+  the argument of `String#unpack`, the attacker can read data on heaps.
+
+  All users running an affected release should upgrade immediately.
+patched_versions:
+  - "~> 2.2.10"
+  - "~> 2.3.7"
+  - "~> 2.4.4"
+  - "~> 2.5.1"
+  - "> 2.6.0-preview1"

--- a/rubies/ruby/CVE-2018-8779.yml
+++ b/rubies/ruby/CVE-2018-8779.yml
@@ -1,0 +1,28 @@
+---
+engine: ruby
+cve: 2018-8779
+url: https://www.ruby-lang.org/en/news/2018/03/28/poisoned-nul-byte-unixsocket-cve-2018-8779/
+title: Unintentional socket creation by poisoned NUL byte in UNIXServer and UNIXSocket
+date: 2018-03-28
+description: |
+  There is a unintentional socket creation vulnerability in `UNIXServer.open`
+  method of socket library bundled with Ruby. And there is also a unintentional
+  socket access vulnerability in `UNIXSocket.open` method.
+
+  `UNIXServer.open` accepts the path of the socket to be created at the first
+  parameter. If the path contains NUL (`\0`) bytes, this method recognize that
+  the path is completed before the NUL bytes. So, if a script accepts an external
+  input as the argument of this method, the attacker can make the socket file in
+  the unintentional path. And, `UNIXSocket.open` also accepts the path of the
+  socket to be created at the first parameter without checking NUL bytes like
+  `UNIXServer.open`. So, if a script accepts an external input as the argument of
+  this method, the attacker can accepts the socket file in the unintentional
+  path.
+
+  All users running an affected release should upgrade immediately.
+patched_versions:
+  - "~> 2.2.10"
+  - "~> 2.3.7"
+  - "~> 2.4.4"
+  - "~> 2.5.1"
+  - "> 2.6.0-preview1"

--- a/rubies/ruby/CVE-2018-8780.yml
+++ b/rubies/ruby/CVE-2018-8780.yml
@@ -1,0 +1,22 @@
+---
+engine: ruby
+cve: 2018-8780
+url: https://www.ruby-lang.org/en/news/2018/03/28/poisoned-nul-byte-dir-cve-2018-8780/
+title: Unintentional directory traversal by poisoned NUL byte in Dir
+date: 2018-03-28
+description: |
+  There is an unintentional directory traversal in some methods in `Dir`
+
+  `Dir.open`, `Dir.new`, `Dir.entries` and `Dir.empty?` accept the path of the
+  target directory as their parameter. If the parameter contains NUL (`\0`)
+  bytes, these methods recognize that the path is completed before the NUL bytes.
+  So, if a script accepts an external input as the argument of these methods, the
+  attacker can make the unintentional directory traversal.
+
+  All users running an affected release should upgrade immediately.
+patched_versions:
+  - "~> 2.2.10"
+  - "~> 2.3.7"
+  - "~> 2.4.4"
+  - "~> 2.5.1"
+  - "> 2.6.0-preview1"


### PR DESCRIPTION
This adds the five remaining CVEs mentioned in https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/