### PR TITLE
Backfill old nokogiri vulnerability report

### DIFF
--- a/gems/nokogiri/CVE-2017-18258.yml
+++ b/gems/nokogiri/CVE-2017-18258.yml
@@ -1,0 +1,24 @@
+---
+gem: nokogiri
+cve: 2017-18258
+ghsa: 882p-jqgm-f45g
+url: https://git.gnome.org/browse/libxml2/commit/?id=e2a9122b8dde53d320750451e9907a7dcb2ca8bb
+title: Moderate severity vulnerability that affects nokogiri
+date: 2018-04-13
+description: |
+  The xz_head function in xzlib.c in libxml2 before 2.9.6 allows remote attackers to cause a denial
+  of service (memory consumption) via a crafted LZMA file, because the decoder functionality does
+  not restrict memory usage to what is required for a legitimate file.
+
+  References:
+  - https://nvd.nist.gov/vuln/detail/CVE-2017-18258
+  - https://git.gnome.org/browse/libxml2/commit/?id=e2a9122b8dde53d320750451e9907a7dcb2ca8bb
+  - https://github.com/advisories/GHSA-882p-jqgm-f45g
+  - https://kc.mcafee.com/corporate/index?page=content&id=SB10284
+  - https://lists.debian.org/debian-lts-announce/2018/09/msg00035.html
+  - https://lists.debian.org/debian-lts-announce/2020/09/msg00009.html
+  - https://security.netapp.com/advisory/ntap-20190719-0001/
+  - https://usn.ubuntu.com/3739-1/
+cvss_v3: 6.5
+patched_versions:
+- ">= 1.8.2"

--- a/gems/nokogiri/CVE-2022-23476.yml
+++ b/gems/nokogiri/CVE-2022-23476.yml
@@ -1,3 +1,4 @@
+---
 gem: nokogiri
 cve: 2022-23476
 ghsa: qv4q-mr5r-qprj


### PR DESCRIPTION
I noticed that the sync task was pulling in an additional GHSA that was not added by the nokogiri maintainers, https://github.com/advisories/GHSA-882p-jqgm-f45g for CVE-2017-18258. This PR backfills that vulnerability.

Also, rename gems/nokogiri/GHSA-qv4q-mr5r-qprj.yml to gems/nokogiri/CVE-2022-23476.yml to reflect the filename convention used by the sync task.

gems/nokogiri is now up to date with github's advisory database.