### PR TITLE
Add latest ruby CVEs

### DIFF
--- a/rubies/ruby/CVE-2022-28738.yml
+++ b/rubies/ruby/CVE-2022-28738.yml
@@ -1,0 +1,18 @@
+---
+engine: ruby
+cve: 2022-28738
+url: https://www.ruby-lang.org/en/news/2022/04/12/double-free-in-regexp-compilation-cve-2022-28738/
+title: Double free in Regexp compilation
+date: 2022-04-12
+description: |
+  A double-free vulnerability is discovered in Regexp compilation. This vulnerability has been assigned the CVE identifier CVE-2022-28738. We strongly recommend upgrading Ruby.
+
+  Due to a bug in the Regexp compilation process, creating a Regexp object with a crafted source string could cause the same memory to be freed twice. This is known as a “double free” vulnerability. Note that, in general, it is considered unsafe to create and use a Regexp object generated from untrusted input. In this case, however, following a comprehensive assessment, we treat this issue as a vulnerability.
+
+  Please update Ruby to 3.0.4, or 3.1.2.
+patched_versions:
+- ~> 3.0.4
+- '>= 3.1.2'
+unaffected_versions:
+- ~> 2.6.0
+- ~> 2.7.0

--- a/rubies/ruby/CVE-2022-28739.yml
+++ b/rubies/ruby/CVE-2022-28739.yml
@@ -1,0 +1,17 @@
+---
+engine: ruby
+cve: 2022-28739
+url: https://www.ruby-lang.org/en/news/2022/04/12/buffer-overrun-in-string-to-float-cve-2022-28739/
+title: Buffer overrun in String-to-Float conversion
+date: 2022-04-12
+description: |
+  A buffer-overrun vulnerability is discovered in a conversion algorithm from a String to a Float. This vulnerability has been assigned the CVE identifier CVE-2022-28739. We strongly recommend upgrading Ruby.
+
+  Due to a bug in an internal function that converts a String to a Float, some convertion methods like Kernel#Float and String#to_f could cause buffer over-read. A typical consequence is a process termination due to segmentation fault, but in a limited circumstances, it may be exploitable for illegal memory read.
+
+  Please update Ruby to 2.6.10, 2.7.6, 3.0.4, or 3.1.2.
+patched_versions:
+- ~> 2.6.10
+- ~> 2.7.6
+- ~> 3.0.4
+- '>= 3.1.2'


### PR DESCRIPTION
Those 2 new CVEs are impacting ruby directly and are not in the github registry of CVEs (hence are not synced here):

* https://www.ruby-lang.org/en/news/2022/04/12/buffer-overrun-in-string-to-float-cve-2022-28739/
* https://www.ruby-lang.org/en/news/2022/04/12/double-free-in-regexp-compilation-cve-2022-28738/