### PR TITLE
Add CVE-2019-15845, CVE-2019-16201, CVE-2019-16254, CVE-2019-16255

### DIFF
--- a/rubies/ruby/CVE-2019-15845.yml
+++ b/rubies/ruby/CVE-2019-15845.yml
@@ -11,8 +11,6 @@ description: |
   NUL byte. Therefore, a script that uses an external input as the pattern
   argument, an attacker can make it wrongly match a pathname that is the second
   parameter.
-
-  All users running any affected releases should upgrade as soon as possible.
 patched_versions:
   - "~> 2.4.8"
   - "~> 2.5.7"

--- a/rubies/ruby/CVE-2019-15845.yml
+++ b/rubies/ruby/CVE-2019-15845.yml
@@ -1,0 +1,20 @@
+---
+engine: ruby
+cve: 2019-15845
+url: https://www.ruby-lang.org/en/news/2019/10/01/nul-injection-file-fnmatch-cve-2019-15845/
+title: A NUL injection vulnerability of File.fnmatch and File.fnmatch?
+date: 2019-10-01
+description: |
+  Built-in methods File.fnmatch and its alias File.fnmatch? accept the path
+  pattern as their first parameter. When the pattern contains NUL character
+  (\0), the methods recognize that the path pattern ends immediately before the
+  NUL byte. Therefore, a script that uses an external input as the pattern
+  argument, an attacker can make it wrongly match a pathname that is the second
+  parameter.
+
+  All users running any affected releases should upgrade as soon as possible.
+patched_versions:
+  - "~> 2.4.8"
+  - "~> 2.5.7"
+  - "~> 2.6.5"
+  - "> 2.7.0-preview1"

--- a/rubies/ruby/CVE-2019-16201.yml
+++ b/rubies/ruby/CVE-2019-16201.yml
@@ -1,0 +1,19 @@
+---
+engine: ruby
+cve: 2019-16201
+url: https://www.ruby-lang.org/en/news/2019/10/01/webrick-regexp-digestauth-dos-cve-2019-16201/
+title: Regular Expression Denial of Service vulnerability of WEBrick's Digest access authentication
+date: 2019-10-01
+description: |
+  Regular expression denial of service vulnerability of WEBrick’s Digest
+  authentication module was found. An attacker can exploit this vulnerability
+  to cause an effective denial of service against a WEBrick service.
+
+  CVE-2019-16201 has been assigned to this vulnerability.
+
+  All users running any affected releases should upgrade as soon as possible.
+patched_versions:
+  - "~> 2.4.8"
+  - "~> 2.5.7"
+  - "~> 2.6.5"
+  - "> 2.7.0-preview1"

--- a/rubies/ruby/CVE-2019-16201.yml
+++ b/rubies/ruby/CVE-2019-16201.yml
@@ -8,10 +8,6 @@ description: |
   Regular expression denial of service vulnerability of WEBrick’s Digest
   authentication module was found. An attacker can exploit this vulnerability
   to cause an effective denial of service against a WEBrick service.
-
-  CVE-2019-16201 has been assigned to this vulnerability.
-
-  All users running any affected releases should upgrade as soon as possible.
 patched_versions:
   - "~> 2.4.8"
   - "~> 2.5.7"

--- a/rubies/ruby/CVE-2019-16254.yml
+++ b/rubies/ruby/CVE-2019-16254.yml
@@ -1,0 +1,21 @@
+---
+engine: ruby
+cve: 2019-16254
+url: https://www.ruby-lang.org/en/news/2019/10/01/http-response-splitting-in-webrick-cve-2019-16254/
+title: HTTP response splitting in WEBrick (Additional fix)
+date: 2019-10-01
+description: |
+  If a program using WEBrick inserts untrusted input into the response header,
+  an attacker can exploit it to insert a newline character to split a header,
+  and inject malicious content to deceive clients.
+
+  This is the same issue as CVE-2017-17742. The previous fix was incomplete,
+  which addressed the CRLF vector, but did not address an isolated CR or an
+  isolated LF.
+
+  All users running an affected release should upgrade immediately.
+patched_versions:
+  - "~> 2.4.8"
+  - "~> 2.5.7"
+  - "~> 2.6.5"
+  - "> 2.7.0-preview1"

--- a/rubies/ruby/CVE-2019-16254.yml
+++ b/rubies/ruby/CVE-2019-16254.yml
@@ -12,8 +12,6 @@ description: |
   This is the same issue as CVE-2017-17742. The previous fix was incomplete,
   which addressed the CRLF vector, but did not address an isolated CR or an
   isolated LF.
-
-  All users running an affected release should upgrade immediately.
 patched_versions:
   - "~> 2.4.8"
   - "~> 2.5.7"

--- a/rubies/ruby/CVE-2019-16255.yml
+++ b/rubies/ruby/CVE-2019-16255.yml
@@ -13,8 +13,6 @@ description: |
   Users must never do it. However, we treat this particular case as a
   vulnerability because the purpose of Shell#[] and Shell#[] is considered file
   testing.
-
-  All users running an affected release should upgrade immediately.
 patched_versions:
   - "~> 2.4.8"
   - "~> 2.5.7"

--- a/rubies/ruby/CVE-2019-16255.yml
+++ b/rubies/ruby/CVE-2019-16255.yml
@@ -1,0 +1,22 @@
+---
+engine: ruby
+cve: 2019-16255
+url: https://www.ruby-lang.org/en/news/2019/10/01/code-injection-shell-test-cve-2019-16255/
+title: A code injection vulnerability of Shell#[] and Shell#test
+date: 2019-10-01
+description: |
+  Shell#[] and its alias Shell#test defined in lib/shell.rb allow code
+  injection if the first argument (aka the “command” argument) is untrusted
+  data. An attacker can exploit this to call an arbitrary Ruby method.
+
+  Note that passing untrusted data to methods of Shell is dangerous in general.
+  Users must never do it. However, we treat this particular case as a
+  vulnerability because the purpose of Shell#[] and Shell#[] is considered file
+  testing.
+
+  All users running an affected release should upgrade immediately.
+patched_versions:
+  - "~> 2.4.8"
+  - "~> 2.5.7"
+  - "~> 2.6.5"
+  - "> 2.7.0-preview1"


### PR DESCRIPTION
From

* https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/
* https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released/
* https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-4-8-released/
* https://www.ruby-lang.org/en/news/2019/10/02/ruby-2-4-9-released/