### PR TITLE
Add CVE-2019-9837 for doorkeeper-openid_connect

### DIFF
--- a/gems/doorkeeper-openid_connect/CVE-2019-9837.yml
+++ b/gems/doorkeeper-openid_connect/CVE-2019-9837.yml
@@ -1,0 +1,16 @@
+---
+gem: doorkeeper-openid_connect
+cve: 2019-9837
+date: 2019-03-25
+url: https://nvd.nist.gov/vuln/detail/CVE-2019-9837
+title: Moderate severity vulnerability that affects doorkeeper-openid_connect
+description: Doorkeeper::OpenidConnect (aka the OpenID Connect extension for Doorkeeper)
+  1.4.x and 1.5.x before 1.5.4 has an open redirect via the redirect_uri field in
+  an OAuth authorization request (that results in an error response) with the 'openid'
+  scope and a prompt=none value. This allows phishing attacks against the authorization
+  flow.
+cvss_v3: 6.1
+patched_versions:
+  - ">= 1.5.4"
+unaffected_versions:
+  - "< 1.4.0"

--- a/gems/doorkeeper-openid_connect/CVE-2019-9837.yml
+++ b/gems/doorkeeper-openid_connect/CVE-2019-9837.yml
@@ -2,8 +2,8 @@
 gem: doorkeeper-openid_connect
 cve: 2019-9837
 date: 2019-03-25
-url: https://nvd.nist.gov/vuln/detail/CVE-2019-9837
-title: Moderate severity vulnerability that affects doorkeeper-openid_connect
+url: https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/master/CHANGELOG.md#v154-2019-02-15
+title: Doorkeeper::OpenidConnect Open Redirect
 description: Doorkeeper::OpenidConnect (aka the OpenID Connect extension for Doorkeeper)
   1.4.x and 1.5.x before 1.5.4 has an open redirect via the redirect_uri field in
   an OAuth authorization request (that results in an error response) with the 'openid'


### PR DESCRIPTION
This adds https://nvd.nist.gov/vuln/detail/CVE-2019-9837 into the DB.

Some additional relevant references for this vulnerability:
- https://github.com/doorkeeper-gem/doorkeeper-openid_connect/blob/master/CHANGELOG.md#v154-2019-02-15
- https://github.com/doorkeeper-gem/doorkeeper-openid_connect/issues/61
- https://github.com/doorkeeper-gem/doorkeeper-openid_connect/pull/66

This advisory was made using the GitHub Advisory sync sync script for ruby-advisory-db.  This script is currently in a [draft PR](https://github.com/rubysec/ruby-advisory-db/pull/392).  This is an initial test of the sync script.
