### PR TITLE
Added CVE-2023-27530 for rack

### DIFF
--- a/gems/rack/CVE-2023-27530.yml
+++ b/gems/rack/CVE-2023-27530.yml
@@ -1,0 +1,23 @@
+---
+gem: rack
+cve: 2023-27530
+url: https://discuss.rubyonrails.org/t/cve-2023-27530-possible-dos-vulnerability-in-multipart-mime-parsing/82388
+title: Possible DoS Vulnerability in Multipart MIME parsing
+date: 2023-03-03
+description: |
+  There is a possible DoS vulnerability in the Multipart MIME parsing code in Rack. This vulnerability has been assigned the CVE identifier CVE-2023-27530.
+
+  Versions Affected: All. Not affected: None Fixed Versions: 3.0.4.2, 2.2.6.3, 2.1.4.3, 2.0.9.3
+
+  # Impact
+  The Multipart MIME parsing code in Rack limits the number of file parts, but does not limit the total number of parts that can be uploaded. Carefully crafted requests can abuse this and cause multipart parsing to take longer than expected.
+
+  All users running an affected release should either upgrade or use one of the workarounds immediately.
+
+  # Workarounds
+  A proxy can be configured to limit the POST body size which will mitigate this issue.
+patched_versions:
+- "~> 2.0.9, >= 2.0.9.3"
+- "~> 2.1.4, >= 2.1.4.3"
+- "~> 2.2.6, >= 2.2.6.3"
+- ">= 3.0.4.2"


### PR DESCRIPTION
Hello,

There is this new CVE for rack that has been reported some days ago: https://discuss.rubyonrails.org/t/cve-2023-27530-possible-dos-vulnerability-in-multipart-mime-parsing/82388