### PR TITLE
Add patched version for CVE-2021-41816 and CVE-2021-41819 on cgi

### DIFF
--- a/gems/cgi/CVE-2021-41816.yml
+++ b/gems/cgi/CVE-2021-41816.yml
@@ -18,6 +18,7 @@ description: |-
   2.6 is not vulnerable.
 cvss_v3: 7.5
 patched_versions:
+- "~> 0.1.0.1"
 - "~> 0.1.1"
 - "~> 0.2.1"
 - ">= 0.3.1"

--- a/gems/cgi/CVE-2021-41819.yml
+++ b/gems/cgi/CVE-2021-41819.yml
@@ -29,6 +29,7 @@ description: |-
     prior.
 cvss_v3: 7.5
 patched_versions:
+- "~> 0.1.0.1"
 - "~> 0.1.1"
 - "~> 0.2.1"
 - ">= 0.3.1"


### PR DESCRIPTION
Add patched version for CVE-2021-41816 and CVE-2021-41819 on cgi. These are fixed in cgi 0.1.0.1 bundled with Ruby 2.7.5 or later.

- ref: https://github.com/ruby/ruby/commit/f69aeb83146be640995753667fdd6c6f157527f5