### PR TITLE
add patched_versions for CVE-2022-25765

### DIFF
--- a/gems/pdfkit/CVE-2022-25765.yml
+++ b/gems/pdfkit/CVE-2022-25765.yml
@@ -13,3 +13,5 @@ related:
   url:
   - "https://github.com/pdfkit/pdfkit/blob/master/lib/pdfkit/source.rb#L44-L50"
   - https://security.snyk.io/vuln/SNYK-RUBY-PDFKIT-2869795
+patched_versions:
+  - '>= 0.8.7'


### PR DESCRIPTION
Hi, it's look like [CVE-2022-25765](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25765) was fixed in [0.8.7v](https://github.com/pdfkit/pdfkit/releases).

closes #517 