### PR TITLE
Add CVE-2021-28965 for REXML

### DIFF
--- a/gems/rexml/CVE-2021-28965.yml
+++ b/gems/rexml/CVE-2021-28965.yml
@@ -1,0 +1,12 @@
+---
+gem: rexml
+cve: 2021-28965
+date: 2021-04-05
+url: https://www.ruby-lang.org/en/news/2021/04/05/xml-round-trip-vulnerability-in-rexml-cve-2021-28965/
+title: |
+  XML round-trip vulnerability in REXML
+
+description: |
+  When parsing and serializing a crafted XML document, REXML gem (including
+  the one bundled with Ruby) can create a wrong XML document whose structure
+  is different from the original one.

--- a/gems/rexml/CVE-2021-28965.yml
+++ b/gems/rexml/CVE-2021-28965.yml
@@ -3,10 +3,12 @@ gem: rexml
 cve: 2021-28965
 date: 2021-04-05
 url: https://www.ruby-lang.org/en/news/2021/04/05/xml-round-trip-vulnerability-in-rexml-cve-2021-28965/
-title: |
-  XML round-trip vulnerability in REXML
+title: XML round-trip vulnerability in REXML
 
 description: |
   When parsing and serializing a crafted XML document, REXML gem (including
   the one bundled with Ruby) can create a wrong XML document whose structure
   is different from the original one.
+
+patched_versions:
+  - ">= 3.2.5"


### PR DESCRIPTION
For [REXML](https://www.ruby-lang.org/en/news/2021/04/05/xml-round-trip-vulnerability-in-rexml-cve-2021-28965/)