### PR TITLE
Remove pre-releases from unaffected versions

### DIFF
--- a/gems/sinatra/CVE-2018-11627.yml
+++ b/gems/sinatra/CVE-2018-11627.yml
@@ -12,4 +12,5 @@ cvss_v3: 6.1
 patched_versions:
   - ">= 2.0.2"
 unaffected_versions:
-  - "< 2.0.0"
+  - "< 2.0.0.beta1"
+  - "2.0.0-alpha"


### PR DESCRIPTION
- `2.0.0.beta[1-2]` and `2.0.0.rc[1-6]` are also affected, but accidentally included to unaffected versions as they are `< 2.0.0`.
- In the commit history, `2.0.0-alpha` exists before `2.0.0.beta1` and it's not affected.  Since rubygems treats `2.0.0-alpha` as between `2.0.0.beta2` and `2.0.0.rc1`, we need to explicitly add it to unaffected versions.