### PR TITLE
Added CVE-2023-27539 for rack

### DIFF
--- a/gems/rack/CVE-2023-27539.yml
+++ b/gems/rack/CVE-2023-27539.yml
@@ -1,0 +1,20 @@
+---
+gem: rack
+cve: 2023-27539
+url: https://discuss.rubyonrails.org/t/cve-2023-27539-possible-denial-of-service-vulnerability-in-racks-header-parsing/82466
+title: Possible Denial of Service Vulnerability in Rack’s header parsing
+date: 2023-03-13
+description: |
+  There is a denial of service vulnerability in the header parsing component of Rack. This vulnerability has been assigned the CVE identifier CVE-2023-27539.
+
+  Versions Affected: >= 2.0.0 Not affected: None. Fixed Versions: 2.2.6.4, 3.0.6.1
+
+  # Impact
+  Carefully crafted input can cause header parsing in Rack to take an unexpected amount of time, possibly resulting in a denial of service attack vector. Any applications that parse headers using Rack (virtually all Rails applications) are impacted.
+
+  # Workarounds
+  Setting Regexp.timeout in Ruby 3.2 is a possible workaround.
+
+patched_versions:
+- "~> 2.0, >= 2.2.6.4"
+- ">= 3.0.6.1"


### PR DESCRIPTION
Hello,

There is this new CVE for rack that has been reported some days ago: https://discuss.rubyonrails.org/t/cve-2023-27539-possible-denial-of-service-vulnerability-in-racks-header-parsing/82466