### PR TITLE
Jruby CVE-2022-25857

### DIFF
--- a/rubies/jruby/CVE-2022-25857.yml
+++ b/rubies/jruby/CVE-2022-25857.yml
@@ -1,0 +1,11 @@
+---
+engine: jruby
+cve: 2022-25857
+url: https://github.com/jruby/jruby/issues/7342
+title: 'CVE-2022-25857 jruby/psych/snakeyaml: Denial of Service (DoS) due missing to nested depth limitation for collections'
+date: 2022-02-24
+description: The package org.yaml:snakeyaml from 0 and before 1.31 are vulnerable to Denial of Service (DoS) due missing to nested depth limitation for collections.
+  This package is bundled into Psych which is in turn bundled into jruby.
+cvss_v3: 7.5
+patched_versions:
+- '>= 9.3.8.0'


### PR DESCRIPTION
Hello, there is a CVE for jruby, I'm not 100% sure of how I did the report as it is a transitive dependency but in the end it gets bundled into the jruby which is available for download.