### PR TITLE
invalid syntax on notes for linkage

### DIFF
--- a/gems/actionview/CVE-2016-6316.yml
+++ b/gems/actionview/CVE-2016-6316.yml
@@ -49,7 +49,7 @@ description: |
 unaffected_versions:
   - "< 3.0.0"
 
-notes: "~> 3.2.22.3" is found in gems/actionpack/CVE-2016-6316.yml
+notes: "~> 3.2.22.3" # is found in gems/actionpack/CVE-2016-6316.yml
 patched_versions:
   - "~> 4.2.7.1"
   - "~> 4.2.8"


### PR DESCRIPTION
Currently Psych is running into a syntax error ingesting this YAML CVE for usage in bundler audit GEM.

This is causing bundler audit to bail out. We make use of bundler audit as part of our CI process, this is how we came across the invalid syntax error.

Output when attempting to run `bundle audit`
```sh
/Users/USER/.rbenv/versions/2.7.1/lib/ruby/2.7.0/psych.rb:456:in `parse': (/Users/USER/.local/share/ruby-advisory-db/gems/actionview/CVE-2016-6316.yml): did not find expected key while parsing a block mapping at line 2 column 1 (Psych::SyntaxError)
```