### PR TITLE
Add patched version for CVE-2018-1000544

### DIFF
--- a/gems/rubyzip/CVE-2018-1000544.yml
+++ b/gems/rubyzip/CVE-2018-1000544.yml
@@ -10,6 +10,8 @@ description: |
   If a site allows uploading of .zip files, an attacker can upload a malicious file
   which contains symlinks or files with absolute pathnames "../" to write arbitrary
   files to the filesystem.
+patched_versions:
+  - "> 1.2.1"
 related:
   cve:
     - 2017-5946

--- a/gems/rubyzip/CVE-2018-1000544.yml
+++ b/gems/rubyzip/CVE-2018-1000544.yml
@@ -11,7 +11,7 @@ description: |
   which contains symlinks or files with absolute pathnames "../" to write arbitrary
   files to the filesystem.
 patched_versions:
-  - "> 1.2.1"
+  - ">= 1.2.2"
 related:
   cve:
     - 2017-5946


### PR DESCRIPTION
The rubyzip community is working on CVE-2018-1000544 in the following PR: https://github.com/rubyzip/rubyzip/pull/376
Earlier they worked on a possible fix but then introduced the previously mentioned PR, which disables symlink support. 

The gem version got increased from 1.2.1 to 1.2.2. in the PR and some people are already using the branch of the PR. Currently their Travis CI build passes but the coverage check does not, although only the version has been updated in the latest commit.

So far, no objection has been raised regarding the PR and it seems that version 1.2.2 will be the next release, closing the vulnerability.

I have therefore adapted the upcoming version of the rubyzip gem as patched version in the corresponding file for CVE-2018-1000544.

It is clear to me that this PR cannot be pulled immediately and we have to wait for the actual release of the new version of rubyzip. I just wanted to already prepare the adjustment.