### PR TITLE
Add CVE-2020-7595 for nokogiri

### DIFF
--- a/gems/nokogiri/CVE-2020-7595.yml
+++ b/gems/nokogiri/CVE-2020-7595.yml
@@ -1,0 +1,23 @@
+---
+gem: nokogiri
+cve: 2020-7595
+url: https://github.com/sparklemotion/nokogiri/issues/1992
+date: 2020-02-12
+title: libxml2 2.9.10 has an infinite loop in a certain end-of-file situation
+description: |-
+
+  CVE-2019-19956 was addressed in upstream libxml2 release v2.9.10, which has
+  been vendored in Nokogiri since v1.10.5 on 2019-10-31.
+
+  CVE-2020-7595 has not yet been addressed in an upstream libxml2 release, and
+  so Nokogiri versions <= v1.10.7 are vulnerable.
+
+  Nokogiri has backported the patch for CVE-2020-7595 into its vendored version
+  of libxml2, and released this as v1.10.8
+
+patched_versions:
+  - ">= 1.10.8"
+
+cvss_v2: 5.0
+cvss_v3: 7.5
+

--- a/gems/nokogiri/CVE-2020-7595.yml
+++ b/gems/nokogiri/CVE-2020-7595.yml
@@ -6,14 +6,11 @@ date: 2020-02-12
 title: libxml2 2.9.10 has an infinite loop in a certain end-of-file situation
 description: |-
 
-  CVE-2019-19956 was addressed in upstream libxml2 release v2.9.10, which has
-  been vendored in Nokogiri since v1.10.5 on 2019-10-31.
+  Nokogiri has backported the patch for CVE-2020-7595 into its vendored version
+  of libxml2, and released this as v1.10.8
 
   CVE-2020-7595 has not yet been addressed in an upstream libxml2 release, and
   so Nokogiri versions <= v1.10.7 are vulnerable.
-
-  Nokogiri has backported the patch for CVE-2020-7595 into its vendored version
-  of libxml2, and released this as v1.10.8
 
 patched_versions:
   - ">= 1.10.8"


### PR DESCRIPTION
For https://github.com/sparklemotion/nokogiri/issues/1992