### PR TITLE
add CVE-2018-17567 on jekyll

### DIFF
--- a/gems/jekyll/CVE-2018-17567.yml
+++ b/gems/jekyll/CVE-2018-17567.yml
@@ -1,7 +1,7 @@
 ---
 gem: jekyll
 cve: 2018-17567
-date: '2018-09-28T19:29:07Z'
+date: 2018-09-28
 url: https://nvd.nist.gov/vuln/detail/CVE-2018-17567
 title: Moderate severity vulnerability that affects jekyll
 description: Jekyll through 3.6.2, 3.7.x through 3.7.3, and 3.8.x through 3.8.3 allows

--- a/gems/jekyll/CVE-2018-17567.yml
+++ b/gems/jekyll/CVE-2018-17567.yml
@@ -2,8 +2,8 @@
 gem: jekyll
 cve: 2018-17567
 date: 2018-09-28
-url: https://nvd.nist.gov/vuln/detail/CVE-2018-17567
-title: Moderate severity vulnerability that affects jekyll
+url: https://jekyllrb.com/news/2018/09/19/security-fixes-for-3-6-3-7-3-8/
+title: Jekyll _config.yml privilege escalation
 description: Jekyll through 3.6.2, 3.7.x through 3.7.3, and 3.8.x through 3.8.3 allows
   attackers to access arbitrary files by specifying a symlink in the "include" key
   in the "_config.yml" file.

--- a/gems/jekyll/CVE-2018-17567.yml
+++ b/gems/jekyll/CVE-2018-17567.yml
@@ -1,0 +1,14 @@
+---
+gem: jekyll
+cve: 2018-17567
+date: '2018-09-28T19:29:07Z'
+url: https://nvd.nist.gov/vuln/detail/CVE-2018-17567
+title: Moderate severity vulnerability that affects jekyll
+description: Jekyll through 3.6.2, 3.7.x through 3.7.3, and 3.8.x through 3.8.3 allows
+  attackers to access arbitrary files by specifying a symlink in the "include" key
+  in the "_config.yml" file.
+cvss_v3: 7.5
+patched_versions:
+- "~> 3.6.3"
+- "~> 3.7.4"
+- ">= 3.8.4"


### PR DESCRIPTION
This adds an important CVE on jekyll:
- https://nvd.nist.gov/vuln/detail/CVE-2018-17567
- https://jekyllrb.com/news/2018/09/19/security-fixes-for-3-6-3-7-3-8/
- https://github.com/jekyll/jekyll/pull/7224

This advisory was made using the GitHub Advisory sync sync script for ruby-advisory-db.  This script is currently in a [draft PR](https://github.com/rubysec/ruby-advisory-db/pull/392).  This is an initial test of the sync script.