### PR TITLE
Add nokogiri CVE-2019-11068

### DIFF
--- a/gems/nokogiri/CVE-2019-11068.yml
+++ b/gems/nokogiri/CVE-2019-11068.yml
@@ -1,7 +1,7 @@
 ---
 gem: nokogiri
 cve: 2019-11068
-date: 2019-04-22
+date: 2019-04-10
 url: https://github.com/sparklemotion/nokogiri/pull/1898
 title: Backport libxslt patch
 description: |

--- a/gems/nokogiri/CVE-2019-11068.yml
+++ b/gems/nokogiri/CVE-2019-11068.yml
@@ -1,0 +1,18 @@
+---
+gem: nokogiri
+cve: 2019-11068
+date: 2019-04-22
+url: https://github.com/sparklemotion/nokogiri/pull/1898
+title: Backport libxslt patch
+description: |
+  libxslt through 1.1.33 allows bypass of a protection mechanism because callers
+  of xsltCheckRead and xsltCheckWrite permit access even upon receiving a -1
+  error code. xsltCheckRead can return -1 for a crafted URL that is not actually
+  invalid and is subsequently loaded.
+patched_versions:
+  - ">= 1.10.3"
+related:
+  url:
+    - https://usn.ubuntu.com/3947-1/
+    - https://usn.ubuntu.com/3947-2/
+    - https://github.com/sparklemotion/nokogiri/issues/1892


### PR DESCRIPTION
A version 1.10.3 of Nokogiri has just been released that fixes two related problems documented in CVE-2019-11068.