### PR TITLE
Adds additional backdoored gems.

### DIFF
--- a/gems/awesome-bot/CVE-2019-15224.yml
+++ b/gems/awesome-bot/CVE-2019-15224.yml
@@ -1,0 +1,16 @@
+---
+gem: awesome-bot
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems/rubygems.org/issues/2097
+date: 2019-08-20
+title: Code execution backdoor in awesome-bot
+description: |-
+  The awesome-bot gem 1.18.0 for Ruby, as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  Users of an affected version should consider downgrading to the last non-affected version of 1.17.2, or upgrading to 1.19.x."
+unaffected_versions:
+  - "< 1.18.0"
+  - "> 1.18.0"
+related:
+  url: 
+    - https://github.com/rubygems/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019

--- a/gems/bitcoin_vanity/CVE-2019-15224.yml
+++ b/gems/bitcoin_vanity/CVE-2019-15224.yml
@@ -1,0 +1,16 @@
+---
+gem: bitcoin_vanity
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019
+date: 2019-08-20
+title: Code execution backdoor in bitcoin_vanity
+description: |-
+  The bitcoin_vanity gem 4.3.3 for Ruby, as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  No unaffected version is known to exist, as the gem appears to have been entirely removed.
+unaffected_versions:
+  - "< 4.3.3"
+  - "> 4.3.3"
+related:
+  url:
+  - https://github.com/rubygems/rubygems.org/issues/2097

--- a/gems/blockchain_wallet/CVE-2019-15224.yml
+++ b/gems/blockchain_wallet/CVE-2019-15224.yml
@@ -1,0 +1,16 @@
+---
+gem: blockchain_wallet
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems.org/issues/2097
+date: 2019-08-20
+title: Code execution backdoor in blockchain_wallet
+description: |-
+  The blockchain_wallet gem 0.0.6 through 0.0.7 for Ruby, as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  Users of an affected version should consider downgrading to the last non-affected version of 0.0.5.
+unaffected_versions:
+  - "< 0.0.6"
+  - "> 0.0.7"
+related:
+  url: 
+  - https://github.com/rubygems/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019

--- a/gems/capistrano-colors/CVE-2019-15224.yml
+++ b/gems/capistrano-colors/CVE-2019-15224.yml
@@ -1,0 +1,16 @@
+---
+gem: capistrano-colors
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems.org/issues/2097
+date: 2019-08-20
+title: Code execution backdoor in capistrano-colors
+description: |-
+  The capistrano-colors 0.5.5 gem for Ruby, as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  Users of an affected version should consider downgrading to the last non-affected version of 0.5.4.
+unaffected_versions:
+  - "< 0.5.5"
+  - "> 0.5.5"
+related:
+  url: 
+  - https://github.com/rubygems/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019

--- a/gems/coin_base/CVE-2019-15224.yml
+++ b/gems/coin_base/CVE-2019-15224.yml
@@ -1,0 +1,16 @@
+---
+gem: coin_base
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems.org/issues/2097
+date: 2019-08-20
+title: Code execution backdoor in coin_base
+description: |-
+  The coin_base gem 4.2.1 through 4.2.2 for Ruby, as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  No unaffected version is known to exist, as the gem appears to have been entirely removed.
+unaffected_versions:
+- "< 4.2.1"
+- "> 4.2.2"
+related:
+  url: 
+  - https://github.com/rubygems/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019

--- a/gems/coming-soon/CVE-2019-15224.yml
+++ b/gems/coming-soon/CVE-2019-15224.yml
@@ -1,0 +1,16 @@
+---
+gem: coming-soon
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems.org/issues/2097
+date: 2019-08-20
+title: Code execution backdoor in coming-soon
+description: |-
+  The coming-soon gem 0.2.8 for Ruby, as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  No unaffected version is known to exist, as the gem appears to have been entirely removed.
+unaffected_versions:
+  - "< 0.2.8"
+  - "> 0.2.8"
+related:
+  url: 
+    - https://github.com/rubygems/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019

