### PR TITLE
Add new CVEs from rubygems

### DIFF
--- a/libraries/rubygems/CVE-2019-8320.yml
+++ b/libraries/rubygems/CVE-2019-8320.yml
@@ -1,0 +1,20 @@
+---
+library: rubygems
+cve: 2019-8320
+url: https://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html
+title: Delete directory using symlink when decompressing tar
+date: 2019-03-05
+description: |
+  A Directory Traversal issue was discovered in RubyGems 2.7.6 and later
+  through 3.0.2. Before making new directories or touching files (which now
+  include path-checking code for symlinks), it would delete the target
+  destination. If that destination was hidden behind a symlink, a malicious gem
+  could delete arbitrary files on the user’s machine, presuming the attacker
+  could guess at paths. Given how frequently gem is run as sudo, and how
+  predictable paths are on modern systems (/tmp, /usr, etc.), this could
+  likely lead to data loss or an unusable system.
+unaffected_versions:
+  - "< 2.7.6"
+patched_versions:
+  - "3.0.3"
+  - "2.7.8"

--- a/libraries/rubygems/CVE-2019-8320.yml
+++ b/libraries/rubygems/CVE-2019-8320.yml
@@ -16,5 +16,5 @@ description: |
 unaffected_versions:
   - "< 2.7.6"
 patched_versions:
-  - "3.0.3"
-  - "2.7.9"
+  - ">= 3.0.3"
+  - "~> 2.7.9"

--- a/libraries/rubygems/CVE-2019-8320.yml
+++ b/libraries/rubygems/CVE-2019-8320.yml
@@ -17,4 +17,4 @@ unaffected_versions:
   - "< 2.7.6"
 patched_versions:
   - "3.0.3"
-  - "2.7.8"
+  - "2.7.9"

--- a/libraries/rubygems/CVE-2019-8321.yml
+++ b/libraries/rubygems/CVE-2019-8321.yml
@@ -1,0 +1,15 @@
+---
+library: rubygems
+cve: 2019-8321
+url: https://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html
+title: Escape sequence injection vulnerability in verbose
+date: 2019-03-05
+description: |
+  An issue was discovered in RubyGems 2.6 and later through 3.0.2. Since
+  Gem::UserInteraction#verbose calls say without escaping, escape sequence
+  injection is possible.
+unaffected_versions:
+  - "< 2.6"
+patched_versions:
+  - "3.0.3"
+  - "2.7.8"

--- a/libraries/rubygems/CVE-2019-8321.yml
+++ b/libraries/rubygems/CVE-2019-8321.yml
@@ -12,4 +12,4 @@ unaffected_versions:
   - "< 2.6"
 patched_versions:
   - "3.0.3"
-  - "2.7.8"
+  - "2.7.9"

--- a/libraries/rubygems/CVE-2019-8321.yml
+++ b/libraries/rubygems/CVE-2019-8321.yml
@@ -11,5 +11,5 @@ description: |
 unaffected_versions:
   - "< 2.6"
 patched_versions:
-  - "3.0.3"
-  - "2.7.9"
+  - ">= 3.0.3"
+  - "~> 2.7.9"

--- a/libraries/rubygems/CVE-2019-8322.yml
+++ b/libraries/rubygems/CVE-2019-8322.yml
@@ -12,4 +12,4 @@ unaffected_versions:
   - "< 2.6"
 patched_versions:
   - "3.0.3"
-  - "2.7.8"
+  - "2.7.9"

--- a/libraries/rubygems/CVE-2019-8322.yml
+++ b/libraries/rubygems/CVE-2019-8322.yml
@@ -11,5 +11,5 @@ description: |
 unaffected_versions:
   - "< 2.6"
 patched_versions:
-  - "3.0.3"
-  - "2.7.9"
+  - ">= 3.0.3"
+  - "~> 2.7.9"

--- a/libraries/rubygems/CVE-2019-8322.yml
+++ b/libraries/rubygems/CVE-2019-8322.yml
@@ -1,0 +1,15 @@
+---
+library: rubygems
+cve: 2019-8322
+url: https://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html
+title: Escape sequence injection vulnerability in gem owner
+date: 2019-03-05
+description: |
+  An issue was discovered in RubyGems 2.6 and later through 3.0.2. The gem
+  owner command outputs the contents of the API response directly to stdout.
+  Therefore, if the response is crafted, escape sequence injection may occur.
+unaffected_versions:
+  - "< 2.6"
+patched_versions:
+  - "3.0.3"
+  - "2.7.8"

