### PR TITLE
Add GHSA-jxhc-q857-3j6g / CVE-2021-32740

### DIFF
--- a/gems/addressable/CVE-2021-32740.yml
+++ b/gems/addressable/CVE-2021-32740.yml
@@ -3,7 +3,7 @@ gem: addressable
 cve: 2021-32740
 ghsa: jxhc-q857-3j6g
 url: https://github.com/advisories/GHSA-jxhc-q857-3j6g
-date: 07-12-2021
+date: 2021-07-12
 title: Regular Expression Denial of Service in Addressable templates
 description: |
   Within the URI template implementation in Addressable, a maliciously crafted template may result in uncontrolled resource consumption,

--- a/gems/addressable/CVE-2021-32740.yml
+++ b/gems/addressable/CVE-2021-32740.yml
@@ -1,0 +1,17 @@
+---
+gem: addressable
+cve: 2021-32740
+ghsa: jxhc-q857-3j6g
+url: https://github.com/advisories/GHSA-jxhc-q857-3j6g
+date: 07-12-2021
+title: Regular Expression Denial of Service in Addressable templates
+description: |
+  Within the URI template implementation in Addressable, a maliciously crafted template may result in uncontrolled resource consumption,
+  leading to denial of service when matched against a URI. In typical usage, templates would not normally be read from untrusted user input,
+  but nonetheless, no previous security advisory for Addressable has cautioned against doing this.
+  Users of the parsing capabilities in Addressable but not the URI template capabilities are unaffected.
+cvss_v3: 7.5
+unaffected_versions:
+- '< 2.3.0'
+patched_versions:
+- '>= 2.8.0'


### PR DESCRIPTION
Add GHSA-jxhc-q857-3j6g / CVE-2021-32740 for `addressable` advisory.

- https://github.com/advisories/GHSA-jxhc-q857-3j6g
- https://nvd.nist.gov/vuln/detail/CVE-2021-32740
- https://github.com/sporkmonger/addressable/security/advisories/GHSA-jxhc-q857-3j6g
