### PR TITLE
Add Ruby CVE 2018-16395 (#358)

### DIFF
--- a/rubies/ruby/CVE-2018-16395.yml
+++ b/rubies/ruby/CVE-2018-16395.yml
@@ -22,11 +22,11 @@ description: |
   or take one of the following workarounds as soon as possible.
 
   openssl gem 2.1.2 or later includes the fix for the vulnerability, so upgrate
-  openssl gem to the latest version if you are usign Ruby 2.4 or later series.
+  openssl gem to the latest version if you are using Ruby 2.4 or later series.
 
   `gem install openssl -v ">= 2.1.2"`
   
-  However, in Ruby 2.3 series, you can not override bundled version of openssl
+  However, in Ruby 2.3 series, you cannot override bundled version of openssl
   with openssl gem. Please upgrade your Ruby installation to the latest
   version.
 patched_versions:

--- a/rubies/ruby/CVE-2018-16395.yml
+++ b/rubies/ruby/CVE-2018-16395.yml
@@ -1,0 +1,26 @@
+---
+engine: ruby
+cve: 2018-16395
+url: ^
+       https://www.ruby-lang.org/en/news/2018/10/17/
+       openssl-x509-name-equality-check-does-not-work-correctly-cve-2018-16395/
+title: Incorrect equality check in OpenSSL::X509::Name
+date: 2018-10-17
+description: |
+  There is an unintentional directory traversal in some methods in `Dir`
+
+  An instance of `OpenSSL::X509::Name` contains entities such as `CN`, `C`
+  and so on. Some two instances of `OpenSSL::X509::Name` are equal only when
+  all entities are exactly equal. However, there is a bug that the equality
+  check is not correct if the value of an entity of the argument (right-hand
+  side) starts with the value of the receiver (left-hand side). So, if a
+  malicious X.509 certificate is passed to compare with an existing
+  certificate, there is a possibility to be judged incorrectly that they are
+  equal.
+
+  It is strongly recommended for Ruby users to upgrade your Ruby installation
+  or take one of the following workarounds as soon as possible.
+patched_versions:
+  - "~> 2.3.8"
+  - "~> 2.4.5"
+  - "~> 2.5.2"

--- a/rubies/ruby/CVE-2018-16395.yml
+++ b/rubies/ruby/CVE-2018-16395.yml
@@ -19,16 +19,7 @@ description: |
   equal.
 
   It is strongly recommended for Ruby users to upgrade your Ruby installation
-  or take one of the following workarounds as soon as possible.
-
-  openssl gem 2.1.2 or later includes the fix for the vulnerability, so upgrate
-  openssl gem to the latest version if you are usign Ruby 2.4 or later series.
-
-  `gem install openssl -v ">= 2.1.2"`
-  
-  However, in Ruby 2.3 series, you can not override bundled version of openssl
-  with openssl gem. Please upgrade your Ruby installation to the latest
-  version.
+  or to upgrade OpenSSL gem when patched version available.
 patched_versions:
   - "~> 2.3.8"
   - "~> 2.4.5"

--- a/rubies/ruby/CVE-2018-16395.yml
+++ b/rubies/ruby/CVE-2018-16395.yml
@@ -19,7 +19,16 @@ description: |
   equal.
 
   It is strongly recommended for Ruby users to upgrade your Ruby installation
-  or to upgrade OpenSSL gem when patched version available.
+  or take one of the following workarounds as soon as possible.
+
+  openssl gem 2.1.2 or later includes the fix for the vulnerability, so upgrate
+  openssl gem to the latest version if you are usign Ruby 2.4 or later series.
+
+  `gem install openssl -v ">= 2.1.2"`
+  
+  However, in Ruby 2.3 series, you can not override bundled version of openssl
+  with openssl gem. Please upgrade your Ruby installation to the latest
+  version.
 patched_versions:
   - "~> 2.3.8"
   - "~> 2.4.5"

--- a/rubies/ruby/CVE-2018-16395.yml
+++ b/rubies/ruby/CVE-2018-16395.yml
@@ -20,6 +20,15 @@ description: |
 
   It is strongly recommended for Ruby users to upgrade your Ruby installation
   or take one of the following workarounds as soon as possible.
+
+  openssl gem 2.1.2 or later includes the fix for the vulnerability, so upgrate
+  openssl gem to the latest version if you are usign Ruby 2.4 or later series.
+
+  `gem install openssl -v ">= 2.1.2"`
+  
+  However, in Ruby 2.3 series, you can not override bundled version of openssl
+  with openssl gem. Please upgrade your Ruby installation to the latest
+  version.
 patched_versions:
   - "~> 2.3.8"
   - "~> 2.4.5"

--- a/rubies/ruby/CVE-2018-16395.yml
+++ b/rubies/ruby/CVE-2018-16395.yml
@@ -1,13 +1,12 @@
 ---
 engine: ruby
 cve: 2018-16395
-url: ^
-       https://www.ruby-lang.org/en/news/2018/10/17/
-       openssl-x509-name-equality-check-does-not-work-correctly-cve-2018-16395/
+url: https://www.ruby-lang.org/en/news/2018/10/17/openssl-x509-name-equality-check-does-not-work-correctly-cve-2018-16395/
 title: Incorrect equality check in OpenSSL::X509::Name
 date: 2018-10-17
 description: |
-  There is an unintentional directory traversal in some methods in `Dir`
+  The equality check of `OpenSSL::X509::Name` is not correctly in openssl
+  extension library bundled with Ruby.
 
   An instance of `OpenSSL::X509::Name` contains entities such as `CN`, `C`
   and so on. Some two instances of `OpenSSL::X509::Name` are equal only when
@@ -21,13 +20,14 @@ description: |
   It is strongly recommended for Ruby users to upgrade your Ruby installation
   or take one of the following workarounds as soon as possible.
 
-  openssl gem 2.1.2 or later includes the fix for the vulnerability, so upgrate
-  openssl gem to the latest version if you are using Ruby 2.4 or later series.
+  `openssl` gem 2.1.2 or later includes the fix for the vulnerability, so
+  upgrade `openssl` gem to the latest version if you are using Ruby 2.4 or
+  later series.
 
   `gem install openssl -v ">= 2.1.2"`
   
   However, in Ruby 2.3 series, you cannot override bundled version of openssl
-  with openssl gem. Please upgrade your Ruby installation to the latest
+  with `openssl` gem. Please upgrade your Ruby installation to the latest
   version.
 patched_versions:
   - "~> 2.3.8"


### PR DESCRIPTION
This PR adds CVE 2018-16395 impacting Ruby.

Note that no new preview release of Ruby 2.6.0 has been announced so don't believe there is a patched version that can be indicated at this time.