### PR TITLE
Add patched version for CVE-2021-28965 on rexml

### DIFF
--- a/gems/rexml/CVE-2021-28965.yml
+++ b/gems/rexml/CVE-2021-28965.yml
@@ -10,4 +10,6 @@ description: |
   the one bundled with Ruby) can create a wrong XML document whose structure
   is different from the original one.
 patched_versions:
+- '~> 3.1.9.1'
+- '~> 3.2.3.1'
 - '>= 3.2.5'


### PR DESCRIPTION
Similar to https://github.com/rubysec/ruby-advisory-db/pull/511.

Add patched version for CVE-2021-28965 on rexml. This is fixed in `rexml-3.1.9.1` included in Ruby `2.6.7` (https://github.com/ruby/ruby/commit/1b59a4dc76caa061355f4289d2c54d4625671735) and `rexml-3.2.3.1` included in Ruby `2.7.3` (https://github.com/ruby/ruby/commit/b59e5a64be40b93370afbb0accfcb73c4d682045).

```
$ docker run -it --rm --name ruby ruby:2.6.7 ls -l /usr/local/lib/ruby/gems/2.6.0/specifications/default/ | grep rexml
-rw-r--r-- 1 root root  2795 Jun 23  2021 rexml-3.1.9.1.gemspec
```

```
$ docker run -it --rm --name ruby ruby:2.7.3 ls -l /usr/local/lib/ruby/gems/2.7.0/specifications/default/ | grep rexml
-rw-r--r-- 1 root root  2617 Jun 23  2021 rexml-3.2.3.1.gemspec
```