### PR TITLE
Add CVE-2019-13574 on mini_magick

### DIFF
--- a/gems/mini_magick/CVE-2019-13574.yml
+++ b/gems/mini_magick/CVE-2019-13574.yml
@@ -1,0 +1,10 @@
+gem: mini_magick
+cve: 2019-13574
+url: https://github.com/minimagick/minimagick/releases/tag/v4.9.4
+title: Remote command execution via filename
+date: 2019-07-12
+description: |
+  A remote shell execution vulnerability when using MiniMagick::Image.open with URL coming from unsanitized user input.
+  e.g. `MiniMagick::Image.open("| touch.txt")`
+patched_versions:
+  - ">= 4.9.4"


### PR DESCRIPTION
This adds an important CVE on mini_magick

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13574
- https://github.com/minimagick/minimagick/releases/tag/v4.9.4

