### PR TITLE
Add unaffected versions for CVE-2022-24722

### DIFF
--- a/gems/view_component/CVE-2022-24722.yml
+++ b/gems/view_component/CVE-2022-24722.yml
@@ -15,6 +15,8 @@ description: |
 
   Avoid passing user input to the `translate` function, or sanitize the inputs
   before passing them.
+unaffected_versions:
+- "< 2.31.0"
 patched_versions:
 - ">= 2.49.1"
 - "~> 2.31.2"


### PR DESCRIPTION
### **Problem:**
Current version of view_component gem we are using on a project is **2.26.1** and checking our Gemfile.lock file against ruby-advisory database by using [bundler-audit](https://github.com/rubysec/bundler-audit) reports CVE-2022-24722.
According to GitHub Advisory view_component versions affected by CVE-2022-24722 are:
```
>= 2.31.0, < 2.31.2
>= 2.32.0, < 2.49.1
```
###  **Solution:**
  Add “< 2.31.0” to  unaffected_versions in [CVE-2022-24722.yml](https://github.com/rubysec/ruby-advisory-db/commit/4a57fd51236cbb0b03d13583f1bf75d9f3d0ced0#diff-655f132a9ea2f6e77397adf43790938ebbaea351027a0f728ff019c5f7649962)