### PR TITLE
update desc of CVE-2019-5420 to indiciate unaffected versions

### DIFF
--- a/gems/railties/CVE-2019-5420.yml
+++ b/gems/railties/CVE-2019-5420.yml
@@ -13,7 +13,7 @@ description: |
   CVE-2019-5420.
 
   Versions Affected:  6.0.0.X, 5.2.X.
-  Not affected:       None.
+  Not affected:       < 5.2.0
   Fixed Versions:     6.0.0.beta3, 5.2.2.1
 
   Impact


### PR DESCRIPTION
https://github.com/rubysec/ruby-advisory-db/pull/382 set the `unaffected_versions` for this CVE to `["< 5.2.0"]`. This PR just updates the `description` to match that.