### PR TITLE
Add CVE-2019-15224 for rest-client.

### DIFF
--- a/gems/rest-client/CVE-2019-15224.yml
+++ b/gems/rest-client/CVE-2019-15224.yml
@@ -1,0 +1,13 @@
+---
+gem: rest-client
+cve: 2019-15224
+url: https://github.com/rest-client/rest-client/issues/713
+date: 2019-08-19
+title: Code execution backdoor in rest-client
+description: |
+  The rest-client gem 1.6.13 for Ruby, as distributed on RubyGems.org,
+  included a code-execution backdoor inserted by a third party.
+
+unaffected_versions:
+  - "<= 1.6.9"
+  - ">= 1.7.0.rc1"


### PR DESCRIPTION
I added rest-client/CVE-2019-15224.yml. Only 1.6.13 was written in https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15224.
 but yanked version in 
https://rubygems.org/gems/rest-client/versions is below.

> 1.6.13 - August 14, 2019 (114KB) yanked
> 1.6.12 - August 14, 2019 (113KB) yanked
> 1.6.11 - August 14, 2019 (113KB) yanked
> 1.6.10 - August 13, 2019 (11.5KB) yanked

So I was set unaffected version to ...1.6.9 and 1.7.0.rc1... .
If 1.6.10 - 1.6.12 was not affected, I will change unaffected version.

see. https://github.com/rest-client/rest-client/issues/713
