### PR TITLE
fixed the grape advisory

### DIFF
--- a/gems/grape/CVE-2018-3769.yml
+++ b/gems/grape/CVE-2018-3769.yml
@@ -1,5 +1,5 @@
 ---
-gem: ruby-grape
+gem: grape
 cve: 2018-3769
 date: 2018-05-23
 url: https://github.com/ruby-grape/grape/issues/1762
@@ -13,7 +13,7 @@ description: |
   http://example.com/api/endpoint?format=%3Cscript%3Ealert(document.cookie)%3C/script%3E
 
 patched_versions:
-  - ">= 1.0.3"
+  - ">= 1.1.0"
 related:
   url:
     - https://github.com/ruby-grape/grape/pull/1763


### PR DESCRIPTION
This fixed the advisory for CVE-2018-3769 which has two inaccuracies in it:
- the gem name is `grape` not `ruby-grape`
- the fix version is `1.1.0` as can be be confirmed here: https://github.com/ruby-grape/grape/pull/1763#issuecomment-410463219