### PR TITLE
add CVE-2021-32823 for bindata

### DIFF
--- a/gems/bindata/CVE-2021-32823.yml
+++ b/gems/bindata/CVE-2021-32823.yml
@@ -1,0 +1,20 @@
+---
+gem: bindata
+cve: 2021-32823
+ghsa: hj56-84jw-67h6
+url:
+  url: https://github.com/rubysec/ruby-advisory-db/issues/476
+date: 2021-06-23
+title: Potential Denial-of-Service in bindata
+description: |
+  In bindata before version 2.4.10 there is a potential denial-of-service
+  vulnerability. In affected versions it is very slow for certain classes in BinData
+  to be created. For example BinData::Bit100000, BinData::Bit100001, BinData::Bit100002,
+  BinData::Bit<N>. In combination with <user_input>.constantize there is a potential
+  for a CPU-based DoS. In version 2.4.10 bindata improved the creation time of Bits
+  and Integers.
+
+cvss_v3: 3.7
+
+patched_versions:
+- ">= 2.4.10"

--- a/gems/bindata/CVE-2021-32823.yml
+++ b/gems/bindata/CVE-2021-32823.yml
@@ -2,16 +2,15 @@
 gem: bindata
 cve: 2021-32823
 ghsa: hj56-84jw-67h6
-url:
-  url: https://github.com/rubysec/ruby-advisory-db/issues/476
-date: 2021-06-23
+url: https://github.com/rubysec/ruby-advisory-db/issues/476
+date: 2021-05-18
 title: Potential Denial-of-Service in bindata
 description: |
-  In bindata before version 2.4.10 there is a potential denial-of-service
-  vulnerability. In affected versions it is very slow for certain classes in BinData
+  In bindata before version 2.4.10, there is a potential denial-of-service
+  vulnerability. In affected versions, it is very slow for certain classes in BinData
   to be created. For example BinData::Bit100000, BinData::Bit100001, BinData::Bit100002,
-  BinData::Bit<N>. In combination with <user_input>.constantize there is a potential
-  for a CPU-based DoS. In version 2.4.10 bindata improved the creation time of Bits
+  BinData::Bit<N>. In combination with `<user_input>.constantize` there is a potential
+  for a CPU-based DoS. In version 2.4.10, bindata improved the creation time of Bits
   and Integers.
 
 cvss_v3: 3.7


### PR DESCRIPTION
This relates to this conversation: https://github.com/rubysec/ruby-advisory-db/issues/476

This adds a new advisory for `bindata` for CVE-2021-32823 / https://github.com/advisories/GHSA-hj56-84jw-67h6.

CC @kuahyeow @reedloden @postmodern 