### PR TITLE
Update gibbon to show 3.4.4 is patched

### DIFF
--- a/gems/gibbon/CVE-2022-27311.yml
+++ b/gems/gibbon/CVE-2022-27311.yml
@@ -5,8 +5,7 @@ ghsa: vx9g-377x-xwxq
 url: https://github.com/amro/gibbon/pull/321
 title: Server side request forgery in gibbon
 date: 2022-04-26
-description: |
-  Gibbon v3.4.4 and below allows attackers to execute a Server-Side Request
-  Forgery (SSRF) via a crafted URL. A partial fix has been introduced in version 3.4.4,
-  however a complete fix has not yet been created. See Pull request 321 in github.com/amro/gibbon
-  for details.
+description: Gibbon v3.4.3 and below allows attackers to execute a Server-Side Request
+  Forgery (SSRF) via a crafted URL. This issue has been resolved in version 3.4.4
+patched_versions:
+- 3.4.4

--- a/gems/gibbon/CVE-2022-27311.yml
+++ b/gems/gibbon/CVE-2022-27311.yml
@@ -8,4 +8,4 @@ date: 2022-04-26
 description: Gibbon v3.4.3 and below allows attackers to execute a Server-Side Request
   Forgery (SSRF) via a crafted URL. This issue has been resolved in version 3.4.4
 patched_versions:
-- 3.4.4
+- ">= 3.4.4"


### PR DESCRIPTION
This reported CVE's fix has now been merged into gibbon, and released as 3.4.4. I've updated the description with the github sync rake task, and included the patched version.