### PR TITLE
Update vulns with patched versions

### DIFF
--- a/gems/fileutils/CVE-2013-2516.yml
+++ b/gems/fileutils/CVE-2013-2516.yml
@@ -1,4 +1,4 @@
---- 
+---
 gem: fileutils
 cve: 2013-2516
 osvdb: 90717
@@ -6,3 +6,6 @@ url: https://nvd.nist.gov/vuln/detail/CVE-2013-2516
 title: fileutils Gem for Ruby file_utils.rb Crafted URL Handling Remote Command Execution
 date: 2013-02-28
 description: fileutils Gem for Ruby contains a flaw in file_utils.rb. The issue is triggered when handling a specially crafted URL containing a command after a delimiter (;). This may allow a remote attacker to potentially execute arbitrary commands.
+
+patched_versions:
+  - '>= 0.7.1'

--- a/gems/lynx/CVE-2014-5002.yml
+++ b/gems/lynx/CVE-2014-5002.yml
@@ -6,3 +6,6 @@ url: https://nvd.nist.gov/vuln/detail/CVE-2014-5002
 title: lynx Gem for Ruby command/basic.rb Process Table Local Plaintext Password Disclosure
 date: 2014-06-30
 description: lynx Gem for Ruby contains a flaw in command/basic.rb that is due to the application exposing password information in plaintext in the process table. This may allow a local attacker to gain access to password information.
+
+patched_versions:
+  - '>= 1.0.0'

--- a/gems/mapbox-rails/OSVDB-129854.yml
+++ b/gems/mapbox-rails/OSVDB-129854.yml
@@ -19,3 +19,7 @@ description: |
   * only trusted TileJSON content is loaded
   * TileJSON content comes only from mapbox.com URLs
   * a Mapbox map ID is supplied, rather than a TileJSON URL
+
+patched_versions:
+  - '~> 1.6.5'
+  - '>= 2.1.7'

--- a/gems/mapbox-rails/OSVDB-132871.yml
+++ b/gems/mapbox-rails/OSVDB-132871.yml
@@ -20,3 +20,7 @@ description: |
 
   * the map does not use a share control (L.mapbox.sharecontrol)
   * only trusted TileJSON content is loaded
+
+patched_versions:
+  - '~> 1.6.6'
+  - '>= 2.2.4'


### PR DESCRIPTION
Some vulnerabilities have been patched in new releases. This avoids false positives.

Regarding `mapbox-rails` the versions are from the upstream JS library, but the gem versions match the upstream JS ones.