### PR TITLE
Add CVE-2020-14001 for Kramdown

### DIFF
--- a/gems/kramdown/CVE-2020-14001.yml
+++ b/gems/kramdown/CVE-2020-14001.yml
@@ -1,0 +1,19 @@
+---
+gem: kramdown
+cve: 2020-14001
+ghsa: mqm2-cgpr-p4m6
+date: 2020-06-28
+url: https://github.com/advisories/GHSA-mqm2-cgpr-p4m6
+title: Unintended read access in kramdown gem
+description: |
+  The kramdown gem before 2.3.0 for Ruby processes the template option inside
+  Kramdown documents by default, which allows unintended read access (such as
+  template="/etc/passwd") or unintended embedded Ruby code execution (such as a
+  string that begins with template="string://<%= `). NOTE: kramdown is used in
+  Jekyll, GitLab Pages, GitHub Pages, and Thredded Forum.
+
+cvss_v2: 7.5
+cvss_v3: 9.8
+
+patched_versions:
+  - ">= 2.3.0"


### PR DESCRIPTION
https://github.com/advisories/GHSA-mqm2-cgpr-p4m6

> The kramdown gem before 2.3.0 for Ruby processes the template option
> inside Kramdown documents by default, which allows unintended read
> access (such as template="/etc/passwd") or unintended embedded Ruby
> code execution (such as a string that begins with
> template="string://<%= `). NOTE: kramdown is used in Jekyll, GitLab
> Pages, GitHub Pages, and Thredded Forum.