### PR TITLE
fixed minitar patched versions

### DIFF
--- a/gems/archive-tar-minitar/CVE-2016-10173.yml
+++ b/gems/archive-tar-minitar/CVE-2016-10173.yml
@@ -13,4 +13,4 @@ description: |
 
   Credit: ecneladis
 patched_versions:
-  - ">= 0.6.1"
+  - ">= 0.6.0"

--- a/gems/minitar/CVE-2016-10173.yml
+++ b/gems/minitar/CVE-2016-10173.yml
@@ -13,4 +13,8 @@ description: |
 
   Credit: ecneladis
 patched_versions:
-  - ">= 0.6.1"
+  - ">= 0.6.0"
+related:
+  url:
+    - https://github.com/halostatue/minitar/issues/16
+    - https://github.com/halostatue/minitar/commit/e25205ecbb6277ae8a3df1e6a306d7ed4458b6e4


### PR DESCRIPTION
This is a small fix to `minitar` and `archive-mini-tar` for CVE-2016-10173.

The true fix version for both is `0.6.0` as can be seen in this commit: https://github.com/halostatue/minitar/commit/e25205ecbb6277ae8a3df1e6a306d7ed4458b6e4
