### PR TITLE
patched_versions for rubyzip CVE-2018-1000544.yml

### DIFF
--- a/gems/rubyzip/CVE-2018-1000544.yml
+++ b/gems/rubyzip/CVE-2018-1000544.yml
@@ -15,3 +15,5 @@ related:
     - 2017-5946
   url:
     - https://security-tracker.debian.org/tracker/CVE-2018-1000544
+patched_versions:
+  - ">= 1.2.2"


### PR DESCRIPTION
RubyZip 1.2.2 was just released.