### PR TITLE
Advisory for gems/bootstrap/CVE-2018-14042.yml

### DIFF
--- a/gems/bootstrap/CVE-2018-14042.yml
+++ b/gems/bootstrap/CVE-2018-14042.yml
@@ -1,0 +1,33 @@
+---
+gem: bootstrap
+cve: 2018-14042
+ghsa: 7mvr-5x2g-wfc8
+url: https://github.com/twbs/bootstrap/issues/26423
+title: Bootstrap Cross-site Scripting vulnerability
+date: 2018-09-13
+description:
+  In Bootstrap before 4.1.2, XSS is possible in the data-container property
+  of tooltip.  This is similar to CVE-2018-14041.
+cvss_v3: 6.1
+patched_versions:
+  - '>= 4.1.2'
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-14042
+    - https://github.com/twbs/bootstrap/issues/26423
+    - https://github.com/twbs/bootstrap/issues/26628
+    - https://github.com/twbs/bootstrap/pull/26630
+    - https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2/
+    - https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@
+    - https://lists.apache.org/thread.html/52e0e6b5df827ee7f1e68f7cc3babe61af3b2160f5d74a85469b7b0e@
+    - https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@
+    - https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@
+    - https://lists.apache.org/thread.html/r3dc0cac8d856bca02bd6997355d7ff83027dcfc82f8646a29b89b714@
+    - https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@
+    - https://seclists.org/bugtraq/2019/May/18
+    - https://www.oracle.com/security-alerts/cpuApr2021.html
+    - http://packetstormsecurity.com/files/156743/OctoberCMS-Insecure-Dependencies.html
+    - http://seclists.org/fulldisclosure/2019/May/10
+    - http://seclists.org/fulldisclosure/2019/May/11
+    - http://seclists.org/fulldisclosure/2019/May/13
+    - https://github.com/advisories/GHSA-7mvr-5x2g-wfc8


### PR DESCRIPTION
Advisory for gems/bootstrap/CVE-2018-14042.yml

* Only one left dated 2015 to present 
* Result of  lib/github_advisory_sync.rb run + post processor + manual "patched_versions" field
* Clean yamllint and rake runs