### PR TITLE
[GHSA SYNC2] Adding four advisories based on CVE-2014-3248 advisory

### DIFF
--- a/gems/bootstrap/CVE-2018-14042.yml
+++ b/gems/bootstrap/CVE-2018-14042.yml
@@ -2,7 +2,7 @@
 gem: bootstrap
 cve: 2018-14042
 ghsa: 7mvr-5x2g-wfc8
-url: https://github.com/twbs/bootstrap/issues/26423
+url: https://github.com/twbs/bootstrap/issues/26428
 title: Bootstrap Cross-site Scripting vulnerability
 date: 2018-09-13
 description:

--- a/gems/bootstrap/CVE-2018-14042.yml
+++ b/gems/bootstrap/CVE-2018-14042.yml
@@ -1,0 +1,33 @@
+---
+gem: bootstrap
+cve: 2018-14042
+ghsa: 7mvr-5x2g-wfc8
+url: https://github.com/twbs/bootstrap/issues/26423
+title: Bootstrap Cross-site Scripting vulnerability
+date: 2018-09-13
+description:
+  In Bootstrap before 4.1.2, XSS is possible in the data-container property
+  of tooltip.  This is similar to CVE-2018-14041.
+cvss_v3: 6.1
+patched_versions:
+  - '>= 4.1.2'
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-14042
+    - https://github.com/twbs/bootstrap/issues/26423
+    - https://github.com/twbs/bootstrap/issues/26628
+    - https://github.com/twbs/bootstrap/pull/26630
+    - https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2/
+    - https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@
+    - https://lists.apache.org/thread.html/52e0e6b5df827ee7f1e68f7cc3babe61af3b2160f5d74a85469b7b0e@
+    - https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@
+    - https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@
+    - https://lists.apache.org/thread.html/r3dc0cac8d856bca02bd6997355d7ff83027dcfc82f8646a29b89b714@
+    - https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@
+    - https://seclists.org/bugtraq/2019/May/18
+    - https://www.oracle.com/security-alerts/cpuApr2021.html
+    - http://packetstormsecurity.com/files/156743/OctoberCMS-Insecure-Dependencies.html
+    - http://seclists.org/fulldisclosure/2019/May/10
+    - http://seclists.org/fulldisclosure/2019/May/11
+    - http://seclists.org/fulldisclosure/2019/May/13
+    - https://github.com/advisories/GHSA-7mvr-5x2g-wfc8

--- a/gems/facter/CVE-2014-3248.yml
+++ b/gems/facter/CVE-2014-3248.yml
@@ -1,0 +1,28 @@
+---
+gem: facter
+cve: 2014-3248
+ghsa: 92v7-pq4h-58j5
+url: https://github.com/advisories/GHSA-92v7-pq4h-58j5
+title: Moderate severity vulnerability that affects facter, hiera, mcollective-client, and puppet
+date: 2017-10-24
+description:
+  Untrusted search path vulnerability in Puppet Enterprise 2.8 before 2.8.7,
+  Puppet before 2.7.26 and 3.x before 3.6.2, Facter 1.6.x and 2.x before 2.0.2, Hiera
+  before 1.3.4, and Mcollective before 2.5.2, when running with Ruby 1.9.1 or earlier,
+  allows local users to gain privileges via a Trojan horse file in the current working
+  directory, as demonstrated using (1) rubygems/defaults/operating_system.rb, (2)
+  Win32API.rb, (3) Win32API.so, (4) safe_yaml.rb, (5) safe_yaml/deep.rb, or (6) safe_yaml/deep.so;
+  or (7) operatingsystem.rb, (8) operatingsystem.so, (9) osfamily.rb, or (10) osfamily.so
+  in puppet/confine.
+patched_versions:
+  - '~> 1.7.6'
+  - '>= 2.0.2'
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-3248
+    - https://github.com/advisories/GHSA-92v7-pq4h-58j5
+    - http://puppetlabs.com/security/cve/cve-2014-3248
+    - http://rowediness.com/2014/06/13/cve-2014-3248-a-little-problem-with-puppet/
+    - http://secunia.com/advisories/59197
+    - http://secunia.com/advisories/59200
+    - http://www.securityfocus.com/bid/68035

