### PR TITLE
Add unaffected versions for railties versions <5.2.0 for CVE-2019-5420

### DIFF
--- a/gems/railties/CVE-2019-5420.yml
+++ b/gems/railties/CVE-2019-5420.yml
@@ -41,6 +41,9 @@ description: |
   -------
   Thanks to ooooooo_q
 
+unaffected_versions:
+  - "< 5.2.0"
+
 patched_versions:
   - "~> 5.2.2, >= 5.2.2.1"
   - ">= 6.0.0.beta3"


### PR DESCRIPTION
This adds `unaffected_versions` to prevent CVE-2019-5420 being triggered as a warning for `railties` affected versions `< 5.2.0`.

I upgraded to `5.0.7.2` and seeing this error, which is incorrect according to the CVE:

```
Name: railties
Version: 5.0.7.2
Advisory: CVE-2019-5420
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/rubyonrails-security/IsQKvDqZdKw
Title: Possible Remote Code Execution Exploit in Rails Development Mode
Solution: upgrade to >= 5.2.2.1, ~> 5.2.2, >= 6.0.0.beta3
```

Fixes https://github.com/rubysec/ruby-advisory-db/issues/381