### PR TITLE
Added CVE-2022-46648.

### DIFF
--- a/gems/git/CVE-2022-46648.yml
+++ b/gems/git/CVE-2022-46648.yml
@@ -1,0 +1,24 @@
+---
+gem: git
+cve: 2022-46648
+url: https://github.com/ruby-git/ruby-git/pull/602
+title: Potential remote code execution in ruby-git
+date: 2023-01-05
+description: |
+  The git gem, between versions 1.2.0 and 1.12.0, incorrectly parsed the output
+  of the 'git ls-files' command using eval() to unescape quoted file names.
+  If a file name was added to the git repository contained special characters,
+  such as '\n', then the 'git ls-files' command would print the file name in
+  quotes and escape any special characters.
+  If the 'Git#ls_files' method encountered a quoted file name it would use
+  eval() to unquote and unescape any special characters, leading to potential
+  remote code execution. Version 1.13.0 of the git gem was released which
+  correctly parses any quoted file names.
+cvss_v3: 5.5
+patched_versions:
+  - '>= 1.13.0'
+unaffected_versions:
+  - '< 1.2.0'
+related:
+  url:
+    - https://github.com/ruby-git/ruby-git/releases/tag/v1.13.0


### PR DESCRIPTION
This CVE is reserved but not public yet, but the vulnerability has been fixed via a pull request and version 1.13.0 of the git gem has been released.

The only other information I could find on CVE-2022-46648 are:

* https://github.com/ruby-git/ruby-git/pull/602/files
* https://jvn.jp/jp/JVN16765254/index.html
* https://www.cybersecurity-help.cz/vdb/SB2023010501
  * Note, their vulnerable version range is incorrect. I checked the version tags for ruby-git, and `eval()` was added in 1.2.0. Versions prior to 1.2.0 do not have the `eval()`.
    https://github.com/ruby-git/ruby-git/commit/ee90922f3da3f67ef19853a0759c1d09860fe3b3