### PR TITLE
Fix for CVE-2021-33621

### DIFF
--- a/rubies/ruby/CVE-2021-33621.yml
+++ b/rubies/ruby/CVE-2021-33621.yml
@@ -10,4 +10,6 @@ description: |
   Also, the contents for a CGI::Cookie object were not checked properly. If an application creates a CGI::Cookie object based on user input, an attacker may exploit it to inject invalid attributes in Set-Cookie header. We think such applications are unlikely, but we have included a change to check arguments for CGI::Cookie#initialize preventatively.
 cvss_v3: 8.8
 patched_versions:
-- '>= 3.0.5'
+- '~> 2.7.7'
+- '~> 3.0.5'
+- '>= 3.1.3'


### PR DESCRIPTION
Ruby 2.7.7 and 3.1.3 also has the security fix