--- a/gems/cron_parser/CVE-2019-15224.yml
+++ b/gems/cron_parser/CVE-2019-15224.yml
@@ -1,0 +1,18 @@
+---
+gem: cron_parser
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems.org/issues/2097
+date: 2019-08-20
+title: Code execution backdoor in cron_parser
+description: |-
+  The cron_parser gem 0.1.4, 1.0.12, and 1.0.13 as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  No unaffected version is known to exist, as the gem appears to have been entirely removed.
+unaffected_versions:
+  - "< 1.0.12"
+  - "> 1.0.13"
+  - "< 0.1.4"
+  - "> 0.1.4"
+related:
+  url: 
+    - https://github.com/rubygems/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019

--- a/gems/datagrid/CVE-2019-14281.yml
+++ b/gems/datagrid/CVE-2019-14281.yml
@@ -1,0 +1,13 @@
+---
+gem: datagrid
+cve: 2019-14281
+ghsa: rqp5-pg7w-832p
+url: https://nvd.nist.gov/vuln/detail/CVE-2019-14281
+date: 2019-07-31
+title: Critical severity vulnerability that affects datagrid
+description: The datagrid gem 1.0.6 for Ruby, as distributed on RubyGems.org, included
+  a code-execution backdoor inserted by a third party.
+cvss_v3: 9.8
+unaffected_versions:
+  - "<= 1.0.6"
+  - "> 1.0.6"

--- a/gems/doge-coin/CVE-2019-15224.yml
+++ b/gems/doge-coin/CVE-2019-15224.yml
@@ -1,0 +1,17 @@
+---
+gem: doge-coin
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems.org/issues/2097
+date: 2019-08-20
+title: Code execution backdoor in doge-coin
+description: |-
+  The doge-coin gem 1.0.2 for Ruby, as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  Users of an affected version should consider downgrading to the last non-affected version of 1.0.1.
+unaffected_versions:
+  - "< 1.0.2"
+  - "> 1.0.2"
+related:
+  url: 
+  - https://github.com/rubygems/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019
+  - https://github.com/rubygems.org/issues/2097

--- a/gems/lita_coin/CVE-2019-15224.yml
+++ b/gems/lita_coin/CVE-2019-15224.yml
@@ -1,0 +1,16 @@
+---
+gem: lita_coin
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems.org/issues/2097
+date: 2019-08-20
+title: Code execution backdoor in lita_coin
+description: |-
+  The lita_coin gem 0.0.3 for Ruby, as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  No unaffected version is known to exist, as the gem appears to have been entirely removed.
+unaffected_versions:
+  - "< 0.0.3"
+  - "> 0.0.3"
+related:
+  url: 
+    - https://github.com/rubygems/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019

--- a/gems/marginalia/CVE-2019-1010191.yml
+++ b/gems/marginalia/CVE-2019-1010191.yml
@@ -1,0 +1,15 @@
+---
+gem: marginalia
+cve: 2019-1010191
+cvss_v3: 9.8
+url: https://github.com/basecamp/marginalia/pull/73/
+date: 2019-07-26
+title: Critical severity vulnerability that affects marginalia
+description: | 
+  The 'marginalia' gem is affected by a SQL Injection vulnerability. All SQL 
+  queries are affected when a user controller argument is added as a component.
+  This affects users that add a component that is user controller, for instance
+  a parameter or a header. The issue is resolved in version 1.6.
+patched_versions:
+  - ">= 1.6"
+

