### PR TITLE
Fix gem versions in rubyzip advisory

### DIFF
--- a/gems/rubyzip/CVE-2018-1000544.yml
+++ b/gems/rubyzip/CVE-2018-1000544.yml
@@ -5,13 +5,13 @@ url: https://github.com/rubyzip/rubyzip/issues/369
 cve: 2018-1000544
 title: Directory Traversal in rubyzip
 description: |
-  rubyzip version 1.2.1 and earlier contains a Directory Traversal vulnerability
+  rubyzip version 1.2.0 and earlier contains a Directory Traversal vulnerability
   in Zip::File component that can result in write arbitrary files to the filesystem.
   If a site allows uploading of .zip files, an attacker can upload a malicious file
   which contains symlinks or files with absolute pathnames "../" to write arbitrary
   files to the filesystem.
 patched_versions:
-  - ">= 1.2.2"
+  - ">= 1.2.1"
 related:
   cve:
     - 2017-5946


### PR DESCRIPTION
The supplied `patched_version` is incorrect. See rubyzip/rubyzip#315 for more details.