### PR TITLE
Add CVE-2019-16060 for airbrake-ruby

### DIFF
--- a/gems/airbrake-ruby/CVE-2019-16060.yml
+++ b/gems/airbrake-ruby/CVE-2019-16060.yml
@@ -1,0 +1,17 @@
+---
+gem: airbrake-ruby
+cve: 2019-16060
+date: 2019-04-10
+url: https://github.com/airbrake/airbrake-ruby/issues/468
+title: Blacklist keys are no longer being filtered in airbrake-ruby
+description: A flaw in airbrake-ruby v4.2.3 prevented user data from being filtered
+  prior to sending to Airbrake. Such data could be user passwords. Therefore, an app
+  could leak user passwords without knowing it.
+unaffected_versions:
+- "<= 4.2.2"
+- ">= 4.2.4"
+patched_versions:
+- "<= 4.2.2"
+- ">= 4.2.4"
+related_links:
+- https://github.com/airbrake/airbrake-ruby/pull/469

--- a/gems/airbrake-ruby/CVE-2019-16060.yml
+++ b/gems/airbrake-ruby/CVE-2019-16060.yml
@@ -4,14 +4,15 @@ cve: 2019-16060
 date: 2019-04-10
 url: https://github.com/airbrake/airbrake-ruby/issues/468
 title: Blacklist keys are no longer being filtered in airbrake-ruby
-description: A flaw in airbrake-ruby v4.2.3 prevented user data from being filtered
+description: |
+  A flaw in airbrake-ruby v4.2.3 prevented user data from being filtered
   prior to sending to Airbrake. Such data could be user passwords. Therefore, an app
   could leak user passwords without knowing it.
 unaffected_versions:
-- "<= 4.2.2"
-- ">= 4.2.4"
+  - "< 4.2.3"
+  - "> 4.2.3"
 patched_versions:
-- "<= 4.2.2"
-- ">= 4.2.4"
-related_links:
-- https://github.com/airbrake/airbrake-ruby/pull/469
+  - ">= 4.2.4"
+related:
+  url:
+    - https://github.com/airbrake/airbrake-ruby/pull/469


### PR DESCRIPTION
For https://github.com/airbrake/airbrake-ruby/issues/468.
There's also an issue in https://github.com/rubysec/bundler-audit/issues/221 that is directly related to this PR.

Sorry, I'm not sure how to obtain a CVE. Any assistance is appreciated.