### PR TITLE
feat: allow the sync task to run for just a single gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,16 @@ The GitHub Advisory API requires a token to access it.
 - It can be a completely scopeless token (recommended); it does not require any permissions at all.
 - Get yours at https://github.com/settings/tokens
 
-To run the GitHub Advisory sync, start by executing the rake task:
+To run the GitHub Advisory sync to retrieve all advisories, start by executing the rake task:
+
 ```
 GH_API_TOKEN=<your GitHub API Token> bundle exec rake sync_github_advisories
+```
+
+Or, to only retrieve advisories for a single gem:
+
+```
+GH_API_TOKEN=<your GitHub API Token> bundle exec rake sync_github_advisories[gem_name]
 ```
 
 - The rake task will write yaml files for any missing advisories.

--- a/Rakefile
+++ b/Rakefile
@@ -13,9 +13,9 @@ namespace :lint do
 end
 
 desc "Sync GitHub RubyGem Advisories into this project"
-task :sync_github_advisories do
+task :sync_github_advisories, [:gem_name] do |_, args|
   require_relative "lib/github_advisory_sync"
-  GitHub::GitHubAdvisorySync.sync
+  GitHub::GitHubAdvisorySync.sync(gem_name: args[:gem_name])
 end
 
 task :lint    => ['lint:yaml']


### PR DESCRIPTION
As a gem maintainer, when I want to add an advisory to the database I either have to start from scratch and write a YAML file by hand, or else run the task to sync the entire database which will create a number of files for gems that I don't maintain and then need to `git clean`.

To make this workflow a bit easier for gem maintainers, this PR adds the ability to pass a single gem name to the rake task, e.g.:

```
rake sync_github_advisories[nokogiri]
```

The output will be something like:

```
Getting page 1 of GitHub Vulnerabilities
Executing GraphQL request: RUBYGEM_VULNERABILITIES_WITH_GITHUB_ADVISORIES. Request variables:
---
first: 100
gem_name: nokogiri

Initializing GitHub API connection to URL: https://api.github.com/graphql
Got response code: 200
Retrieved 24 Vulnerabilities from GitHub API
Wrote: gems/nokogiri/CVE-2022-23476.yml
Wrote: gems/nokogiri/CVE-2017-18258.yml

Sync completed
Wrote these files:
---
- gems/nokogiri/CVE-2022-23476.yml
- gems/nokogiri/CVE-2017-18258.yml

```

Note that running the task without a gem name argument will still sync the entire database.