### PR TITLE
Add Bundler CVE-2020-36327

### DIFF
--- a/gems/bundler/CVE-2020-36327.yml
+++ b/gems/bundler/CVE-2020-36327.yml
@@ -1,0 +1,33 @@
+---
+gem: bundler
+cve: 2020-36327
+ghsa: fp4w-jxhp-m23p
+date: 2020-09-30
+url: https://github.com/rubygems/rubygems/issues/3982
+title: Dependency Confusion in Bundler with Implicit Private Dependencies
+
+description: |
+  Bundler 1.16.0 through 2.2.9 and 2.2.11 through 2.2.17 sometimes chooses a
+  dependency source based on the highest gem version number, which means that a
+  rogue gem found at a public source may be chosen, even if the intended choice
+  was a private gem that is a dependency of another private gem that is
+  explicitly depended on by the application.
+
+cvss_v3: 8.8
+
+patched_versions:
+  - ">= 2.2.18"
+  - "2.2.10"
+
+unaffected_versions:
+  - "< 1.16.0"
+
+related:
+  cve:
+    - 2021-24105
+  url:
+    - https://bundler.io/blog/2021/02/15/a-more-secure-bundler-we-fixed-our-source-priorities.html
+    - https://mensfeld.pl/2021/02/rubygems-dependency-confusion-attack-side-of-things/
+    - https://www.zofrex.com/blog/2021/04/29/bundler-still-vulnerable-dependency-confusion-cve-2020-36327/
+    - https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2021-24105
+    - https://github.com/rubygems/rubygems/pull/4609


### PR DESCRIPTION
PR to add the CVE for implicit dependency confusion.

I have two questions about this:

1) Is it correct to put 2.2.10 in the `unaffected_versions` section? Technically that version was patched (and the patch was rolled back in 2.2.11), so `patched_versions` seems more appropriate. However, if I put it there then a test fails:

```
Failures:

  1) gems /Users/zofrex/Code/ruby/ruby-advisory-db/spec/../gems/bundler/CVE-2020-36327.yml versions assumes that future versions will be patched
     Failure/Error: expect(versions.last.match(/^>=|^>/)).to be_truthy
     
       expected: truthy value
            got: nil
     Shared Example Group: "Gem Advisory" called from ./spec/advisories_spec.rb:8
     # ./spec/gem_example.rb:32:in `block (4 levels) in <top (required)>'
```

2) I wrote a blog post about this vulnerability, explaining it in more detail and outlining some possible mitigations. Would it be OK to add the URL to the related section? I've left it out to start with in case self-promotion isn't ok.