### PR TITLE
Add missing CVSS scores for CVE-2022-29970 on sinatra

### DIFF
--- a/gems/sinatra/CVE-2022-29970.yml
+++ b/gems/sinatra/CVE-2022-29970.yml
@@ -8,5 +8,7 @@ date: 2022-05-03
 description: |
   Sinatra before 2.2.0 does not validate that the expanded path matches
   public_dir when serving static files.
+cvss_v2: 5.0
+cvss_v3: 7.5
 patched_versions:
 - ">= 2.2.0"


### PR DESCRIPTION
Saw this go by on the NIST feed and noticed that it's not here

https://nvd.nist.gov/vuln/detail/CVE-2022-29970
https://github.com/advisories/GHSA-qp49-3pvw-x4m5