### PR TITLE
Update activerecord-session_store advisory info

### DIFF
--- a/gems/activerecord-session_store/CVE-2019-25025.yml
+++ b/gems/activerecord-session_store/CVE-2019-25025.yml
@@ -13,15 +13,16 @@ description: |
   amount of time. This is a related issue to CVE-2019-16782.
 
   ## Recommendation
-  As of the publishing of this advisory, there is no official fix in place.
-
-  An unofficial fix is described here:
-  https://github.com/rails/activerecord-session_store/pull/151#issuecomment-631705247
+  Users should upgrade to `activerecord-session_store` version 2.0.0 or later.
 
 cvss_v3: 5.9
+
+patched_versions:
+  - ">= 2.0.0"
 
 related:
   cve:
     - 2019-16782
   url:
     - https://github.com/rails/activerecord-session_store/pull/151
+    - https://github.com/rails/activerecord-session_store/releases/tag/v2.0.0


### PR DESCRIPTION
I just merged https://github.com/rails/activerecord-session_store/pull/151 and release [version 2.0.0](https://github.com/rails/activerecord-session_store/releases/tag/v2.0.0) which contains a fix and mitigation. Users are now advised to upgrade to version 2.0.0 or later.

Please let me know if this patch is ok, or if there's anything else I should fix. Thank you very much.