--- a/libraries/rubygems/CVE-2019-8323.yml
+++ b/libraries/rubygems/CVE-2019-8323.yml
@@ -12,5 +12,5 @@ description: |
 unaffected_versions:
   - "< 2.6"
 patched_versions:
-  - "3.0.3"
-  - "2.7.9"
+  - ">= 3.0.3"
+  - "~> 2.7.9"

--- a/libraries/rubygems/CVE-2019-8323.yml
+++ b/libraries/rubygems/CVE-2019-8323.yml
@@ -1,0 +1,16 @@
+---
+library: rubygems
+cve: 2019-8323
+url: https://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html
+title: Escape sequence injection vulnerability in api response handling
+date: 2019-03-05
+description: |
+  An issue was discovered in RubyGems 2.6 and later through 3.0.2.
+  Gem::GemcutterUtilities#with_response may output the API response to stdout
+  as it is. Therefore, if the API side modifies the response, escape sequence
+  injection may occur.
+unaffected_versions:
+  - "< 2.6"
+patched_versions:
+  - "3.0.3"
+  - "2.7.8"

--- a/libraries/rubygems/CVE-2019-8323.yml
+++ b/libraries/rubygems/CVE-2019-8323.yml
@@ -13,4 +13,4 @@ unaffected_versions:
   - "< 2.6"
 patched_versions:
   - "3.0.3"
-  - "2.7.8"
+  - "2.7.9"

--- a/libraries/rubygems/CVE-2019-8324.yml
+++ b/libraries/rubygems/CVE-2019-8324.yml
@@ -1,0 +1,17 @@
+---
+library: rubygems
+cve: 2019-8324
+url: https://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html
+title: Installing a malicious gem may lead to arbitrary code execution
+date: 2019-03-05
+description: |
+  An issue was discovered in RubyGems 2.6 and later through 3.0.2. A crafted
+  gem with a multi-line name is not handled correctly. Therefore, an attacker
+  could inject arbitrary code to the stub line of gemspec, which is eval-ed by
+  code in ensure_loadable_spec during the preinstall check.
+
+unaffected_versions:
+  - "< 2.6"
+patched_versions:
+  - "3.0.3"
+  - "2.7.8"

--- a/libraries/rubygems/CVE-2019-8324.yml
+++ b/libraries/rubygems/CVE-2019-8324.yml
@@ -14,4 +14,4 @@ unaffected_versions:
   - "< 2.6"
 patched_versions:
   - "3.0.3"
-  - "2.7.8"
+  - "2.7.9"

--- a/libraries/rubygems/CVE-2019-8324.yml
+++ b/libraries/rubygems/CVE-2019-8324.yml
@@ -13,5 +13,5 @@ description: |
 unaffected_versions:
   - "< 2.6"
 patched_versions:
-  - "3.0.3"
-  - "2.7.9"
+  - ">= 3.0.3"
+  - "~> 2.7.9"

--- a/libraries/rubygems/CVE-2019-8325.yml
+++ b/libraries/rubygems/CVE-2019-8325.yml
@@ -1,0 +1,15 @@
+---
+library: rubygems
+cve: 2019-8325
+url: https://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html
+title: Escape sequence injection vulnerability in errors
+date: 2019-03-05
+description: |
+  An issue was discovered in RubyGems 2.6 and later through 3.0.2. Since
+  Gem::CommandManager#run calls alert_error without escaping, escape sequence
+  injection is possible. (There are many ways to cause an error.)
+unaffected_versions:
+  - "< 2.6"
+patched_versions:
+  - "3.0.3"
+  - "2.7.8"

--- a/libraries/rubygems/CVE-2019-8325.yml
+++ b/libraries/rubygems/CVE-2019-8325.yml
@@ -12,4 +12,4 @@ unaffected_versions:
   - "< 2.6"
 patched_versions:
   - "3.0.3"
-  - "2.7.8"
+  - "2.7.9"

--- a/libraries/rubygems/CVE-2019-8325.yml
+++ b/libraries/rubygems/CVE-2019-8325.yml
@@ -11,5 +11,5 @@ description: |
 unaffected_versions:
   - "< 2.6"
 patched_versions:
-  - "3.0.3"
-  - "2.7.9"
+  - ">= 3.0.3"
+  - "~> 2.7.9"


### PR DESCRIPTION
Disclosed at https://blog.rubygems.org/2019/03/05/security-advisories-2019-03.html

It seems even though they have CVEs at the post, they are not yet in the mitre db.