### PR TITLE
Add missing CVE-2017-1002201 for haml

### DIFF
--- a/gems/haml/CVE-2017-1002201.yml
+++ b/gems/haml/CVE-2017-1002201.yml
@@ -1,0 +1,19 @@
+---
+gem: haml
+cve: 2017-1002201
+url: https://nvd.nist.gov/vuln/detail/CVE-2017-1002201
+title: haml failure to escape single quotes
+date: 2017-05-08
+description: |
+  In haml versions prior to version 5.0.0.beta.2, when using user input to
+  perform tasks on the server, characters like < > " ' must be escaped properly.
+  In this case, the ' character was missed. An attacker can manipulate the input
+  to introduce additional attributes, potentially executing code.
+cvss_v2: 4.3
+patched_versions:
+  - ">= 5.0.0.beta.2"
+
+related:
+  url:
+    - https://github.com/haml/haml/commit/18576ae6e9bdcb4303fdbe6b3199869d289d67c2
+    - https://snyk.io/vuln/SNYK-RUBY-HAML-20362

--- a/gems/haml/CVE-2017-1002201.yml
+++ b/gems/haml/CVE-2017-1002201.yml
@@ -10,6 +10,7 @@ description: |
   In this case, the ' character was missed. An attacker can manipulate the input
   to introduce additional attributes, potentially executing code.
 cvss_v2: 4.3
+cvss_v3: 6.1
 patched_versions:
   - ">= 5.0.0.beta.2"
 

--- a/gems/haml/CVE-2017-1002201.yml
+++ b/gems/haml/CVE-2017-1002201.yml
@@ -1,7 +1,7 @@
 ---
 gem: haml
 cve: 2017-1002201
-url: https://nvd.nist.gov/vuln/detail/CVE-2017-1002201
+url: https://github.com/haml/haml/commit/18576ae6e9bdcb4303fdbe6b3199869d289d67c2
 title: haml failure to escape single quotes
 date: 2017-05-08
 description: |
@@ -16,5 +16,4 @@ patched_versions:
 
 related:
   url:
-    - https://github.com/haml/haml/commit/18576ae6e9bdcb4303fdbe6b3199869d289d67c2
     - https://snyk.io/vuln/SNYK-RUBY-HAML-20362


### PR DESCRIPTION
This advisory was apparently published by snyk in 2017, though the publish date on NIST is 10/15/2019. I was made aware of it by Github security scanning which has recently picked this up as well.