### PR TITLE
Ruby: CVE-2021-33621

### DIFF
--- a/rubies/ruby/CVE-2021-33621.yml
+++ b/rubies/ruby/CVE-2021-33621.yml
@@ -1,0 +1,13 @@
+---
+engine: ruby
+cve: 2021-33621
+url: https://www.ruby-lang.org/en/news/2022/11/22/http-response-splitting-in-cgi-cve-2021-33621/
+title: HTTP response splitting in CGI
+date: 2022-11-22
+description: |
+  If an application that generates HTTP responses using the cgi gem with untrusted user input, an attacker can exploit it to inject a malicious HTTP response header and/or body.
+
+  Also, the contents for a CGI::Cookie object were not checked properly. If an application creates a CGI::Cookie object based on user input, an attacker may exploit it to inject invalid attributes in Set-Cookie header. We think such applications are unlikely, but we have included a change to check arguments for CGI::Cookie#initialize preventatively.
+cvss_v3: 8.8
+patched_versions:
+- '>= 3.0.5'


### PR DESCRIPTION
Add latest ruby cve: 

- https://www.ruby-lang.org/en/news/2022/11/24/ruby-3-0-5-released/
- https://www.ruby-lang.org/en/news/2022/11/22/http-response-splitting-in-cgi-cve-2021-33621/