### PR TITLE
fix: remove credits and use `related` for references

### DIFF
--- a/gems/loofah/CVE-2022-23514.yml
+++ b/gems/loofah/CVE-2022-23514.yml
@@ -10,26 +10,13 @@ description: |
 
   Loofah `< 2.19.1` contains an inefficient regular expression that is susceptible to excessive backtracking when attempting to sanitize certain SVG attributes. This may lead to a denial of service through CPU resource consumption.
 
-
   ## Mitigation
 
   Upgrade to Loofah `>= 2.19.1`.
-
-
-  ## Severity
-
-  The Loofah maintainers have evaluated this as [High Severity 7.5 (CVSS3.1)](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H).
-
-
-  ## References
-
-  - [CWE - CWE-1333: Inefficient Regular Expression Complexity (4.9)](https://cwe.mitre.org/data/definitions/1333.html)
-  - https://hackerone.com/reports/1684163
-
-
-  ## Credit
-
-  This vulnerability was responsibly reported by @ooooooo-q (https://github.com/ooooooo-q).
 cvss_v3: 7.5
 patched_versions:
   - ">= 2.19.1"
+related:
+  url:
+    - https://cwe.mitre.org/data/definitions/1333.html
+    - https://hackerone.com/reports/1684163

--- a/gems/loofah/CVE-2022-23515.yml
+++ b/gems/loofah/CVE-2022-23515.yml
@@ -10,29 +10,17 @@ description: |
 
   Loofah `>= 2.1.0, < 2.19.1` is vulnerable to cross-site scripting via the `image/svg+xml` media type in data URIs.
 
-
   ## Mitigation
 
   Upgrade to Loofah `>= 2.19.1`.
-
-
-  ## Severity
-
-  The Loofah maintainers have evaluated this as [Medium Severity 6.1](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N).
-
-
-  ## References
-
-  - [CWE - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') (4.9)](https://cwe.mitre.org/data/definitions/79.html)
-  - [SVG MIME Type (image/svg+xml) is misleading to developers · Issue #266 · w3c/svgwg](https://github.com/w3c/svgwg/issues/266)
-  - https://hackerone.com/reports/1694173
-  - https://github.com/flavorjones/loofah/issues/101
-
-  ## Credit
-
-  This vulnerability was responsibly reported by Maciej Piechota (@haqpl).
 cvss_v3: 6.1
 unaffected_versions:
   - "< 2.1.0"
 patched_versions:
   - ">= 2.19.1"
+related:
+  url:
+    - https://cwe.mitre.org/data/definitions/79.html
+    - https://github.com/w3c/svgwg/issues/266
+    - https://hackerone.com/reports/1694173
+    - https://github.com/flavorjones/loofah/issues/101

--- a/gems/loofah/CVE-2022-23516.yml
+++ b/gems/loofah/CVE-2022-23516.yml
@@ -10,24 +10,16 @@ description: |
 
   Loofah `>= 2.2.0, < 2.19.1` uses recursion for sanitizing `CDATA` sections, making it susceptible to stack exhaustion and raising a `SystemStackError` exception.  This may lead to a denial of service through CPU resource consumption.
 
-
   ## Mitigation
 
   Upgrade to Loofah `>= 2.19.1`.
 
   Users who are unable to upgrade may be able to mitigate this vulnerability by limiting the length of the strings that are sanitized.
-
-
-  ## Severity
-
-  The Loofah maintainers have evaluated this as [High Severity 7.5 (CVSS3.1)](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H).
-
-
-  ## References
-
-  - [CWE - CWE-674: Uncontrolled Recursion (4.9)](https://cwe.mitre.org/data/definitions/674.html)
 cvss_v3: 7.5
 unaffected_versions:
   - "< 2.2.0"
 patched_versions:
   - ">= 2.19.1"
+related:
+  url:
+    - https://cwe.mitre.org/data/definitions/674.html

--- a/gems/rails-html-sanitizer/CVE-2022-23517.yml
+++ b/gems/rails-html-sanitizer/CVE-2022-23517.yml
@@ -10,26 +10,13 @@ description: |
 
   Certain configurations of rails-html-sanitizer `< 1.4.4` use an inefficient regular expression that is susceptible to excessive backtracking when attempting to sanitize certain SVG attributes. This may lead to a denial of service through CPU resource consumption.
 
-
   ## Mitigation
 
   Upgrade to rails-html-sanitizer `>= 1.4.4`.
-
-
-  ## Severity
-
-  The maintainers have evaluated this as [High Severity 7.5 (CVSS3.1)](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H).
-
-
-  ## References
-
-  - [CWE - CWE-1333: Inefficient Regular Expression Complexity (4.9)](https://cwe.mitre.org/data/definitions/1333.html)
-  - https://hackerone.com/reports/1684163
-
-
-  ## Credit
-
-  This vulnerability was responsibly reported by @ooooooo-q (https://github.com/ooooooo-q).
 cvss_v3: 7.5
 patched_versions:
   - ">= 1.4.4"
+related:
+  url:
+    - https://cwe.mitre.org/data/definitions/1333.html
+    - https://hackerone.com/reports/1684163

--- a/gems/rails-html-sanitizer/CVE-2022-23518.yml
+++ b/gems/rails-html-sanitizer/CVE-2022-23518.yml
@@ -10,30 +10,17 @@ description: |
 
   rails-html-sanitizer `>= 1.0.3, < 1.4.4` is vulnerable to cross-site scripting via data URIs when used in combination with Loofah `>= 2.1.0`.
 
-
   ## Mitigation
 
   Upgrade to rails-html-sanitizer `>= 1.4.4`.
-
-
-  ## Severity
-
-  The maintainers have evaluated this as [Medium Severity 6.1](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N).
-
-
-  ## References
-
-  - [CWE - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') (4.9)](https://cwe.mitre.org/data/definitions/79.html)
-  - [SVG MIME Type (image/svg+xml) is misleading to developers · Issue #266 · w3c/svgwg](https://github.com/w3c/svgwg/issues/266)
-  - https://github.com/rails/rails-html-sanitizer/issues/135
-  - https://hackerone.com/reports/1694173
-
-
-  ## Credit
-
-  This vulnerability was independently reported by Maciej Piechota (@haqpl) and Mrinmoy Das (@goromlagche).
 cvss_v3: 6.1
 unaffected_versions:
   - "< 1.0.3"
 patched_versions:
   - ">= 1.4.4"
+related:
+  url:
+    - https://cwe.mitre.org/data/definitions/79.html
+    - https://github.com/w3c/svgwg/issues/266
+    - https://github.com/rails/rails-html-sanitizer/issues/135
+    - https://hackerone.com/reports/1694173

--- a/gems/rails-html-sanitizer/CVE-2022-23519.yml
+++ b/gems/rails-html-sanitizer/CVE-2022-23519.yml
@@ -14,7 +14,6 @@ description: |
   - Not affected: NONE
   - Fixed versions: 1.4.4
 
-
   ## Impact
 
   A possible XSS vulnerability with certain configurations of Rails::Html::Sanitizer may allow an attacker to inject content if the application developer has overridden the sanitizer's allowed tags in either of the following ways:
@@ -65,20 +64,12 @@ description: |
 
   All users overriding the allowed tags by any of the above mechanisms to include (("math" or "svg") and "style") should either upgrade or use one of the workarounds immediately.
 
-
   ## Workarounds
 
   Remove "style" from the overridden allowed tags, or remove "math" and "svg" from the overridden allowed tags.
-
-
-  ## References
-
-  - [CWE - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') (4.9)](https://cwe.mitre.org/data/definitions/79.html)
-  - https://hackerone.com/reports/1656627
-
-
-  ## Credit
-
-  This vulnerability was responsibly reported by Dominic Breuker.
 patched_versions:
   - ">= 1.4.4"
+related:
+  url:
+    - https://cwe.mitre.org/data/definitions/79.html
+    - https://hackerone.com/reports/1656627

--- a/gems/rails-html-sanitizer/CVE-2022-23520.yml
+++ b/gems/rails-html-sanitizer/CVE-2022-23520.yml
@@ -14,7 +14,6 @@ description: |
   - Not affected: NONE
   - Fixed versions: 1.4.4
 
-
   ## Impact
 
   A possible XSS vulnerability with certain configurations of Rails::Html::Sanitizer may allow an attacker to inject content if the application developer has overridden the sanitizer's allowed tags to allow both "select" and "style" elements.
@@ -44,21 +43,14 @@ description: |
   - the `:tags` option to the Action View helper method `sanitize`.
   - the `:tags` option to the instance method `SafeListSanitizer#sanitize`.
 
-
   ## Workarounds
 
   Remove either "select" or "style" from the overridden allowed tags.
-
-
-  ## References
-
-  - [CWE - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') (4.9)](https://cwe.mitre.org/data/definitions/79.html)
-  - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32209
-  - https://hackerone.com/reports/1654310
-
-
-  ## Credit
-
-  This vulnerability was responsibly reported by Dominic Breuker.
 patched_versions:
   - ">= 1.4.4"
+related:
+  cve:
+    - 2022-32209
+  url:
+    - https://cwe.mitre.org/data/definitions/79.html
+    - https://hackerone.com/reports/1654310


### PR DESCRIPTION
Per comments at #531, remove credits and use `related` for references. Also remove redundant CVE information from descriptions.