### PR TITLE
Add Ruby CVE 2018-16396

### DIFF
--- a/rubies/ruby/CVE-2018-16396.yml
+++ b/rubies/ruby/CVE-2018-16396.yml
@@ -1,0 +1,24 @@
+---
+engine: ruby
+cve: 2018-16396
+url: ^
+       https://www.ruby-lang.org/en/news/2018/10/17/
+       not-propagated-taint-flag-in-some-formats-of-pack-cve-2018-16396/
+title: Tainted flags not always propogated in Array#pack and String#unpack
+date: 2018-10-17
+description: |
+  `Array#pack` method converts the receiver’s contents into a string with
+  specified format. If the receiver contains some tainted objects, the
+  returned string also should be tainted. `String#unpack` method which
+  converts the receiver into an array also should propagate its tainted flag
+  to the objects contained in the returned array. But, with `B`, `b`, `H` and
+  `h` directives, the tainted flags are not propagated. So, if a script
+  processes unreliable inputs by `Array#pack` and/or `String#unpack` with these
+  directives and checks the reliability with tainted flags, the check might be
+  wrong.
+
+  All users running an affected release should upgrade immediately.
+patched_versions:
+  - "~> 2.3.8"
+  - "~> 2.4.5"
+  - "~> 2.5.2"


### PR DESCRIPTION
This PR adds CVE 2018-16396 impacting Ruby.

Note that no new preview release of Ruby 2.6.0 has been announced so don't believe there is a patched version that can be indicated at this time.