### PR TITLE
Two recent 2 Rails-related Advisories

### DIFF
--- a/gems/actionview/CVE-2023-23913.yml
+++ b/gems/actionview/CVE-2023-23913.yml
@@ -1,0 +1,72 @@
+---
+gem: actionview
+framework: rails
+cve: 2023-23913
+url: https://discuss.rubyonrails.org/t/cve-2023-23913-dom-based-cross-site-scripting-in-rails-ujs-for-contenteditable-html-elements/82468
+title: DOM Based Cross-site Scripting in rails-ujs for contenteditable HTML Elements
+date: 2023-03-13
+description: |
+
+  NOTE: rails-ujs is part of Rails/actionview since 5.1.0.
+
+  There is a potential DOM based cross-site scripting issue in rails-ujs
+  which leverages the Clipboard API to target HTML elements that are
+  assigned the contenteditable attribute. This has the potential to occur
+  when pasting malicious HTML content from the clipboard that includes a
+  data-method, data-remote or data-disable-with attribute.
+
+  This vulnerability has been assigned the CVE identifier CVE-2023-23913.
+
+  Versions Affected: >= 5.1.0 Not affected: < 5.1.0
+  Fixed Versions: 6.1.7.3, 7.0.4.3
+
+  Impact
+    If the specified malicious HTML clipboard content is provided to a
+    contenteditable element, this could result in the arbitrary execution
+    of javascript on the origin in question.
+
+  Releases
+    The FIXED releases are available at the normal locations.
+
+  Workarounds
+    We recommend that all users upgrade to one of the FIXED versions.
+    In the meantime, users can attempt to mitigate this vulnerability
+    by removing the contenteditable attribute from elements in pages
+    that rails-ujs will interact with.
+
+  Patches
+    To aid users who aren’t able to upgrade immediately we have provided
+    patches for the two supported release series. They are in git-am
+    format and consist of a single changeset.
+
+  * rails-ujs-data-method-contenteditable-6-1.patch - Patch for 6.1 series
+  * rails-ujs-data-method-contenteditable-7-0.patch - Patch for 7.0 series
+
+  Please note that only the 7.0.Z and 6.1.Z series are supported at
+  present, and 6.0.Z for severe vulnerabilities.
+
+  Users of earlier unsupported releases are advised to upgrade as soon
+  as possible as we cannot guarantee the continued availability of
+  security fixes for unsupported releases.
+
+  Credits
+    We would like to thank ryotak 15 for reporting this!
+
+  * rails-ujs-data-method-contenteditable-6-1.patch (8.5 KB)
+  * rails-ujs-data-method-contenteditable-7-0.patch (8.5 KB)
+  * rails-ujs-data-method-contenteditable-main.patch (8.9 KB)
+
+cvss_v3: 7.5
+patched_versions:
+ - '~> 6.1.7.3'
+ - '>= 7.0.4.3'
+related:
+ url:
+  - https://discuss.rubyonrails.org/t/cve-2023-23913-dom-based-cross-site-scripting-in-rails-ujs-for-contenteditable-html-elements/82468
+  - https://vulmon.com/vendoradvisory?qidtp=debian_cvelist_bugreportlogs&qid=aa67066c383f12dee5aee964667de4d8
+  - https://github.com/cloudsecurityalliance/gsd-database/blob/main/2023/29xxx/GSD-2023-29013.json
+  - https://access.redhat.com/security/cve/cve-2023-23913
+  - https://bugzilla.redhat.com/show_bug.cgi?id=2182160
+  - https://github.com/cloudsecurityalliance/gsd-database/blob/main/2023/29xxx/GSD-2023-29013.json
+
+# NOTES: No values for [library, platform, osvdb, ghsa, unaffected_versions] fields.

--- a/gems/kredis/CVE-2023-27531.yml
+++ b/gems/kredis/CVE-2023-27531.yml
@@ -1,0 +1,45 @@
+---
+gem: kredis
+framework: rails
+cve: 2023-27531
+url: https://discuss.rubyonrails.org/t/cve-2023-27531-possible-deserialization-of-untrusted-data-vulnerability-in-kredis-json/82467#post_1
+title: Possible Deserialization of Untrusted Data Vulnerability in Kredis JSON
+date: 2023-03-13
+description: |
+    There is a deserialization of untrusted data vulnerability in
+    the Kredis JSON deserialization code. This vulnerability has
+    been assigned the CVE identifier CVE-2023-27531.
+
+    Versions Affected: All. Not affected: None. Fixed Versions: 1.3.0.1
+
+    Impact
+      Carefully crafted JSON data processed by Kredis may result in
+      deserialization of untrusted data, potentially leading to
+      deserialization of unexpected objects in the system.
+
+      Any applications using Kredis with JSON are affected.
+
+    Releases
+      The fixed releases are available at the normal locations.
+
+    Workarounds
+      There are no feasible workarounds for this issue.
+
+    Patches
+      To aid users who aren’t able to upgrade immediately we have
+      provided patches for the two supported release series. They
+      are in git-am format and consist of a single changeset.
+
+      1-3-0-1-kredis.patch - Patch for 1.3.0 series
+
+     Credits
+      Thank you ooooooo_k 7 for reporting this!
+
+patched_versions:
+ - '>= 1.3.0.1'
+related:
+ url:
+  - https://github.com/rails/kredis/releases/tag/v1.3.0.1
+  - https://discuss.rubyonrails.org/t/cve-2023-27531-possible-deserialization-of-untrusted-data-vulnerability-in-kredis-json/82467#post_1
+
+# NOTES: No [osvdb, ghsa, cvss_v2, cvss-v3] values. Blank CVE.


### PR DESCRIPTION
Added two recent Rails-related Advisories mentioned in this issue: https://github.com/rubysec/ruby-advisory-db/issues/552
```
	new file:   gems/actionview/CVE-2023-23913.yml
	new file:   gems/kredis/CVE-2023-27531.yml
```
