### PR TITLE
[RFC]: Support EOL

### DIFF
--- a/gems/eol.yml
+++ b/gems/eol.yml
@@ -1,0 +1,11 @@
+---
+ruby-sass:
+  url: https://github.com/sass/ruby-sass/issues/112
+  date: 2019-03-26
+
+  description: With the release of Dart Sass 1.0.0 stable, Ruby Sass was
+    officially deprecated. Applications should move to Dart Sass or LibSass.
+
+  related:
+    url:
+      - http://sass.logdown.com/posts/7081811

--- a/rubies/eol.yml
+++ b/rubies/eol.yml
@@ -1,0 +1,5 @@
+---
+ruby:
+  url: https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/
+  date: 2019-03-31
+  version: "< 2.4"


### PR DESCRIPTION
#416 
I have included only 2 examples of how it can be implemented. 
`gems/eol.yml` file format:
```yaml
<gem name>:
  url:
  date:
  description:
```
I see `title` attribute here as always useless, because it will every time be the same, something like `"<gem name>  is deprecated"`.

`rubies/eol.yml` file format:
```yaml
<engine>:
  url:
  date:
  version:
```
Here I see `description` field as useless, as it will always be the same, like `"<engine> is deprecated, you should upgrade"`.

But for consistency, we can provide `title` and `description` in both variants.

I can think of an alternative implementation:
```
ruby-advisory-db/:
  eols/:
    gems/:
      ruby-sass.yml
      foo-bar.yml
      ...
   rubies/:
     ruby.yml
     jruby.yml
     ...
```

Where `ruby-sass.yml` has format:
```yaml
url:
date:
description:
```

And `ruby.yml` has format:
```yaml
url:
date:
version:
```

Will add missing tests after agreeing on implementation.