### PR TITLE
Sidekiq version 5.2.10 also addresses CVE-2022-23837

### DIFF
--- a/gems/sidekiq/CVE-2022-23837.yml
+++ b/gems/sidekiq/CVE-2022-23837.yml
@@ -13,6 +13,7 @@ cvss_v2: 5.0
 cvss_v3: 7.5
 patched_versions:
 - ">= 6.4.0"
+- ">= 5.2.10"
 related:
   url:
   - https://github.com/TUTUMSPACE/exploits/blob/main/sidekiq.md

--- a/gems/sidekiq/CVE-2022-23837.yml
+++ b/gems/sidekiq/CVE-2022-23837.yml
@@ -6,14 +6,14 @@ url: https://github.com/mperham/sidekiq/commit/7785ac1399f1b28992adb56055f6acd88
 title: Denial of service in sidekiq
 date: 2022-01-27
 description: |
-  In api.rb in Sidekiq before 6.4.0, there is no limit on the number of
+  In api.rb in Sidekiq before 5.2.10 and 6.4.0, there is no limit on the number of
   days when requesting stats for the graph. This overloads the system, affecting the
   Web UI, and makes it unavailable to users.
 cvss_v2: 5.0
 cvss_v3: 7.5
 patched_versions:
 - ">= 6.4.0"
-- ">= 5.2.10"
+- "~> 5.2.10"
 related:
   url:
   - https://github.com/TUTUMSPACE/exploits/blob/main/sidekiq.md


### PR DESCRIPTION
PR that backports: https://github.com/mperham/sidekiq/pull/5157
Rubygems release: https://rubygems.org/gems/sidekiq/versions/5.2.10