### PR TITLE
Add CVE-2021-28966 for tmpdir

### DIFF
--- a/gems/tmpdir/CVE-2021-28966.yml
+++ b/gems/tmpdir/CVE-2021-28966.yml
@@ -1,0 +1,21 @@
+---
+gem: tmpdir
+cve: 2021-28966
+date: 2021-04-05
+url: https://www.ruby-lang.org/en/news/2021/04/05/tempfile-path-traversal-on-windows-cve-2021-28966/
+title: Path traversal in Tempfile on Windows
+
+description: |
+  There is an unintentional directory creation vulnerability in tmpdir library 
+  bundled with Ruby on Windows. And there is also an unintentional file 
+  creation vulnerability in tempfile library bundled with Ruby on Windows, 
+  because it uses tmpdir internally. 
+
+patched_versions:
+  - ">= 0.1.2"
+
+related:
+  cve:
+    - 2018-6914
+  url:
+    - https://www.ruby-lang.org/en/news/2018/03/28/unintentional-file-and-directory-creation-with-directory-traversal-cve-2018-6914/


### PR DESCRIPTION
Here is the modified commit on the repository side of gem. https://github.com/ruby/tmpdir/commit/adf294bc2d10cd223aa3ca488079ec313032c07b