### PR TITLE
Add CVE-2023-28120 for ActiveSupport

### DIFF
--- a/gems/activesupport/CVE-2023-28120.yml
+++ b/gems/activesupport/CVE-2023-28120.yml
@@ -1,0 +1,29 @@
+---
+gem: activesupport
+framework: rails
+cve: 2023-28120
+url: https://discuss.rubyonrails.org/t/cve-2023-28120-possible-xss-security-vulnerability-in-safebuffer-bytesplice/82469
+title: Possible XSS Security Vulnerability in SafeBuffer#bytesplice
+date: 2023-03-13
+description: |
+  There is a vulnerability in ActiveSupport if the new bytesplice method is called on a SafeBuffer with untrusted user input.
+  This vulnerability has been assigned the CVE identifier CVE-2023-28120.
+
+  Versions Affected: All. Not affected: None Fixed Versions: 7.0.4.3, 6.1.7.3
+
+  # Impact
+
+  ActiveSupport uses the SafeBuffer string subclass to tag strings as html_safe after they have been sanitized.
+  When these strings are mutated, the tag is should be removed to mark them as no longer being html_safe.
+
+  Ruby 3.2 introduced a new bytesplice method which ActiveSupport did not yet understand to be a mutation. 
+  Users on older versions of Ruby are likely unaffected.
+
+  All users running an affected release and using bytesplice should either upgrade or use one of the workarounds immediately.
+
+  # Workarounds
+
+  Avoid calling bytesplice on a SafeBuffer (html_safe) string with untrusted user input.
+patched_versions:
+- "~> 6.1.7, >= 6.1.7.3"
+- "~> 7.0.4, >= 7.0.4.3"

--- a/gems/activesupport/CVE-2023-28120.yml
+++ b/gems/activesupport/CVE-2023-28120.yml
@@ -16,7 +16,7 @@ description: |
   ActiveSupport uses the SafeBuffer string subclass to tag strings as html_safe after they have been sanitized.
   When these strings are mutated, the tag is should be removed to mark them as no longer being html_safe.
 
-  Ruby 3.2 introduced a new bytesplice method which ActiveSupport did not yet understand to be a mutation. 
+  Ruby 3.2 introduced a new bytesplice method which ActiveSupport did not yet understand to be a mutation.
   Users on older versions of Ruby are likely unaffected.
 
   All users running an affected release and using bytesplice should either upgrade or use one of the workarounds immediately.

--- a/gems/activesupport/CVE-2023-28120.yml
+++ b/gems/activesupport/CVE-2023-28120.yml
@@ -26,4 +26,4 @@ description: |
   Avoid calling bytesplice on a SafeBuffer (html_safe) string with untrusted user input.
 patched_versions:
 - "~> 6.1.7, >= 6.1.7.3"
-- "~> 7.0.4, >= 7.0.4.3"
+- ">= 7.0.4.3"


### PR DESCRIPTION
Hello

A possible XSS vulnerability in ActiveSupport was recently discovered. 

The CVE identifier CVE-2023-28120 has been reserved: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-28120