### PR TITLE
Add CVE-2015-9284 for OmniAuth

### DIFF
--- a/gems/omniauth/CVE-2015-9284.yml
+++ b/gems/omniauth/CVE-2015-9284.yml
@@ -1,0 +1,19 @@
+---
+gem: omniauth
+cve: 2015-9284
+url: https://github.com/omniauth/omniauth/pull/809
+title: Cross-site request forgery (CSRF) vulnerability in OmniAuth's request phase
+date: 2015-05-25
+
+description: |
+  The request phase in OmniAuth is currently vulnerable to Cross-Site Request
+  Forgery, which allows an attacker to easily gain full access to a user's
+  account on a site that uses OmniAuth, when used in combination with another
+  CSRF vulnerability on the side of a connected OAuth provider.
+
+cvss_v2: 6.8
+cvss_v3: 8.8
+
+related:
+  url:
+    - https://github.com/cookpad/omniauth-rails_csrf_protection

--- a/gems/omniauth/CVE-2015-9284.yml
+++ b/gems/omniauth/CVE-2015-9284.yml
@@ -2,14 +2,20 @@
 gem: omniauth
 cve: 2015-9284
 url: https://github.com/omniauth/omniauth/pull/809
-title: Cross-site request forgery (CSRF) vulnerability in OmniAuth's request phase
+title: CSRF vulnerability in OmniAuth's request phase
 date: 2015-05-25
 
 description: |
-  The request phase in OmniAuth is currently vulnerable to Cross-Site Request
-  Forgery, which allows an attacker to easily gain full access to a user's
-  account on a site that uses OmniAuth, when used in combination with another
-  CSRF vulnerability on the side of a connected OAuth provider.
+  The request phase of the OmniAuth Ruby gem is vulnerable to Cross-Site
+  Request Forgery (CSRF) when used as part of the Ruby on Rails framework, allowing
+  accounts to be connected without user intent, user interaction, or feedback to
+  the user. This permits a secondary account to be able to sign into the web
+  application as the primary account.
+  
+  In order to mitigate this vulnerability, Rails users should consider using the
+  `omniauth-rails_csrf_protection` gem.
+  
+  More info is available here: https://github.com/omniauth/omniauth/pull/809#issuecomment-502079405
 
 cvss_v2: 6.8
 cvss_v3: 8.8


### PR DESCRIPTION
For a CSRF vulnerability in OmniAuth: https://github.com/omniauth/omniauth/pull/809

There's currently no patched version of OmniAuth to address this vulnerability, but there is an additional [omniauth-rails_csrf_protection gem](https://github.com/cookpad/omniauth-rails_csrf_protection) that patches the vulnerability if OmniAuth is being used with Rails. So I added a related link to this gem, but I'm open to suggestions for other ways to clarify this. See https://github.com/omniauth/omniauth/pull/809#issuecomment-497376674 and https://github.com/omniauth/omniauth/pull/809#issuecomment-497462504 for context on this separate gem and why it's only applicable to Rails usage.