--- a/gems/hiera/CVE-2014-3248.yml
+++ b/gems/hiera/CVE-2014-3248.yml
@@ -1,0 +1,27 @@
+---
+gem: hiera
+cve: 2014-3248
+ghsa: 92v7-pq4h-58j5
+url: https://github.com/advisories/GHSA-92v7-pq4h-58j5
+title: Moderate severity vulnerability that affects facter, hiera, mcollective-client, and puppet
+date: 2017-10-24
+description:
+  Untrusted search path vulnerability in Puppet Enterprise 2.8 before 2.8.7,
+  Puppet before 2.7.26 and 3.x before 3.6.2, Facter 1.6.x and 2.x before 2.0.2, Hiera
+  before 1.3.4, and Mcollective before 2.5.2, when running with Ruby 1.9.1 or earlier,
+  allows local users to gain privileges via a Trojan horse file in the current working
+  directory, as demonstrated using (1) rubygems/defaults/operating_system.rb, (2)
+  Win32API.rb, (3) Win32API.so, (4) safe_yaml.rb, (5) safe_yaml/deep.rb, or (6) safe_yaml/deep.so;
+  or (7) operatingsystem.rb, (8) operatingsystem.so, (9) osfamily.rb, or (10) osfamily.so
+  in puppet/confine.
+patched_versions:
+  - '>= 1.3.4'
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-3248
+    - https://github.com/advisories/GHSA-92v7-pq4h-58j5
+    - http://puppetlabs.com/security/cve/cve-2014-3248
+    - http://rowediness.com/2014/06/13/cve-2014-3248-a-little-problem-with-puppet/
+    - http://secunia.com/advisories/59197
+    - http://secunia.com/advisories/59200
+    - http://www.securityfocus.com/bid/68035

--- a/gems/mcollective-client/CVE-2014-3248.yml
+++ b/gems/mcollective-client/CVE-2014-3248.yml
@@ -1,0 +1,27 @@
+---
+gem: mcollective-client
+cve: 2014-3248
+ghsa: 92v7-pq4h-58j5
+url: https://github.com/advisories/GHSA-92v7-pq4h-58j5
+title: Moderate severity vulnerability that affects facter, hiera, mcollective-client, and puppet
+date: 2017-10-24
+description:
+  Untrusted search path vulnerability in Puppet Enterprise 2.8 before 2.8.7,
+  Puppet before 2.7.26 and 3.x before 3.6.2, Facter 1.6.x and 2.x before 2.0.2, Hiera
+  before 1.3.4, and Mcollective before 2.5.2, when running with Ruby 1.9.1 or earlier,
+  allows local users to gain privileges via a Trojan horse file in the current working
+  directory, as demonstrated using (1) rubygems/defaults/operating_system.rb, (2)
+  Win32API.rb, (3) Win32API.so, (4) safe_yaml.rb, (5) safe_yaml/deep.rb, or (6) safe_yaml/deep.so;
+  or (7) operatingsystem.rb, (8) operatingsystem.so, (9) osfamily.rb, or (10) osfamily.so
+  in puppet/confine.
+patched_versions:
+  - '>= 2.5.2'
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-3248
+    - https://github.com/advisories/GHSA-92v7-pq4h-58j5
+    - http://puppetlabs.com/security/cve/cve-2014-3248
+    - http://rowediness.com/2014/06/13/cve-2014-3248-a-little-problem-with-puppet/
+    - http://secunia.com/advisories/59197
+    - http://secunia.com/advisories/59200
+    - http://www.securityfocus.com/bid/68035

--- a/gems/puppet/CVE-2014-3248.yml
+++ b/gems/puppet/CVE-2014-3248.yml
@@ -1,0 +1,28 @@
+---
+gem: puppet
+cve: 2014-3248
+ghsa: 92v7-pq4h-58j5
+url: https://github.com/advisories/GHSA-92v7-pq4h-58j5
+title: Moderate severity vulnerability that affects facter, hiera, mcollective-client, and puppet
+date: 2017-10-24
+description:
+  Untrusted search path vulnerability in Puppet Enterprise 2.8 before 2.8.7,
+  Puppet before 2.7.26 and 3.x before 3.6.2, Facter 1.6.x and 2.x before 2.0.2, Hiera
+  before 1.3.4, and Mcollective before 2.5.2, when running with Ruby 1.9.1 or earlier,
+  allows local users to gain privileges via a Trojan horse file in the current working
+  directory, as demonstrated using (1) rubygems/defaults/operating_system.rb, (2)
+  Win32API.rb, (3) Win32API.so, (4) safe_yaml.rb, (5) safe_yaml/deep.rb, or (6) safe_yaml/deep.so;
+  or (7) operatingsystem.rb, (8) operatingsystem.so, (9) osfamily.rb, or (10) osfamily.so
+  in puppet/confine.
+patched_versions:
+  - '~> 2.7.26'
+  - '>= 3.6.2'
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-3248
+    - https://github.com/advisories/GHSA-92v7-pq4h-58j5
+    - http://puppetlabs.com/security/cve/cve-2014-3248
+    - http://rowediness.com/2014/06/13/cve-2014-3248-a-little-problem-with-puppet/
+    - http://secunia.com/advisories/59197
+    - http://secunia.com/advisories/59200
+    - http://www.securityfocus.com/bid/68035


### PR DESCRIPTION
Adding four advisories (files) based on CVE-2014-3248 advisory.

* These files were imported using "lib/github_advisory_sync.rb" script.
* Only edit was making 2-line title into 1.
* Checked "yamllint" (clean) and ran "rake" (clean).
