### PR TITLE
Add patched version for  CVE-2021-31799 on rdoc

### DIFF
--- a/gems/rdoc/CVE-2021-31799.yml
+++ b/gems/rdoc/CVE-2021-31799.yml
@@ -13,4 +13,6 @@ description: |
   command.
 cvss_v3: 7.0
 patched_versions:
+- "~> 6.1.2.1"
+- "~> 6.2.1.1"
 - ">= 6.3.1"


### PR DESCRIPTION
Similar to https://github.com/rubysec/ruby-advisory-db/pull/511.

Add patched version for CVE-2021-31799 on rdoc. This is fixed in `rdoc-6.1.2.1` included in Ruby `2.6.8` (https://github.com/ruby/ruby/commit/fe3c49c9baeeab58304ede915b7edd18ecf360fc) and `rdoc-6.2.1.1` included in Ruby `2.7.4` (https://github.com/ruby/ruby/commit/483f303d02e768b69e476e0b9be4ab2f26389522, https://github.com/ruby/ruby/commit/9e0e99023ddef9c0ea80dfc7f0b6924c1be95d03).

```
$ docker run -it --rm --name ruby ruby:2.6.8 ls -l /usr/local/lib/ruby/gems/2.6.0/specifications/default | grep rdoc
-rw-r--r-- 1 root root  6422 Nov 17  2021 rdoc-6.1.2.1.gemspec
```

```
$ docker run -it --rm --name ruby ruby:2.7.4 ls -l /usr/local/lib/ruby/gems/2.7.0/specifications/default | grep rdoc
-rw-r--r-- 1 root root  5309 Nov 17  2021 rdoc-6.2.1.1.gemspec
```