### PR TITLE
#573: Changed "lib/github_advisory_sync.rb" to remove the need for a shell-based post processor

### DIFF
--- a/gems/govuk_tech_docs/GHSA-x2xw-hw8g-6773.yml
+++ b/gems/govuk_tech_docs/GHSA-x2xw-hw8g-6773.yml
@@ -1,0 +1,24 @@
+---
+gem: govuk_tech_docs
+ghsa: x2xw-hw8g-6773
+url: https://github.com/alphagov/tech-docs-gem/security/advisories/GHSA-x2xw-hw8g-6773
+title: govuk_tech_docs vulnerable to unescaped HTML on search results page
+date: 2023-04-11
+description: |-
+  ### Impact
+
+  Pages that are indexed in search results have their entire contents indexed, including any HTML code snippets. These HTML snippets would appear in the search results unsanitised, so it was possible to render arbitrary HTML or run arbitrary scripts.
+
+  This is a low risk security issue; to exploit it, an attacker would need to find a way of committing malicious code to a page indexed by a site that uses tech-docs-gem (which are typically not editable by untrusted users). Their code would also be limited by the relatively short length that's rendered in the corresponding search result. Nevertheless, the XSS would then be triggerable by visiting a pre-constructed URL (/search/index.html?q=some+search+term), which users could be tricked into clicking on through social engineering.
+
+  ### Patches
+
+  This has been fixed in v3.3.1. HTML is now sanitised in search results.
+patched_versions:
+- '>= 3.3.1'
+related:
+  url:
+  - https://github.com/alphagov/tech-docs-gem/security/advisories/GHSA-x2xw-hw8g-6773
+  - https://github.com/alphagov/tech-docs-gem/pull/323
+  - https://github.com/alphagov/tech-docs-gem/releases/tag/v3.3.1
+  - https://github.com/advisories/GHSA-x2xw-hw8g-6773

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -308,7 +308,7 @@ module GitHub
         "ghsa"        => ghsa_id[5..],
         "url"         => external_reference,
         "title"       => advisory["summary"],
-        "description" => advisory["description"],
+        "description" => advisory["description"].gsub(/description: (.*)/, 'description: |\n\1'),
         "cvss_v3"     => cvss,
       }.compact
     end
@@ -342,9 +342,10 @@ module GitHub
       filename_to_write = package.filename
 
       new_data = package.merge_data(
-        "cvss_v3"             => ("<FILL IN IF AVAILABLE>" unless cvss),
-        "patched_versions"    => ["<FILL IN SEE BELOW>"],
-        "unaffected_versions" => ["<OPTIONAL: FILL IN SEE BELOW>"]
+        "cvss_v3"             => (nil unless cvss),
+#HID        "cvss_v3"             => ("<FILL IN IF AVAILABLE>" unless cvss),
+#HID        "patched_versions"    => ["<FILL IN SEE BELOW>"],
+#HID        "unaffected_versions" => ["<OPTIONAL: FILL IN SEE BELOW>"]
       )
 
       FileUtils.mkdir_p(File.dirname(filename_to_write))
@@ -353,7 +354,7 @@ module GitHub
         file.write new_data.merge(
           "patched_versions" => vulnerabilities,
           "related" => {
-            "url"  => advisory["references"]
+            "url"  => advisory["references"].map! { |url| url['url'] }
           }
         ).to_yaml
 
@@ -373,9 +374,9 @@ module GitHub
         # The second block of yaml in a .yaml file is ignored (after the second "---" line)
         # This effectively makes this data a large comment
         # Still it should be removed before the data goes into rubysec
-        file.write "\n\n# GitHub advisory data below - **Remove this data before committing**\n"
-        file.write "# Use this data to write patched_versions (and potentially unaffected_versions) above\n"
-        file.write advisory.merge("vulnerabilities" => vulnerabilities).to_yaml
+#HID        file.write "\n\n# GitHub advisory data below - **Remove this data before committing**\n"
+#HID        file.write "# Use this data to write patched_versions (and potentially unaffected_versions) above\n"
+#HID        file.write advisory.merge("vulnerabilities" => vulnerabilities).to_yaml
       end
       puts "Wrote: #{filename_to_write}"
       filename_to_write


### PR DESCRIPTION
## #573: Changed the ruby code of "lib/github_advisory_sync.rb" to remove the need for a shell-based post processor.

 * Issue 573 punch list items 2 and 3 required code changes.
 * Issue 573 punch list items 1, 5, and 6 were done by commenting out the code instead of deleting it.
 * Issue 573 punch list item 4 will be tracked in #571.
 * Therefore #573 will be considered fixed when PR is accepted.
    * Limitation: Must start "patched_versions" 2nd line in column 1 for "yamllint" to be happy.