### PR TITLE
Add CVE-2020-8130 for Rake

### DIFF
--- a/gems/rake/CVE-2020-8130.yml
+++ b/gems/rake/CVE-2020-8130.yml
@@ -1,0 +1,17 @@
+---
+gem: rake
+cve: 2020-8130
+date: 2019-08-29
+url: https://github.com/advisories/GHSA-jppv-gw3r-w3q8
+title: OS Command Injection in Rake
+
+description: |
+  There is an OS command injection vulnerability in Ruby Rake < 12.3.3 in
+  Rake::FileList when supplying a filename that begins with the pipe character
+  `|`.
+
+cvss_v2: 9.3
+cvss_v3: 8.1
+
+patched_versions:
+  - ">= 12.3.3"

--- a/gems/rake/CVE-2020-8130.yml
+++ b/gems/rake/CVE-2020-8130.yml
@@ -1,6 +1,7 @@
 ---
 gem: rake
 cve: 2020-8130
+ghsa: jppv-gw3r-w3q8
 date: 2019-08-29
 url: https://github.com/advisories/GHSA-jppv-gw3r-w3q8
 title: OS Command Injection in Rake


### PR DESCRIPTION
https://github.com/advisories/GHSA-jppv-gw3r-w3q8

> There is an OS command injection vulnerability in Rake (a ruby make-like utility) < 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character `|`.