### PR TITLE
Remove misleading fileutils OSVDB reports

### DIFF
--- a/gems/fileutils/OSVDB-90715.yml
+++ b/gems/fileutils/OSVDB-90715.yml
@@ -1,7 +1,0 @@
---- 
-gem: fileutils
-osvdb: 90715
-url: http://osvdb.org/show/osvdb/90715
-title: fileutils Gem for Ruby files_utils.rb /tmp File Symlink Arbitrary File Overwrite
-date: 2013-02-28
-description: fileutils Gem for Ruby contains a flaw as the program creates temporary files insecurely. It is possible for a local attacker to use a symlink attack against temporary files created by files_utils.rb to cause the program to unexpectedly overwrite an arbitrary file.

--- a/gems/fileutils/OSVDB-90716.yml
+++ b/gems/fileutils/OSVDB-90716.yml
@@ -1,7 +1,0 @@
---- 
-gem: fileutils
-osvdb: 90716
-url: http://osvdb.org/show/osvdb/90716
-title: fileutils Gem for Ruby Temporary Directory Hijacking Weakness
-date: 2013-02-28
-description: fileutils Gem for Ruby contains a flaw that is due to the program not verifying the existence of a directory before attempting to create it. This may allow a local attacker to create the directory in advance, thus owning any files subsequently written to it.

--- a/gems/fileutils/OSVDB-90718.yml
+++ b/gems/fileutils/OSVDB-90718.yml
@@ -1,7 +1,0 @@
---- 
-gem: fileutils
-osvdb: 90718
-url: http://osvdb.org/show/osvdb/90718
-title: fileutils Gem for Ruby /lib/file_utils/open_office.rb Character Handling Remote Command Execution
-date: 2013-02-28
-description: fileutils Gem for Ruby contains a flaw in /lib/file_utils/open_office.rb. The issue is triggered when handling a specially crafted URL containing a command after a delimiter (;). This may allow a remote attacker to potentially execute arbitrary commands.


### PR DESCRIPTION
As a followup to my discussion with Hiroshi Shibata, maintainer of the https://rubygems.org/gems/fileutils gem:

![Zrzut ekranu z 2020-12-22 14-31-59](https://user-images.githubusercontent.com/392754/102893882-8b54b400-4462-11eb-9745-51637183eb70.png)

The following reports are no longer valid and completely misleading, causing the users of those to get false alarms in case fileutils ends up in the gemfile.