### PR TITLE
CVE-2019-18409.yml for brakeman

### DIFF
--- a/gems/brakeman/CVE-2019-18409.yml
+++ b/gems/brakeman/CVE-2019-18409.yml
@@ -1,0 +1,27 @@
+---
+gem: brakeman
+cve: 2019-18409
+date: 2019-10-24
+url: https://nvd.nist.gov/vuln/detail/CVE-2019-18409
+title: |
+  brakeman has world writable files in the release 4.5.0 through 4.7.0 that allow local privilege escalation.
+
+description: |
+  The ruby_parser-legacy (aka legacy) gem 1.0.0 for Ruby allows local
+  privilege escalation because of world-writable files. For example,
+  if the brakeman gem (which has a legacy dependency) 4.5.0 through 4.7.0 is used,
+  a local user can insert malicious code into the
+  ruby_parser-legacy-1.0.0/lib/ruby_parser/legacy/ruby_parser.rb file.
+
+cvss_v2: 4.6
+cvss_v3: 7.8
+
+patched_versions:
+  - ">= 4.7.1"
+
+unaffected_versions:
+  - "<= 4.4.0"
+
+related:
+  url:
+    - https://github.com/zenspider/ruby_parser-legacy/issues/1

--- a/gems/brakeman/CVE-2019-18409.yml
+++ b/gems/brakeman/CVE-2019-18409.yml
@@ -2,9 +2,8 @@
 gem: brakeman
 cve: 2019-18409
 date: 2019-10-24
-url: https://nvd.nist.gov/vuln/detail/CVE-2019-18409
-title: |
-  brakeman has world writable files in the release 4.5.0 through 4.7.0 that allow local privilege escalation.
+url: https://brakemanscanner.org/blog/2019/10/14/brakeman-4-dot-7-dot-1-released
+title: brakeman world writable files allow local privilege escalation
 
 description: |
   The ruby_parser-legacy (aka legacy) gem 1.0.0 for Ruby allows local


### PR DESCRIPTION
Hi, 

Please consider this PR for the brakeman gems.

The brakeman's security team has published a fix in the version 4.7.1.
The gem ruby_parser-legacy is statically include in brakeman when the gem is builded.

https://github.com/zenspider/ruby_parser-legacy/issues/1