### PR TITLE
Fix unsafe yaml config option in CVE-2022-32224

### DIFF
--- a/gems/activerecord/CVE-2022-32224.yml
+++ b/gems/activerecord/CVE-2022-32224.yml
@@ -48,7 +48,7 @@ description: |
   new Active Record configuration options.  The configuration options are as
   follows:
 
-  * `config.active_storage.use_yaml_unsafe_load`
+  * `config.active_record.use_yaml_unsafe_load`
 
   When set to true, this configuration option tells Rails to use the old
   "unsafe" YAML loading strategy, maintaining the existing behavior but leaving


### PR DESCRIPTION
The file for this CVE contains an Active Record config option but with `active_storage` instead of `active_record`. This doesn't work, but does work when corrected to `active_record`. I assume this was just a typo so have corrected it.