### PR TITLE
Test that advisory file extensions are .yml

### DIFF
--- a/spec/advisories_spec.rb
+++ b/spec/advisories_spec.rb
@@ -4,19 +4,19 @@ require 'library_example'
 require 'ruby_example'
 
 describe "gems" do
-  Dir.glob(File.join(File.dirname(__FILE__), '../gems/*/*.yml')) do |path|
+  Dir.glob(File.join(File.dirname(__FILE__), '../gems/*/*')) do |path|
     include_examples 'Gem Advisory', path
   end
 end
 
 describe "libraries" do
-  Dir.glob(File.join(File.dirname(__FILE__), '../libraries/*/*.yml')) do |path|
+  Dir.glob(File.join(File.dirname(__FILE__), '../libraries/*/*')) do |path|
     include_examples 'Libraries Advisory', path
   end
 end
 
 describe "rubies" do
-  Dir.glob(File.join(File.dirname(__FILE__), '../rubies/*/*.yml')) do |path|
+  Dir.glob(File.join(File.dirname(__FILE__), '../rubies/*/*')) do |path|
     include_examples 'Rubies Advisory', path
   end
 end

--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -5,7 +5,7 @@ shared_examples_for 'Advisory' do |path|
   advisory = YAML.load_file(path)
 
   describe path do
-    let(:filename) { File.basename(path).chomp('.yml') }
+    let(:filename) { File.basename(path) }
 
     let(:filename_cve) do
       if filename.start_with?('CVE-')
@@ -20,7 +20,8 @@ shared_examples_for 'Advisory' do |path|
     end
 
     it "should be correctly named CVE-XXX or OSVDB-XXX" do
-      expect(filename).to match(/^(CVE-\d{4}-(0\d{3}|[1-9]\d{3,})|OSVDB-\d+)$/)
+      expect(filename).
+        to match(/^(CVE-\d{4}-(0\d{3}|[1-9]\d{3,})|OSVDB-\d+)\.yml$/)
     end
 
     it "should have CVE or OSVDB" do
@@ -51,7 +52,7 @@ shared_examples_for 'Advisory' do |path|
       end
       it "should be id in filename if filename is CVE-XXX" do
         if filename_cve
-          is_expected.to eq(filename_cve)
+          is_expected.to eq(filename_cve.chomp('.yml'))
         end
       end
     end


### PR DESCRIPTION
Alternative to #366. I prefer this because it tells you which file is failing the filename regex, but I'm nto fussed as long as one of this of #366 is merged. :octocat: 