### PR TITLE
Add first GitHub Security Advisory on yard: GHSA-xfhh-rx56-rxcr

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Each advisory file contains the advisory information in [YAML] format:
 * `framework` \[String\] (optional): Name of the framework which the affected
   gem belongs to.
 * `platform` \[String\] (optional): If this vulnerability is platform-specific, name of platform this vulnerability affects (e.g. jruby)
-* `cve` \[String\]: CVE id.
-* `osvdb` \[Integer\]: OSVDB id.
-* `ghsa` \[String\]: GitHub Security Advisory ID.
+* `cve` \[String\]: Common Vulnerabilities and Exposures (CVE) ID.
+* `osvdb` \[Integer\]: Open Sourced Vulnerability Database (OSVDB) ID.
+* `ghsa` \[String\]: GitHub Security Advisory (GHSA) ID.
 * `url` \[String\]: The URL to the full advisory.
 * `title` \[String\]: The title of the advisory or individual vulnerability.
 * `date` \[Date\]: The public disclosure date of the advisory.
@@ -93,7 +93,7 @@ but are not already in this dataset.  This script can be periodically run to ens
 this repo has all the data that is present in the GitHub Advisory data.
 
 The GitHub Advisory API requires a token to access it.
-- It can be a completely scopeless token (recommended), it does not require any permissions at all.
+- It can be a completely scopeless token (recommended); it does not require any permissions at all.
 - Get yours at https://github.com/settings/tokens
 
 To run the GitHub Advisory sync, start by executing the rake task:
@@ -109,7 +109,7 @@ GH_API_TOKEN=<your GitHub API Token> bundle exec rake sync_github_advisories
   - delete the GitHub data at the bottom of the yaml file
   - double check all the data, commit it, and make a PR
     - *The GitHub Advisory data is structured opposite of RubySec unfortunately:
-       GitHub identifies version range which are vulnerable, RubySec identifies
+       GitHub identifies version range which are vulnerable; RubySec identifies
       version ranges which are not vulnerable.  This is why some manual
       work to translate is needed.*
 
@@ -118,12 +118,13 @@ GH_API_TOKEN=<your GitHub API Token> bundle exec rake sync_github_advisories
 
 Please see [CONTRIBUTORS.md].
 
-This database also includes data from the [Open Source Vulnerability Database][OSVDB]
+This database also includes data from the [Open Sourced Vulnerability Database][OSVDB]
 developed by the Open Security Foundation (OSF) and its contributors.
 
 [rubygems.org]: https://rubygems.org/
-[CVE]: http://cve.mitre.org/
+[CVE]: https://cve.mitre.org/
 [OSVDB]: http://www.osvdb.org/
+[GHSA]: https://help.github.com/en/articles/about-maintainer-security-advisories
 [CVSSv2]: https://www.first.org/cvss/v2/guide
 [CVSSv3]: https://www.first.org/cvss/user-guide
 [YAML]: http://www.yaml.org/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Each advisory file contains the advisory information in [YAML] format:
 * `platform` \[String\] (optional): If this vulnerability is platform-specific, name of platform this vulnerability affects (e.g. jruby)
 * `cve` \[String\]: CVE id.
 * `osvdb` \[Integer\]: OSVDB id.
+* `ghsa` \[String\]: GitHub Security Advisory ID.
 * `url` \[String\]: The URL to the full advisory.
 * `title` \[String\]: The title of the advisory or individual vulnerability.
 * `date` \[Date\]: The public disclosure date of the advisory.

--- a/gems/yard/GHSA-xfhh-rx56-rxcr.yml
+++ b/gems/yard/GHSA-xfhh-rx56-rxcr.yml
@@ -1,7 +1,7 @@
 ---
 gem: yard
+ghsa: xfhh-rx56-rxcr
 date: 2019-07-02
-ghsa: GHSA-xfhh-rx56-rxcr
 url: https://github.com/lsegal/yard/security/advisories/GHSA-xfhh-rx56-rxcr
 title: Possible arbitrary path traversal and file access via `yard server`
 description: A path traversal vulnerability was discovered in YARD <= 0.9.19 when

