### PR TITLE
Add CVE-2021-29509 for puma

### DIFF
--- a/gems/puma/CVE-2021-29509.yml
+++ b/gems/puma/CVE-2021-29509.yml
@@ -1,0 +1,47 @@
+---
+gem: puma
+cve: 2021-29509
+ghsa: q28m-8xjw-8vr5
+url: https://github.com/puma/puma/security/advisories/GHSA-q28m-8xjw-8vr5
+date: 2021-05-11
+title: Keepalive Connections Causing Denial Of Service in puma
+description: |-
+  ### Impact
+
+  The fix for CVE-2019-16770 was incomplete. The original fix only protected
+  existing connections that had already been accepted from having their
+  requests starved by greedy persistent-connections saturating all threads in
+  the same process. However, new connections may still be starved by greedy
+  persistent-connections saturating all threads in all processes in the
+  cluster.
+
+  A puma server which received more concurrent keep-alive connections than the
+  server had threads in its threadpool would service only a subset of
+  connections, denying service to the unserved connections.
+
+  ### Patches
+
+  This problem has been fixed in puma 4.3.8 and 5.3.1.
+
+  ### Workarounds
+
+  Setting queue_requests false also fixes the issue. This is not advised when
+  using puma without a reverse proxy, such as nginx or apache, because you will
+  open yourself to slow client attacks (e.g. [slowloris][1]).
+
+  The fix is very small. [A git patch is available here][2] for those using
+  [unsupported versions][3] of Puma.
+
+  [1]: https://en.wikipedia.org/wiki/Slowloris_(computer_security)
+  [2]: https://gist.github.com/nateberkopec/4b3ea5676c0d70cbb37c82d54be25837
+  [3]: https://github.com/puma/puma/security/policy#supported-versions
+
+cvss_v3: 7.5
+
+patched_versions:
+  - "~> 4.3.8"
+  - ">= 5.3.1"
+
+related:
+  cve:
+    - 2019-16770


### PR DESCRIPTION
It seems that this cannot be found by `sync_github_advisories` so I added it manually. Is this something expected or I missed something? Thanks!