--- a/gems/omniauth_amazon/CVE-2019-15224.yml
+++ b/gems/omniauth_amazon/CVE-2019-15224.yml
@@ -1,0 +1,16 @@
+---
+gem: omniauth_amazon
+cve: 2019-15224
+ghsa: 333g-rpr4-7hxq
+url: https://github.com/rubygems.org/issues/2097
+date: 2019-08-20
+title: Code execution backdoor in omniauth_amazon
+description: |-
+  The omniauth_amazon gem 1.0.1 for Ruby, as distributed on RubyGems.org, included a code-execution backdoor inserted by a third party.
+  Users of an affected version should consider downgrading to the last non-affected version of 1.0.1.
+unaffected_versions:
+  - "< 1.0.1"
+  - "> 1.0.1"
+related:
+  url: 
+    - https://github.com/rubygems/rubygems.org/wiki/Gems-yanked-and-accounts-locked#19-aug-2019

--- a/gems/paranoid2/CVE-2019-13589.yml
+++ b/gems/paranoid2/CVE-2019-13589.yml
@@ -1,0 +1,15 @@
+---
+gem: paranoid2
+cve: 2019-13589
+ghsa: GHSA-4g4c-8gqh-m4vm
+url: https://github.com/rubygems/rubygems.org/issues/2051
+date: 2019-07-16
+title: Critical severity vulnerability that affects paranoid2
+description: The paranoid2 gem 1.1.6 for Ruby, as distributed on RubyGems.org, included
+  a code-execution backdoor inserted by a third party. The current version, without
+  this backdoor, is 1.1.5.
+cvss_v3: 9.8
+patched_versions:
+- "> 1.1.6"
+unaffected_versions:
+- "<= 1.1.5"

--- a/gems/simple_captcha2/CVE-2019-14282.yml
+++ b/gems/simple_captcha2/CVE-2019-14282.yml
@@ -1,0 +1,13 @@
+---
+gem: simple_captcha2
+cve: 2019-14282
+cvss_v3: 9.8
+url: https://github.com/rubygems/rubygems.org/issues/2073
+date: 2019-07-31
+title: Critical severity vulnerability that affects simple_captcha2
+description: |
+  The simple_captcha2 gem 0.2.3 for Ruby, as distributed on RubyGems.org,
+  included a code-execution backdoor inserted by a third party.
+unaffected_versions:
+  - "< 0.2.3"
+  - "> 0.2.3"

--- a/gems/slanger/CVE-2019-1010306.yml
+++ b/gems/slanger/CVE-2019-1010306.yml
@@ -1,0 +1,14 @@
+---
+gem: slanger
+cve: 2019-1010306
+ghsa: rg32-m3hf-772v
+cvss_v3: 9.8
+url: https://github.com/stevegraham/slanger/pull/238
+date: 2019-07-16
+title: Critical severity vulnerability that affects slanger
+description: |
+  Slanger 0.6.0 is affected by: Remote Code Execution (RCE). 
+  A remote attacker can execute arbitrary commands by sending a crafted request to the server. 
+  The issue is resolved in versions after commit 5267b455caeb2e055cccf0d2b6a22727c111f5c3.
+patched_versions:
+  - ">= 0.6.1"

--- a/gems/yard/CVE-2019-1020001.yml
+++ b/gems/yard/CVE-2019-1020001.yml
@@ -1,0 +1,16 @@
+---
+gem: yard
+cve: 2019-1020001
+cvss_v3: 7.3
+url: https://github.com/lsegal/yard/security/advisories/GHSA-
+ghsa: xfhh-rx56-rxcr
+date: 2019-07-02
+title: Moderate severity vulnerability that affects yard
+description: | 
+  Possible arbitrary path traversal and file access via `yard server`
+  A path traversal vulnerability was discovered in YARD <= 0.9.19 when using 
+  `yard server` to serve documentation. This bug would allow unsanitized HTTP
+  requests to access arbitrary files on the machine of a yard server host under
+  certain conditions. The issue is resolved in v0.9.20 and later.
+patched_versions:
+  - ">= 0.9.20"


### PR DESCRIPTION
This PR adds additional gems affected by CVE-2019-15224 following GHSA's lead by including them under a single CVE and GHSA ID.

I've also included updates for all CVE-2019-* advisories added to GHSA since last sync.

There's a few more (older) GHSA vulns to be sync'd over yet..
