### PR TITLE
Add CVE-2019-10842 - remote code execution in bootstrap-sass

### DIFF
--- a/gems/bootstrap-sass/CVE-2019-10842.yml
+++ b/gems/bootstrap-sass/CVE-2019-10842.yml
@@ -5,12 +5,19 @@ url: https://github.com/twbs/bootstrap-sass/issues/1195
 title: Remote code execution in bootstrap-sass
 date: 2019-04-04
 
-description: >-
-  bootstrap-sass is a Sass-powered version of Bootstrap 3, ready to drop right
-  into your Sass powered applications. Affected versions of this package are
-  malicious. The file `lib/active-controller/middleware.rb` contains a backdoor
-  which will enable a remote attacker to run arbitrary code on the server by
-  decoding a specific cookie value and evaluating its content.
+description: |
+  Arbitrary code execution (via backdoor code, when 
+  downloaded from rubygems.org) was discovered in 
+  bootstrap-sass 3.2.0.3.
+  
+  Users are advised to upgrade immediately to 3.2.0.4
+  
+  An unauthenticated attacker can craft the ___cfduid cookie value
+  with base64 arbitrary code to be executed via eval(), which can
+  be leveraged to execute arbitrary code on the target system. 
+  (Note that there are three underscore characters in the cookie name. 
+  This is unrelated to the __cfduid cookie that is legitimately used by 
+  Cloudflare.)
 
 unaffected_versions:
   - "<= 3.2.0.2"

--- a/gems/bootstrap-sass/CVE-2019-10842.yml
+++ b/gems/bootstrap-sass/CVE-2019-10842.yml
@@ -1,0 +1,18 @@
+---
+gem: bootstrap-sass
+cve: 2019-10842
+url: https://github.com/twbs/bootstrap-sass/issues/1195
+title: Remote code execution in bootstrap-sass
+date: 2019-04-04
+
+description: >-
+  bootstrap-sass is a Sass-powered version of Bootstrap 3, ready to drop right
+  into your Sass powered applications. Affected versions of this package are
+  malicious. The file `lib/active-controller/middleware.rb` contains a backdoor
+  which will enable a remote attacker to run arbitrary code on the server by
+  decoding a specific cookie value and evaluating its content.
+
+unaffected_versions:
+  - "<= 3.2.0.2"
+patched_versions:
+  - ">= 3.2.0.4"


### PR DESCRIPTION
* Closes issue #385.
* CVE number taken from https://github.com/twbs/bootstrap-sass/issues/1195#issuecomment-479616107
* More context on the issue: https://snyk.io/blog/malicious-remote-code-execution-backdoor-discovered-in-the-popular-bootstrap-sass-ruby-gem/
