### PR TITLE
Add CVE-2018-12026 for passenger.

### DIFF
--- a/gems/passenger/CVE-2018-12026.yml
+++ b/gems/passenger/CVE-2018-12026.yml
@@ -1,0 +1,27 @@
+---
+gem: passenger
+cve: 2018-12026
+url: https://blog.phusion.nl/2018/06/12/passenger-5-3-2-various-security-fixes/
+title: SpawningKit exploits
+date: 2018-06-07
+
+description: >-
+  During the spawning of a malicious Passenger-managed application, SpawningKit
+  in Phusion Passenger 5.3.x before 5.3.2 allows such applications to replace
+  key files or directories in the spawning communication directory with
+  symlinks. This then could result in arbitrary reads and writes, which in turn
+  can result in information disclosure and privilege escalation.
+
+cvss_v2: 7.5
+cvss_v3: 9.8
+
+patched_versions:
+  - ">= 5.3.2"
+unaffected_versions:
+ - "< 5.3.0"
+ - ">= 5.3.2"
+
+related:
+  cve:
+    - 2018-12027
+    - 2018-12028

--- a/gems/passenger/CVE-2018-12026.yml
+++ b/gems/passenger/CVE-2018-12026.yml
@@ -3,7 +3,7 @@ gem: passenger
 cve: 2018-12026
 url: https://blog.phusion.nl/2018/06/12/passenger-5-3-2-various-security-fixes/
 title: SpawningKit exploits
-date: 2018-06-07
+date: 2018-06-12
 
 description: >-
   During the spawning of a malicious Passenger-managed application, SpawningKit
@@ -17,9 +17,9 @@ cvss_v3: 9.8
 
 patched_versions:
   - ">= 5.3.2"
+
 unaffected_versions:
- - "< 5.3.0"
- - ">= 5.3.2"
+  - "< 5.3.0"
 
 related:
   cve:


### PR DESCRIPTION
I add CVE-2018-12026.yml.

I used the following articles as a reference when I wrote CVE-2018-12026.yml.
https://blog.phusion.nl/2018/06/12/passenger-5-3-2-various-security-fixes/
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12026
https://nvd.nist.gov/vuln/detail/CVE-2018-12026