### PR TITLE
Add CVE-2018-11627 for Sinatra (#337)

### DIFF
--- a/gems/sinatra/CVE-2018-11627.yml
+++ b/gems/sinatra/CVE-2018-11627.yml
@@ -11,3 +11,5 @@ cvss_v3: 6.1
 
 patched_versions:
   - ">= 2.0.2"
+unaffected_versions:
+  - "< 2.0.0"

--- a/gems/sinatra/CVE-2018-11627.yml
+++ b/gems/sinatra/CVE-2018-11627.yml
@@ -1,0 +1,13 @@
+---
+gem: sinatra
+cve: 2018-11627
+url: https://github.com/sinatra/sinatra/issues/1428
+title: XSS via the 400 Bad Request page
+date: 2018-05-31
+description: |
+  Sinatra before 2.0.2 has XSS via the 400 Bad Request page that occurs upon a params parser exception.
+
+cvss_v3: 6.1
+
+patched_versions:
+  - ">= 2.0.2"


### PR DESCRIPTION
This CVE was flagged by GitHub but missed by bundle-audit as sinatra not in the advisory DB.