### PR TITLE
Mark Rails ~> 6.0.4 as patched

### DIFF
--- a/gems/actionpack/CVE-2021-22881.yml
+++ b/gems/actionpack/CVE-2021-22881.yml
@@ -63,5 +63,5 @@ unaffected_versions:
   - "< 6.0.0"
 
 patched_versions:
-  - "~> 6.0.3.5"
+  - "~> 6.0.3, >= 6.0.3.5"
   - ">= 6.1.2.1"


### PR DESCRIPTION
I missed one in #477. Mark CVE-2021-22881 as patched in Rails 6.0.4.