--- a/gems/yard/GHSA-xfhh-rx56-rxcr.yml
+++ b/gems/yard/GHSA-xfhh-rx56-rxcr.yml
@@ -1,0 +1,12 @@
+---
+gem: yard
+date: 2019-07-02
+ghsa: GHSA-xfhh-rx56-rxcr
+url: https://github.com/lsegal/yard/security/advisories/GHSA-xfhh-rx56-rxcr
+title: Possible arbitrary path traversal and file access via `yard server`
+description: A path traversal vulnerability was discovered in YARD <= 0.9.19 when
+  using `yard server` to serve documentation. This bug would allow unsanitized HTTP
+  requests to access arbitrary files on the machine of a yard server host under certain
+  conditions.
+patched_versions:
+- ">= 0.9.20"

--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -18,10 +18,16 @@ shared_examples_for 'Advisory' do |path|
         filename.gsub('OSVDB-','')
       end
     end
+    
+    let(:filename_ghsa) do
+      if filename.start_with?('GHSA-')
+        filename.gsub('GHSA-','')
+      end
+    end
 
     it "should be correctly named CVE-XXX or OSVDB-XXX or GHSA-XXX" do
       expect(filename).
-        to match(/^(CVE-\d{4}-(0\d{3}|[1-9]\d{3,})|OSVDB-\d+|GHSA(-\w{4}){3})\.yml$/)
+        to match(/^(CVE-\d{4}-(0\d{3}|[1-9]\d{3,})|OSVDB-\d+|GHSA(-[a-z0-9]{4}){3})\.yml$/)
     end
 
     it "should have CVE or OSVDB or GHSA" do
@@ -67,6 +73,19 @@ shared_examples_for 'Advisory' do |path|
        it "should be id in filename if filename is OSVDB-XXX" do
         if filename_osvdb
           is_expected.to eq(filename_osvdb.to_i)
+        end
+      end
+    end
+    
+    describe "ghsa" do
+      subject { advisory['ghsa'] }
+
+      it "may be nil or a String" do
+        expect(subject).to be_kind_of(String).or(be_nil)
+      end
+      it "should be id in filename if filename is GHSA-XXX" do
+        if filename_ghsa
+          is_expected.to eq(filename_ghsa.chomp('.yml'))
         end
       end
     end
@@ -192,8 +211,8 @@ shared_examples_for 'Advisory' do |path|
       when Hash
         advisory["related"].each_pair do |name, values|
           describe name do
-            it "should be either a cve, an osvdb or a url" do
-              expect(["cve", "osvdb", "url"]).to include(name)
+            it "should be either a cve, an osvdb, a ghsa, or a url" do
+              expect(["cve", "osvdb", "ghsa", "url"]).to include(name)
             end
 
             it "should always contain an array" do

--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -19,13 +19,13 @@ shared_examples_for 'Advisory' do |path|
       end
     end
 
-    it "should be correctly named CVE-XXX or OSVDB-XXX" do
+    it "should be correctly named CVE-XXX or OSVDB-XXX or GHSA-XXX" do
       expect(filename).
-        to match(/^(CVE-\d{4}-(0\d{3}|[1-9]\d{3,})|OSVDB-\d+)\.yml$/)
+        to match(/^(CVE-\d{4}-(0\d{3}|[1-9]\d{3,})|OSVDB-\d+|GHSA(-\w{4}){3})\.yml$/)
     end
 
-    it "should have CVE or OSVDB" do
-      expect(advisory['cve'] || advisory['osvdb']).not_to be_nil
+    it "should have CVE or OSVDB or GHSA" do
+      expect(advisory['cve'] || advisory['osvdb'] || advisory['ghsa']).not_to be_nil
     end
 
     describe "framework" do


### PR DESCRIPTION
This PR is the first add of a GitHub Security Advisory to this dataset.

The advisory is this one, on `yard`, which has been fixed in latest `0.9.20` version: https://github.com/lsegal/yard/security/advisories/GHSA-xfhh-rx56-rxcr

Since this advisory does not have a CVE, only a "GHSA ID", some small changes to the validation tests were needed in order to allow advisory records to have a ghsa field but no cve/osvdb.  Also, a small tweak to the README is included so ghsa is now a field in the advisory "schema".

This PR was partially made by the GitHub sync script, which itself required some changes to work with non-CVE advisories, and those are in a separate PR: https://github.com/rubysec/ruby-advisory-db/pull/396

