### PR TITLE
CVE-2019-18409.yml for ruby_parser-legacy

### DIFF
--- a/gems/ruby_parser-legacy/CVE-2019-18409.yml
+++ b/gems/ruby_parser-legacy/CVE-2019-18409.yml
@@ -1,0 +1,20 @@
+---
+gem: ruby_parser-legacy
+cve: 2019-18409
+date: 2019-10-24
+url: https://github.com/zenspider/ruby_parser-legacy/issues/1
+title: |
+  ruby_parser-legacy has world writable files in the release 1.0.0 that allow local privilege escalation.
+
+description: |
+  The ruby_parser-legacy (aka legacy) gem 1.0.0 for Ruby allows local
+  privilege escalation because of world-writable files. For example,
+  if the brakeman gem (which has a legacy dependency) 4.5.0 through 4.7.0 is used,
+  a local user can insert malicious code into the
+  ruby_parser-legacy-1.0.0/lib/ruby_parser/legacy/ruby_parser.rb file.
+
+cvss_v2: 4.6
+cvss_v3: 7.8
+
+patched_versions:
+  - "> 1.0.0"

--- a/gems/ruby_parser-legacy/CVE-2019-18409.yml
+++ b/gems/ruby_parser-legacy/CVE-2019-18409.yml
@@ -3,8 +3,7 @@ gem: ruby_parser-legacy
 cve: 2019-18409
 date: 2019-10-24
 url: https://github.com/zenspider/ruby_parser-legacy/issues/1
-title: |
-  ruby_parser-legacy has world writable files in the release 1.0.0 that allow local privilege escalation.
+title: ruby_parser-legacy world writable files allow local privilege escalation
 
 description: |
   The ruby_parser-legacy (aka legacy) gem 1.0.0 for Ruby allows local

--- a/gems/ruby_parser-legacy/CVE-2019-18409.yml
+++ b/gems/ruby_parser-legacy/CVE-2019-18409.yml
@@ -14,6 +14,3 @@ description: |
 
 cvss_v2: 4.6
 cvss_v3: 7.8
-
-patched_versions:
-  - "> 1.0.0"


### PR DESCRIPTION
Hi,

Please consider this PR for the CVE-2019-18409.

https://nvd.nist.gov/vuln/detail/CVE-2019-18409.

Thanks