### PR TITLE
Update CVSS score for CVE-2019-5477  nokogiri

### DIFF
--- a/gems/nokogiri/CVE-2019-5477.yml
+++ b/gems/nokogiri/CVE-2019-5477.yml
@@ -22,6 +22,9 @@ description: |
 patched_versions:
   - ">= 1.10.4"
 
+cvss_v2: 7.5
+cvss_v3: 9.8
+
 related:
   url:
     - https://github.com/tenderlove/rexical/commit/a652474dbc66be350055db3e8f9b3a7b3fd75926

--- a/gems/rexical/CVE-2019-5477.yml
+++ b/gems/rexical/CVE-2019-5477.yml
@@ -12,6 +12,9 @@ description: |
 patched_versions:
   - ">= 1.0.7"
 
+cvss_v2: 7.5
+cvss_v3: 9.8
+
 related:
   url:
     - https://github.com/tenderlove/rexical/blob/master/CHANGELOG.rdoc#107--2019-08-06


### PR DESCRIPTION
Source: https://nvd.nist.gov/vuln/detail/CVE-2019-5477