### PR TITLE
Add specs to check against .yaml files

### DIFF
--- a/spec/advisories_spec.rb
+++ b/spec/advisories_spec.rb
@@ -7,11 +7,21 @@ describe "gems" do
   Dir.glob(File.join(File.dirname(__FILE__), '../gems/*/*.yml')) do |path|
     include_examples 'Gem Advisory', path
   end
+
+  it "shouldn't contain .yaml files" do
+    yaml_files = Dir.glob(File.join(File.dirname(__FILE__), '../gems/*/*.yaml'))
+    expect(yaml_files).to be_empty
+  end
 end
 
 describe "libraries" do
   Dir.glob(File.join(File.dirname(__FILE__), '../libraries/*/*.yml')) do |path|
     include_examples 'Libraries Advisory', path
+  end
+
+  it "shouldn't contain .yaml files" do
+    yaml_files = Dir.glob(File.join(File.dirname(__FILE__), '../libraries/*/*.yaml'))
+    expect(yaml_files).to be_empty
   end
 end
 
@@ -19,5 +29,9 @@ describe "rubies" do
   Dir.glob(File.join(File.dirname(__FILE__), '../rubies/*/*.yml')) do |path|
     include_examples 'Rubies Advisory', path
   end
-end
 
+  it "shouldn't contain .yaml files" do
+    yaml_files = Dir.glob(File.join(File.dirname(__FILE__), '../rubies/*/*.yaml'))
+    expect(yaml_files).to be_empty
+  end
+end


### PR DESCRIPTION
I suggest adding extra check for filenames to avoid accidental pushing of `.yaml` files, which are ignored in bundler-audit. This results in missed advisories (which is a vulnerability itself 💣, see #365)

Thanks guys for keeping our apps secure 👍 