### PR TITLE
Modified github_advisory_sync.rb's new_data variable to add 'patched_versions' and related:'s url…

### DIFF
--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -351,9 +351,9 @@ module GitHub
       File.open(filename_to_write, "w") do |file|
         # create an automatically generated advisory yaml file
         file.write new_data.merge(
-          { "patched_versions" => vulnerabilities },
-          { "related" => { "url"  => advisory["references"] } }
-        ).to_yaml
+          { "patched_versions" => vulnerabilities,
+            "related" => { "url"  => advisory["references"] }
+          } ).to_yaml
 
         # The data we just wrote is incomplete,
         # and therefore should not be committed as is

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -352,7 +352,7 @@ module GitHub
         # create an automatically generated advisory yaml file
         file.write new_data.merge(
           { "patched_versions" => vulnerabilities },
-          { "related:\nurl:"  => advisory["references"] }
+          { "related" => { "url"  => advisory["references"] } }
         ).to_yaml
 
         # The data we just wrote is incomplete,

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -350,7 +350,10 @@ module GitHub
       Dir.mkdir dir_to_write unless Dir.exist?(dir_to_write)
       File.open(filename_to_write, "w") do |file|
         # create an automatically generated advisory yaml file
-        file.write new_data.to_yaml
+        file.write new_data.merge(
+          { "patched_versions" => vulnerabilities },
+          { "related:\nurl:"  => advisory["references"] }
+        ).to_yaml
 
         # The data we just wrote is incomplete,
         # and therefore should not be committed as is


### PR DESCRIPTION
Modified github_advisory_sync.rb's **new_data** variable to add the "patched_versions" and "related:'"/"url:" sections.

The new (unreleased 1-line shell) post processor does the rest to get GHSA files ready for ruby-advisory-db repo. Long term this shell will be turned into Ruby code.