### PR TITLE
Add CVE-2020-5247 against puma, fixing #435

### DIFF
--- a/gems/puma/CVE-2020-5247.yml
+++ b/gems/puma/CVE-2020-5247.yml
@@ -1,0 +1,25 @@
+---
+gem: puma
+cve: 2020-5247
+ghsa: 84j7-475p-hp8v
+url: https://github.com/puma/puma/security/advisories/GHSA-84j7-475p-hp8v
+date: 2020-02-27
+title: HTTP Response Splitting
+description: |
+  If an application using Puma allows untrusted input in a response header,
+  an attacker can use newline characters (i.e. CR, LF) to end the header and
+  inject malicious content, such as additional headers or an entirely new
+  response body. This vulnerability is known as HTTP Response Splitting.
+
+  While not an attack in itself, response splitting is a vector for several
+  other attacks, such as cross-site scripting (XSS).
+
+cvss_v3: 6.5
+
+patched_versions:
+  - "~> 3.12.4"
+  - ">= 4.3.3"
+
+related:
+  cve:
+    - 2019-16254

--- a/gems/puma/CVE-2020-5247.yml
+++ b/gems/puma/CVE-2020-5247.yml
@@ -4,7 +4,7 @@ cve: 2020-5247
 ghsa: 84j7-475p-hp8v
 url: https://github.com/puma/puma/security/advisories/GHSA-84j7-475p-hp8v
 date: 2020-02-27
-title: HTTP Response Splitting
+title: HTTP Response Splitting vulnerability in puma
 description: |
   If an application using Puma allows untrusted input in a response header,
   an attacker can use newline characters (i.e. CR, LF) to end the header and


### PR DESCRIPTION
NB: Patched versions are an extra point release higher than the CVE is declared against, as a bug was fixed against the immediate release and a further vector (early hints) was closed.