### PR TITLE
Prefer double quotes for `title:` values if they contain special characters

### DIFF
--- a/gems/RedCloth/CVE-2012-6684.yml
+++ b/gems/RedCloth/CVE-2012-6684.yml
@@ -3,7 +3,7 @@ gem: RedCloth
 cve: 2012-6684
 osvdb: 115941
 url: https://co3k.org/blog/redcloth-unfixed-xss-en
-title: 'CVE-2012-6684 rubygem-RedCloth: XSS vulnerability'
+title: "CVE-2012-6684 rubygem-RedCloth: XSS vulnerability"
 date: 2012-02-29
 description: 'Cross-site scripting (XSS) vulnerability in the RedCloth library 4.2.9
   for Ruby and earlier allows remote attackers to inject arbitrary web script or HTML

--- a/gems/actionmailer/CVE-2013-4389.yml
+++ b/gems/actionmailer/CVE-2013-4389.yml
@@ -4,7 +4,7 @@ cve: 2013-4389
 osvdb: 98629
 ghsa: rg5m-3fqp-6px8
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-4389
-title: 'CVE-2013-4389 rubygem-actionmailer: email address processing DoS'
+title: "CVE-2013-4389 rubygem-actionmailer: email address processing DoS"
 date: 2013-10-16
 description: |
   Multiple format string vulnerabilities in log_subscriber.rb files in

--- a/gems/actionpack/CVE-2012-1099.yml
+++ b/gems/actionpack/CVE-2012-1099.yml
@@ -5,7 +5,7 @@ cve: 2012-1099
 osvdb: 79727
 ghsa: 2xjj-5x6h-8vmf
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-1099
-title: 'CVE-2012-1099 rubygem-actionpack: XSS in the "select" helper'
+title: "CVE-2012-1099 rubygem-actionpack: XSS in the \"select\" helper"
 date: 2012-03-01
 description: |
   Cross-site scripting (XSS) vulnerability in actionpack/lib/action_view/helpers/form_options_helper.rb

--- a/gems/actionpack/CVE-2012-3424.yml
+++ b/gems/actionpack/CVE-2012-3424.yml
@@ -5,7 +5,7 @@ cve: 2012-3424
 osvdb: 84243
 ghsa: 92w9-2pqw-rhjj
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-3424
-title: 'CVE-2012-3424 rubygem-actionpack: DoS vulnerability in authenticate_or_request_with_http_digest'
+title: "CVE-2012-3424 rubygem-actionpack: DoS vulnerability in authenticate_or_request_with_http_digest"
 date: 2012-07-26
 description: |
   The decode_credentials method in actionpack/lib/action_controller/metal/http_authentication.rb

--- a/gems/actionpack/CVE-2012-3465.yml
+++ b/gems/actionpack/CVE-2012-3465.yml
@@ -5,7 +5,7 @@ cve: 2012-3465
 osvdb: 84513
 ghsa: 7g65-ghrg-hpf5
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-3465
-title: 'CVE-2012-3465 rubygem-actionpack: XSS Vulnerability in strip_tags'
+title: "CVE-2012-3465 rubygem-actionpack: XSS Vulnerability in strip_tags"
 date: 2012-08-09
 description: |
   Cross-site scripting (XSS) vulnerability in actionpack/lib/action_view/helpers/sanitize_helper.rb

--- a/gems/actionpack/CVE-2013-1855.yml
+++ b/gems/actionpack/CVE-2013-1855.yml
@@ -5,7 +5,7 @@ cve: 2013-1855
 osvdb: 91452
 ghsa: q759-hwvc-m3jg
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-1855
-title: 'CVE-2013-1855 rubygem-actionpack: css_sanitization: XSS vulnerability in sanitize_css'
+title: "CVE-2013-1855 rubygem-actionpack: css_sanitization: XSS vulnerability in sanitize_css"
 date: 2013-03-19
 description: |
   The sanitize_css method in lib/action_controller/vendor/html-scanner/html/sanitizer.rb

--- a/gems/actionpack/CVE-2014-0082.yml
+++ b/gems/actionpack/CVE-2014-0082.yml
@@ -5,7 +5,7 @@ cve: 2014-0082
 osvdb: 103440
 ghsa: 7cgp-c3g7-qvrw
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-0082
-title: 'CVE-2014-0082 rubygem-actionpack: Action View string handling denial of service'
+title: "CVE-2014-0082 rubygem-actionpack: Action View string handling denial of service"
 date: 2014-02-18
 description: actionpack/lib/action_view/template/text.rb in Action View in Ruby on
   Rails 3.x before 3.2.17 converts MIME type strings to symbols during use of the

--- a/gems/activerecord/CVE-2012-2660.yml
+++ b/gems/activerecord/CVE-2012-2660.yml
@@ -4,7 +4,7 @@ framework: rails
 cve: 2012-2660
 osvdb: 82610
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-2660
-title: 'CVE-2012-2660 rubygem-actionpack: Unsafe query generation'
+title: "CVE-2012-2660 rubygem-actionpack: Unsafe query generation"
 date: 2012-05-31
 description: actionpack/lib/action_dispatch/http/request.rb in Ruby on Rails before
   3.0.13, 3.1.x before 3.1.5, and 3.2.x before 3.2.4 does not properly consider differences

--- a/gems/activerecord/CVE-2013-0276.yml
+++ b/gems/activerecord/CVE-2013-0276.yml
@@ -5,7 +5,7 @@ cve: 2013-0276
 osvdb: 90072
 ghsa: gr44-7grc-37vq
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-0276
-title: 'CVE-2013-0276 rubygem-activerecord/rubygem-activemodel: circumvention of attr_protected'
+title: "CVE-2013-0276 rubygem-activerecord/rubygem-activemodel: circumvention of attr_protected"
 date: 2013-02-11
 description: |
   ActiveRecord in Ruby on Rails before 2.3.17, 3.1.x before 3.1.11, and

--- a/gems/activerecord/CVE-2013-1854.yml
+++ b/gems/activerecord/CVE-2013-1854.yml
@@ -5,7 +5,7 @@ cve: 2013-1854
 osvdb: 91453
 ghsa: 3crr-9vmg-864v
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-1854
-title: 'CVE-2013-1854 rubygem-activerecord: attribute_dos Symbol DoS vulnerability'
+title: "CVE-2013-1854 rubygem-activerecord: attribute_dos Symbol DoS vulnerability"
 date: 2013-03-19
 description: |
   The Active Record component in Ruby on Rails 2.3.x before 2.3.18, 3.1.x

--- a/gems/activerecord/CVE-2014-0080.yml
+++ b/gems/activerecord/CVE-2014-0080.yml
@@ -5,7 +5,7 @@ cve: 2014-0080
 osvdb: 103438
 ghsa: hqf9-rc9j-5fmj
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-0080
-title: 'CVE-2014-0080 rubygem-activerecord: PostgreSQL array data injection vulnerability'
+title: "CVE-2014-0080 rubygem-activerecord: PostgreSQL array data injection vulnerability"
 date: 2014-02-18
 description: SQL injection vulnerability in activerecord/lib/active_record/connection_adapters/postgresql/cast.rb
   in Active Record in Ruby on Rails 4.0.x before 4.0.3, and 4.1.0.beta1, when PostgreSQL

--- a/gems/activerecord/CVE-2014-3482.yml
+++ b/gems/activerecord/CVE-2014-3482.yml
@@ -5,8 +5,7 @@ cve: 2014-3482
 osvdb: 108664
 ghsa: mhwp-qhpc-h3jm
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-3482
-title: 'CVE-2014-3482 rubygem-activerecord: SQL injection vulnerability in ''bitstring''
-  quoting'
+title: "CVE-2014-3482 rubygem-activerecord: SQL injection vulnerability in 'bitstring' quoting"
 date: 2014-07-02
 description: SQL injection vulnerability in activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
   in the PostgreSQL adapter for Active Record in Ruby on Rails 2.x and 3.x before

--- a/gems/activerecord/CVE-2014-3483.yml
+++ b/gems/activerecord/CVE-2014-3483.yml
@@ -5,7 +5,7 @@ cve: 2014-3483
 osvdb: 108665
 ghsa: r8fh-hq2p-7qhq
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-3483
-title: 'CVE-2014-3483 rubygem-activerecord: SQL injection vulnerability in ''range'' quoting'
+title: "CVE-2014-3483 rubygem-activerecord: SQL injection vulnerability in 'range' quoting"
 date: 2014-07-02
 description: |
   SQL injection vulnerability in activerecord/lib/active_record/connection_adapters/postgresql/quoting.rb

--- a/gems/activesupport/CVE-2012-3464.yml
+++ b/gems/activesupport/CVE-2012-3464.yml
@@ -5,7 +5,7 @@ cve: 2012-3464
 osvdb: 84516
 ghsa: h835-75hw-pj89
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-3464
-title: 'CVE-2012-3464 rubygem-actionpack: potential XSS vulnerability'
+title: "CVE-2012-3464 rubygem-actionpack: potential XSS vulnerability"
 date: 2012-08-09
 description: |
   Cross-site scripting (XSS) vulnerability in activesupport/lib/active_support/core_ext/string/output_safety.rb

--- a/gems/activesupport/CVE-2013-0333.yml
+++ b/gems/activesupport/CVE-2013-0333.yml
@@ -5,7 +5,7 @@ cve: 2013-0333
 osvdb: 89594
 ghsa: xgr2-v94m-rc9g
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-0333
-title: 'CVE-2013-0333 rubygem-activesupport: json to yaml parsing'
+title: "CVE-2013-0333 rubygem-activesupport: json to yaml parsing"
 date: 2013-01-28
 description: |
   lib/active_support/json/backends/yaml.rb in Ruby on Rails 2.3.x before

--- a/gems/bundler/CVE-2013-0334.yml
+++ b/gems/bundler/CVE-2013-0334.yml
@@ -4,7 +4,7 @@ cve: 2013-0334
 osvdb: 110004
 ghsa: 49jx-9cmc-xjxm
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-0334
-title: 'CVE-2013-0334 rubygem-bundler: ''bundle install'' may install a gem from a source other than expected'
+title: "CVE-2013-0334 rubygem-bundler: 'bundle install' may install a gem from a source other than expected"
 date: 2014-08-13
 description: |
   Bundler before 1.7, when multiple top-level source lines are used, allows

--- a/gems/crack/CVE-2013-1800.yml
+++ b/gems/crack/CVE-2013-1800.yml
@@ -4,7 +4,7 @@ cve: 2013-1800
 osvdb: 90742
 ghsa: m7fq-cf8q-35q7
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-1800
-title: 'CVE-2013-1800 rubygem-crack: YAML parameter parsing vulnerability'
+title: "CVE-2013-1800 rubygem-crack: YAML parameter parsing vulnerability"
 date: 2013-01-09
 description: |
   The crack gem 0.3.1 and earlier for Ruby does not properly restrict casts

--- a/gems/curl/CVE-2013-2617.yml
+++ b/gems/curl/CVE-2013-2617.yml
@@ -4,7 +4,7 @@ cve: 2013-2617
 osvdb: 91230
 ghsa: hxx6-p24v-wg8c
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-2617
-title: 'CVE-2013-2617 rubygem-curl: insufficient URL escaping command injection'
+title: "CVE-2013-2617 rubygem-curl: insufficient URL escaping command injection"
 date: 2013-03-12
 description: |
   lib/curl.rb in the Curl Gem for Ruby allows remote attackers to execute

--- a/gems/gtk2/CVE-2007-6183.yml
+++ b/gems/gtk2/CVE-2007-6183.yml
@@ -4,7 +4,7 @@ cve: 2007-6183
 osvdb: 40774
 ghsa: xgj6-pgrm-x4r2
 url: https://nvd.nist.gov/vuln/detail/CVE-2007-6183
-title: 'CVE-2007-6183 ruby-gnome2: format string vulnerability'
+title: "CVE-2007-6183 ruby-gnome2: format string vulnerability"
 date: 2007-11-27
 description: |
   Format string vulnerability in the mdiag_initialize function in gtk/src/rbgtkmessagedialog.c

--- a/gems/json/CVE-2013-0269.yml
+++ b/gems/json/CVE-2013-0269.yml
@@ -3,7 +3,7 @@ gem: json
 cve: 2013-0269
 osvdb: 101137
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-0269
-title: 'CVE-2013-0269 rubygem-json: Denial of Service and SQL Injection'
+title: "CVE-2013-0269 rubygem-json: Denial of Service and SQL Injection"
 date: 2013-02-12
 description: The JSON gem before 1.5.5, 1.6.x before 1.6.8, and 1.7.x before 1.7.7
   for Ruby allows remote attackers to cause a denial of service (resource consumption)

--- a/gems/mail/CVE-2012-2139.yml
+++ b/gems/mail/CVE-2012-2139.yml
@@ -4,7 +4,7 @@ cve: 2012-2139
 osvdb: 81631
 ghsa: cj92-c4fj-w9c5
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-2139
-title: 'CVE-2012-2139 rubygem-mail: directory traversal'
+title: "CVE-2012-2139 rubygem-mail: directory traversal"
 date: 2012-03-14
 description: |
   Directory traversal vulnerability in lib/mail/network/delivery_methods/file_delivery.rb

--- a/gems/mail/CVE-2015-9097.yml
+++ b/gems/mail/CVE-2015-9097.yml
@@ -4,7 +4,7 @@ cve: 2015-9097
 osvdb: 131677
 ghsa: q86f-fmqf-qrf6
 url: https://hackerone.com/reports/137631
-title: 'CVE-2015-9097 rubygem-mail: SMTP injection via recipient email addresses'
+title: "CVE-2015-9097 rubygem-mail: SMTP injection via recipient email addresses"
 date: 2015-12-09
 description: The mail gem before 2.5.5 for Ruby (aka A Really Ruby Mail Library) is
   vulnerable to SMTP command injection via CRLF sequences in a RCPT TO or MAIL FROM

--- a/gems/nokogiri/CVE-2012-6685.yml
+++ b/gems/nokogiri/CVE-2012-6685.yml
@@ -4,7 +4,7 @@ cve: 2012-6685
 osvdb: 90946
 ghsa: 6wj9-77wq-jq7p
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-6685
-title: 'CVE-2012-6685 rubygem-nokogiri: XML eXternal Entity (XXE) flaw'
+title: "CVE-2012-6685 rubygem-nokogiri: XML eXternal Entity (XXE) flaw"
 date: 2012-06-08
 description: |
   Nokogiri before 1.5.4 is vulnerable to XXE attacks

--- a/gems/nokogiri/CVE-2013-6460.yml
+++ b/gems/nokogiri/CVE-2013-6460.yml
@@ -4,7 +4,7 @@ platform: jruby
 cve: 2013-6460
 osvdb: 101179
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-6460
-title: 'CVE-2013-6460 rubygem-nokogiri: DoS while parsing XML documents'
+title: "CVE-2013-6460 rubygem-nokogiri: DoS while parsing XML documents"
 date: 2013-12-14
 description: Nokogiri gem 1.5.x has Denial of Service via infinite loop when parsing
   XML documents

--- a/gems/nokogiri/CVE-2013-6461.yml
+++ b/gems/nokogiri/CVE-2013-6461.yml
@@ -3,7 +3,7 @@ gem: nokogiri
 cve: 2013-6461
 osvdb: 101458
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-6461
-title: 'CVE-2013-6461 rubygem-nokogiri: DoS while parsing XML entities'
+title: "CVE-2013-6461 rubygem-nokogiri: DoS while parsing XML entities"
 date: 2013-12-14
 description: Nokogiri gem 1.5.x and 1.6.x has DoS while parsing XML entities by failing
   to apply limits

--- a/gems/passenger/CVE-2013-2119.yml
+++ b/gems/passenger/CVE-2013-2119.yml
@@ -3,7 +3,7 @@ gem: passenger
 cve: 2013-2119
 osvdb: 93752
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-2119
-title: 'CVE-2013-2119 rubygem-passenger: incorrect temporary file usage'
+title: "CVE-2013-2119 rubygem-passenger: incorrect temporary file usage"
 date: 2013-05-29
 description: Phusion Passenger gem before 3.0.21 and 4.0.x before 4.0.5 for Ruby allows
   local users to cause a denial of service (prevent application start) or gain privileges

--- a/gems/passenger/CVE-2014-1831.yml
+++ b/gems/passenger/CVE-2014-1831.yml
@@ -4,7 +4,7 @@ cve: 2014-1831
 osvdb: 102613
 ghsa: c7j7-p5jq-26ff
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-1831
-title: 'CVE-2014-1831 CVE-2014-1832 rubygem-passenger: insecure use of temporary files'
+title: "CVE-2014-1831 CVE-2014-1832 rubygem-passenger: insecure use of temporary files"
 date: 2014-01-28
 description: Phusion Passenger before 4.0.37 allows local users to write to certain
   files and directories via a symlink attack on (1) control_process.pid or a (2) generation-*

--- a/gems/passenger/CVE-2014-1832.yml
+++ b/gems/passenger/CVE-2014-1832.yml
@@ -4,7 +4,7 @@ cve: 2014-1832
 osvdb: 102613
 ghsa: qw8w-2xcp-xg59
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-1832
-title: 'CVE-2014-1831 CVE-2014-1832 rubygem-passenger: insecure use of temporary files'
+title: "CVE-2014-1831 CVE-2014-1832 rubygem-passenger: insecure use of temporary files"
 date: 2014-01-29
 description: 'Phusion Passenger 4.0.37 allows local users to write to certain files
   and directories via a symlink attack on (1) control_process.pid or a (2) generation-*

--- a/gems/rack-ssl/CVE-2014-2538.yml
+++ b/gems/rack-ssl/CVE-2014-2538.yml
@@ -4,7 +4,7 @@ cve: 2014-2538
 osvdb: 104734
 ghsa: v3rr-cph9-2g2q
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-2538
-title: 'CVE-2014-2538 rubygem rack-ssl: URL error display XSS'
+title: "CVE-2014-2538 rubygem rack-ssl: URL error display XSS"
 date: 2013-07-09
 description: Cross-site scripting (XSS) vulnerability in lib/rack/ssl.rb in the rack-ssl
   gem before 1.4.0 for Ruby allows remote attackers to inject arbitrary web script

--- a/gems/rack/CVE-2011-5036.yml
+++ b/gems/rack/CVE-2011-5036.yml
@@ -4,7 +4,7 @@ cve: 2011-5036
 osvdb: 78121
 ghsa: v6j3-7jrw-hq2p
 url: https://nvd.nist.gov/vuln/detail/CVE-2011-5036
-title: 'CVE-2011-5036 rubygem-rack: hash table collisions DoS (oCERT-2011-003)'
+title: "CVE-2011-5036 rubygem-rack: hash table collisions DoS (oCERT-2011-003)"
 date: 2011-12-28
 description: |
   Rack before 1.1.3, 1.2.x before 1.2.5, and 1.3.x before 1.3.6 computes

--- a/gems/rack/CVE-2012-6109.yml
+++ b/gems/rack/CVE-2012-6109.yml
@@ -4,7 +4,7 @@ cve: 2012-6109
 osvdb: 89317
 ghsa: h77x-m5q8-c29h
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-6109
-title: 'CVE-2012-6109 rubygem-rack: parsing Content-Disposition header DoS'
+title: "CVE-2012-6109 rubygem-rack: parsing Content-Disposition header DoS"
 date: 2012-05-04
 description: |
   lib/rack/multipart.rb in Rack before 1.1.4, 1.2.x before 1.2.6, 1.3.x

--- a/gems/rack/CVE-2013-0184.yml
+++ b/gems/rack/CVE-2013-0184.yml
@@ -3,7 +3,7 @@ gem: rack
 cve: 2013-0184
 osvdb: 89327
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-0184
-title: 'CVE-2013-0184 rubygem-rack: Rack::Auth::AbstractRequest DoS'
+title: "CVE-2013-0184 rubygem-rack: Rack::Auth::AbstractRequest DoS"
 date: 2013-01-13
 description: Unspecified vulnerability in Rack::Auth::AbstractRequest in Rack 1.1.x
   before 1.1.5, 1.2.x before 1.2.7, 1.3.x before 1.3.9, and 1.4.x before 1.4.4 allows

--- a/gems/rack/CVE-2013-0262.yml
+++ b/gems/rack/CVE-2013-0262.yml
@@ -3,7 +3,7 @@ gem: rack
 cve: 2013-0262
 osvdb: 89938
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-0262
-title: 'CVE-2013-0262 rubygem-rack: Path sanitization information disclosure'
+title: "CVE-2013-0262 rubygem-rack: Path sanitization information disclosure"
 date: 2013-02-07
 description: rack/file.rb (Rack::File) in Rack 1.5.x before 1.5.2 and 1.4.x before
   1.4.5 allows attackers to access arbitrary files outside the intended root directory

--- a/gems/rack/CVE-2013-0263.yml
+++ b/gems/rack/CVE-2013-0263.yml
@@ -3,7 +3,7 @@ gem: rack
 cve: 2013-0263
 osvdb: 89939
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-0263
-title: 'CVE-2013-0263 rubygem-rack: Timing attack in cookie sessions'
+title: "CVE-2013-0263 rubygem-rack: Timing attack in cookie sessions"
 date: 2013-02-07
 description: Rack::Session::Cookie in Rack 1.5.x before 1.5.2, 1.4.x before 1.4.5,
   1.3.x before 1.3.10, 1.2.x before 1.2.8, and 1.1.x before 1.1.6 allows remote attackers

--- a/gems/rbovirt/CVE-2014-0036.yml
+++ b/gems/rbovirt/CVE-2014-0036.yml
@@ -4,7 +4,7 @@ cve: 2014-0036
 osvdb: 104080
 ghsa: ww79-8xwv-932x
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-0036
-title: 'CVE-2014-0036 rubygem-rbovirt: unsafe use of rest-client'
+title: "CVE-2014-0036 rubygem-rbovirt: unsafe use of rest-client"
 date: 2014-03-05
 description: The rbovirt gem before 0.0.24 for Ruby uses the rest-client gem with
   SSL verification disabled, which allows remote attackers to conduct man-in-the-middle

--- a/gems/ruby_parser/CVE-2013-0162.yml
+++ b/gems/ruby_parser/CVE-2013-0162.yml
@@ -3,7 +3,7 @@ gem: ruby_parser
 cve: 2013-0162
 osvdb: 90561
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-0162
-title: 'CVE-2013-0162 rubygem-ruby_parser: incorrect temporary file usage'
+title: "CVE-2013-0162 rubygem-ruby_parser: incorrect temporary file usage"
 date: 2013-02-21
 description: The diff_pp function in lib/gauntlet_rubyparser.rb in the ruby_parser
   gem 3.1.1 and earlier for Ruby allows local users to overwrite arbitrary files via

--- a/gems/rubygems-update/CVE-2007-0469.yml
+++ b/gems/rubygems-update/CVE-2007-0469.yml
@@ -5,7 +5,7 @@ cve: 2007-0469
 osvdb: 33561
 ghsa: 95vx-q4c2-64gr
 url: https://nvd.nist.gov/vuln/detail/CVE-2007-0469
-title: 'CVE-2007-0469 RubyGems: Specially-crafted Gem archive can overwrite system files'
+title: "CVE-2007-0469 RubyGems: Specially-crafted Gem archive can overwrite system files"
 date: 2007-01-22
 description: |
   The extract_files function in installer.rb in RubyGems before 0.9.1 does

--- a/gems/rubygems-update/CVE-2012-2125.yml
+++ b/gems/rubygems-update/CVE-2012-2125.yml
@@ -4,7 +4,7 @@ library: rubygems
 cve: 2012-2125
 osvdb: 85809
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-2125
-title: 'CVE-2012-2125 CVE-2012-2126 rubygems: Two security fixes in v1.8.23'
+title: "CVE-2012-2125 CVE-2012-2126 rubygems: Two security fixes in v1.8.23"
 date: 2012-09-25
 description: RubyGems before 1.8.23 can redirect HTTPS connections to HTTP, which
   makes it easier for remote attackers to observe or modify a gem during installation

--- a/gems/rubygems-update/CVE-2012-2126.yml
+++ b/gems/rubygems-update/CVE-2012-2126.yml
@@ -4,7 +4,7 @@ library: rubygems
 cve: 2012-2126
 osvdb: 81444
 url: https://nvd.nist.gov/vuln/detail/CVE-2012-2126
-title: 'CVE-2012-2125 CVE-2012-2126 rubygems: Two security fixes in v1.8.23'
+title: "CVE-2012-2125 CVE-2012-2126 rubygems: Two security fixes in v1.8.23"
 date: 2012-04-20
 description: RubyGems before 1.8.23 does not verify an SSL certificate, which allows
   remote attackers to modify a gem during installation via a man-in-the-middle attack.

--- a/gems/rubygems-update/CVE-2013-4287.yml
+++ b/gems/rubygems-update/CVE-2013-4287.yml
@@ -4,7 +4,7 @@ library: rubygems
 cve: 2013-4287
 osvdb: 97163
 url: http://blog.rubygems.org/2013/09/09/CVE-2013-4287.html
-title: 'CVE-2013-4287 rubygems: version regex algorithmic complexity vulnerability'
+title: "CVE-2013-4287 rubygems: version regex algorithmic complexity vulnerability"
 date: 2013-09-09
 description: Algorithmic complexity vulnerability in Gem::Version::VERSION_PATTERN
   in lib/rubygems/version.rb in RubyGems before 1.8.23.1, 1.8.24 through 1.8.25, 2.0.x

--- a/gems/rubygems-update/CVE-2015-3900.yml
+++ b/gems/rubygems-update/CVE-2015-3900.yml
@@ -5,7 +5,7 @@ cve: 2015-3900
 osvdb: 122162
 ghsa: wp3j-rvfp-624h
 url: https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2015-007/?fid=6356
-title: 'CVE-2015-3900 rubygems: DNS hijacking vulnerability in api_endpoint()'
+title: "CVE-2015-3900 rubygems: DNS hijacking vulnerability in api_endpoint()"
 date: 2015-05-14
 description: RubyGems 2.0.x before 2.0.16, 2.2.x before 2.2.4, and 2.4.x before 2.4.7
   does not validate the hostname when fetching gems or making API requests, which

--- a/gems/spree/CVE-2008-7310.yml
+++ b/gems/spree/CVE-2008-7310.yml
@@ -4,7 +4,7 @@ cve: 2008-7310
 osvdb: 81505
 ghsa: 7h48-m3rw-vr27
 url: https://spreecommerce.com/blog/security-vulnerability-mass-assignment
-title: 'Spree Hash Restriction Weakness URL Parsing Order State Value Manipulation'
+title: "Spree Hash Restriction Weakness URL Parsing Order State Value Manipulation"
 date: 2008-09-22
 description: |
   Spree contains a hash restriction weakness that occurs when parsing a

--- a/gems/sprockets/CVE-2014-7819.yml
+++ b/gems/sprockets/CVE-2014-7819.yml
@@ -4,7 +4,7 @@ cve: 2014-7819
 osvdb: 113965
 ghsa: 33pp-3763-mrfp
 url: https://groups.google.com/forum/#!topic/rubyonrails-security/doAVp0YaTqY
-title: 'CVE-2014-7819 rubygem-sprockets: arbitrary file existence disclosure'
+title: "CVE-2014-7819 rubygem-sprockets: arbitrary file existence disclosure"
 date: 2014-10-30
 description: Multiple directory traversal vulnerabilities in server.rb in Sprockets
   before 2.0.5, 2.1.x before 2.1.4, 2.2.x before 2.2.3, 2.3.x before 2.3.3, 2.4.x

--- a/gems/will_paginate/CVE-2013-6459.yml
+++ b/gems/will_paginate/CVE-2013-6459.yml
@@ -3,7 +3,7 @@ gem: will_paginate
 cve: 2013-6459
 osvdb: 101138
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-6459
-title: 'CVE-2013-6459 rubygem-will_paginate: XSS vulnerabilities'
+title: "CVE-2013-6459 rubygem-will_paginate: XSS vulnerabilities"
 date: 2013-09-19
 description: Cross-site scripting (XSS) vulnerability in the will_paginate gem before
   3.0.5 for Ruby allows remote attackers to inject arbitrary web script or HTML via

--- a/rubies/jruby/CVE-2011-4838.yml
+++ b/rubies/jruby/CVE-2011-4838.yml
@@ -3,7 +3,7 @@ engine: jruby
 cve: 2011-4838
 osvdb: 78116
 url: http://jruby.org/2011/12/27/jruby-1-6-5-1
-title: 'CVE-2011-4838 jruby: hash table collisions DoS (oCERT-2011-003)'
+title: "CVE-2011-4838 jruby: hash table collisions DoS (oCERT-2011-003)"
 date: 2011-12-27
 description: JRuby before 1.6.5.1 computes hash values without restricting the ability
   to trigger hash collisions predictably, which allows context-dependent attackers

--- a/rubies/jruby/CVE-2012-5370.yml
+++ b/rubies/jruby/CVE-2012-5370.yml
@@ -3,7 +3,7 @@ engine: jruby
 cve: 2012-5370
 osvdb: 87864
 url: http://jruby.org/2012/12/03/jruby-1-7-1
-title: 'CVE-2012-5370 jruby: Murmur hash function collisions (oCERT-2012-001)'
+title: "CVE-2012-5370 jruby: Murmur hash function collisions (oCERT-2012-001)"
 date: 2012-11-23
 description: JRuby computes hash values without properly restricting the ability to
   trigger hash collisions predictably, which allows context-dependent attackers to

--- a/rubies/jruby/CVE-2022-25857.yml
+++ b/rubies/jruby/CVE-2022-25857.yml
@@ -2,7 +2,7 @@
 engine: jruby
 cve: 2022-25857
 url: https://github.com/jruby/jruby/issues/7342
-title: 'CVE-2022-25857 jruby/psych/snakeyaml: Denial of Service (DoS) due missing to nested depth limitation for collections'
+title: "CVE-2022-25857 jruby/psych/snakeyaml: Denial of Service (DoS) due missing to nested depth limitation for collections"
 date: 2022-02-24
 description: The package org.yaml:snakeyaml from 0 and before 1.31 are vulnerable to Denial of Service (DoS) due missing to nested depth limitation for collections.
   This package is bundled into Psych which is in turn bundled into jruby.

--- a/rubies/ruby/CVE-2008-2662.yml
+++ b/rubies/ruby/CVE-2008-2662.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2008-2662
 osvdb: 46550
 url: http://www.osvdb.org/show/osvdb/46550
-title: 'CVE-2008-2662 ruby: Integer overflows in rb_str_buf_append()'
+title: "CVE-2008-2662 ruby: Integer overflows in rb_str_buf_append()"
 date: 2008-06-20
 description: 'Multiple integer overflows in the rb_str_buf_append function in Ruby
   1.8.4 and earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230, 1.8.7 before

--- a/rubies/ruby/CVE-2008-2663.yml
+++ b/rubies/ruby/CVE-2008-2663.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2008-2663
 osvdb: 46551
 url: http://www.osvdb.org/show/osvdb/46551
-title: 'CVE-2008-2663 ruby: Integer overflows in rb_ary_store()'
+title: "CVE-2008-2663 ruby: Integer overflows in rb_ary_store()"
 date: 2008-06-20
 description: 'Multiple integer overflows in the rb_ary_store function in Ruby 1.8.4
   and earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230, and 1.8.7 before

--- a/rubies/ruby/CVE-2008-2664.yml
+++ b/rubies/ruby/CVE-2008-2664.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2008-2664
 osvdb: 46552
 url: http://www.osvdb.org/show/osvdb/46552
-title: 'CVE-2008-2664 ruby: Unsafe use of alloca in rb_str_format()'
+title: "CVE-2008-2664 ruby: Unsafe use of alloca in rb_str_format()"
 date: 2008-06-20
 description: 'The rb_str_format function in Ruby 1.8.4 and earlier, 1.8.5 before 1.8.5-p231,
   1.8.6 before 1.8.6-p230, 1.8.7 before 1.8.7-p22, and 1.9.0 before 1.9.0-2 allows

--- a/rubies/ruby/CVE-2008-2725.yml
+++ b/rubies/ruby/CVE-2008-2725.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2008-2725
 osvdb: 46553
 url: http://www.osvdb.org/show/osvdb/46553
-title: 'CVE-2008-2725 ruby: integer overflow in rb_ary_splice/update/replace() - REALLOC_N'
+title: "CVE-2008-2725 ruby: integer overflow in rb_ary_splice/update/replace() - REALLOC_N"
 date: 2008-06-20
 description: 'Integer overflow in the (1) rb_ary_splice function in Ruby 1.8.4 and
   earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230, and 1.8.7 before 1.8.7-p22;

--- a/rubies/ruby/CVE-2008-3790.yml
+++ b/rubies/ruby/CVE-2008-3790.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2008-3790
 osvdb: 47753
 url: http://www.osvdb.org/show/osvdb/47753
-title: 'CVE-2008-3790 ruby: DoS vulnerability in the REXML module'
+title: "CVE-2008-3790 ruby: DoS vulnerability in the REXML module"
 date: 2008-08-25
 description: The REXML module in Ruby 1.8.6 through 1.8.6-p287, 1.8.7 through 1.8.7-p72,
   and 1.9 allows context-dependent attackers to cause a denial of service (CPU consumption)

--- a/rubies/ruby/CVE-2009-1904.yml
+++ b/rubies/ruby/CVE-2009-1904.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2009-1904
 osvdb: 55031
 url: http://www.osvdb.org/show/osvdb/55031
-title: 'CVE-2009-1904 ruby: DoS vulnerability in BigDecimal'
+title: "CVE-2009-1904 ruby: DoS vulnerability in BigDecimal"
 date: 2009-06-10
 description: The BigDecimal library in Ruby 1.8.6 before p369 and 1.8.7 before p173
   allows context-dependent attackers to cause a denial of service (application crash)

--- a/rubies/ruby/CVE-2009-4124.yml
+++ b/rubies/ruby/CVE-2009-4124.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2009-4124
 osvdb: 60880
 url: http://www.osvdb.org/show/osvdb/60880
-title: 'CVE-2009-4124 ruby: Heap-based buffer overflow in the rb_str_justify() function'
+title: "CVE-2009-4124 ruby: Heap-based buffer overflow in the rb_str_justify() function"
 date: 2009-12-07
 description: 'Heap-based buffer overflow in the rb_str_justify function in string.c
   in Ruby 1.9.1 before 1.9.1-p376 allows context-dependent attackers to execute arbitrary

--- a/rubies/ruby/CVE-2011-1005.yml
+++ b/rubies/ruby/CVE-2011-1005.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2011-1005
 osvdb: 70957
 url: http://www.osvdb.org/show/osvdb/70957
-title: 'CVE-2011-1005 Ruby: Untrusted codes able to modify arbitrary strings'
+title: "CVE-2011-1005 Ruby: Untrusted codes able to modify arbitrary strings"
 date: 2011-02-18
 description: The safe-level feature in Ruby 1.8.6 through 1.8.6-420, 1.8.7 through
   1.8.7-330, and 1.8.8dev allows context-dependent attackers to modify strings via

--- a/rubies/ruby/CVE-2011-3389.yml
+++ b/rubies/ruby/CVE-2011-3389.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2011-3389
 osvdb: 74829
 url: http://www.osvdb.org/show/osvdb/74829
-title: 'CVE-2011-3389 HTTPS: block-wise chosen-plaintext attack against SSL/TLS (BEAST)'
+title: "CVE-2011-3389 HTTPS: block-wise chosen-plaintext attack against SSL/TLS (BEAST)"
 date: 2011-08-31
 description: The SSL protocol, as used in certain configurations in Microsoft Windows
   and Microsoft Internet Explorer, Mozilla Firefox, Google Chrome, Opera, and other

--- a/rubies/ruby/CVE-2011-4815.yml
+++ b/rubies/ruby/CVE-2011-4815.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2011-4815
 osvdb: 78118
 url: http://www.osvdb.org/show/osvdb/78118
-title: 'CVE-2011-4815 ruby: hash table collisions CPU usage DoS (oCERT-2011-003)'
+title: "CVE-2011-4815 ruby: hash table collisions CPU usage DoS (oCERT-2011-003)"
 date: 2011-12-28
 description: Ruby (aka CRuby) before 1.8.7-p357 computes hash values without restricting
   the ability to trigger hash collisions predictably, which allows context-dependent

--- a/rubies/ruby/CVE-2012-5371.yml
+++ b/rubies/ruby/CVE-2012-5371.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2012-5371
 osvdb: 87863
 url: http://www.osvdb.org/show/osvdb/87863
-title: 'CVE-2012-5371 ruby: Murmur hash-flooding DoS flaw in ruby 1.9 (oCERT-2012-001)'
+title: "CVE-2012-5371 ruby: Murmur hash-flooding DoS flaw in ruby 1.9 (oCERT-2012-001)"
 date: 2012-11-23
 description: Ruby (aka CRuby) 1.9 before 1.9.3-p327 and 2.0 before r37575 computes
   hash values without properly restricting the ability to trigger hash collisions

--- a/rubies/ruby/CVE-2013-1821.yml
+++ b/rubies/ruby/CVE-2013-1821.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2013-1821
 osvdb: 90587
 url: http://www.osvdb.org/show/osvdb/90587
-title: 'CVE-2013-1821 ruby: entity expansion DoS vulnerability in REXML'
+title: "CVE-2013-1821 ruby: entity expansion DoS vulnerability in REXML"
 date: 2013-02-22
 description: lib/rexml/text.rb in the REXML parser in Ruby before 1.9.3-p392 allows
   remote attackers to cause a denial of service (memory consumption and crash) via

--- a/rubies/ruby/CVE-2013-2065.yml
+++ b/rubies/ruby/CVE-2013-2065.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2013-2065
 osvdb: 93414
 url: http://www.osvdb.org/show/osvdb/93414
-title: 'CVE-2013-2065 Ruby: Object taint bypassing in DL and Fiddle'
+title: "CVE-2013-2065 Ruby: Object taint bypassing in DL and Fiddle"
 date: 2013-05-14
 description: (1) DL and (2) Fiddle in Ruby 1.9 before 1.9.3 patchlevel 426, and 2.0
   before 2.0.0 patchlevel 195, do not perform taint checking for native functions,

--- a/rubies/ruby/CVE-2013-4073.yml
+++ b/rubies/ruby/CVE-2013-4073.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2013-4073
 osvdb: 94628
 url: http://www.osvdb.org/show/osvdb/94628
-title: 'CVE-2013-4073 ruby: hostname check bypassing vulnerability in SSL client'
+title: "CVE-2013-4073 ruby: hostname check bypassing vulnerability in SSL client"
 date: 2013-06-27
 description: The OpenSSL::SSL.verify_certificate_identity function in lib/openssl/ssl.rb
   in Ruby 1.8 before 1.8.7-p374, 1.9 before 1.9.3-p448, and 2.0 before 2.0.0-p247

--- a/rubies/ruby/CVE-2013-4164.yml
+++ b/rubies/ruby/CVE-2013-4164.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2013-4164
 osvdb: 100113
 url: http://www.osvdb.org/show/osvdb/100113
-title: 'CVE-2013-4164 ruby: heap overflow in floating point parsing'
+title: "CVE-2013-4164 ruby: heap overflow in floating point parsing"
 date: 2013-11-22
 description: Heap-based buffer overflow in Ruby 1.8, 1.9 before 1.9.3-p484, 2.0 before
   2.0.0-p353, 2.1 before 2.1.0 preview2, and trunk before revision 43780 allows context-dependent

--- a/rubies/ruby/CVE-2014-2525.yml
+++ b/rubies/ruby/CVE-2014-2525.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2014-2525
 osvdb: 105027
 url: http://www.osvdb.org/show/osvdb/105027
-title: 'CVE-2014-2525 libyaml: heap-based buffer overflow when parsing URLs'
+title: "CVE-2014-2525 libyaml: heap-based buffer overflow when parsing URLs"
 date: 2014-03-26
 description: Heap-based buffer overflow in the yaml_parser_scan_uri_escapes function
   in LibYAML before 0.1.6 allows context-dependent attackers to execute arbitrary

--- a/rubies/ruby/CVE-2014-3916.yml
+++ b/rubies/ruby/CVE-2014-3916.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2014-3916
 osvdb: 107478
 url: http://www.osvdb.org/show/osvdb/107478
-title: 'CVE-2014-3916 ruby: DoS via long string in str_buf_cat()'
+title: "CVE-2014-3916 ruby: DoS via long string in str_buf_cat()"
 date: 2014-04-07
 description: The str_buf_cat function in string.c in Ruby 1.9.3, 2.0.0, and 2.1 allows
   context-dependent attackers to cause a denial of service (segmentation fault and

--- a/rubies/ruby/CVE-2014-8080.yml
+++ b/rubies/ruby/CVE-2014-8080.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2014-8080
 osvdb: 113747
 url: http://www.osvdb.org/show/osvdb/113747
-title: 'CVE-2014-8080 ruby: REXML billion laughs attack via parameter entity expansion'
+title: "CVE-2014-8080 ruby: REXML billion laughs attack via parameter entity expansion"
 date: 2014-10-27
 description: The REXML parser in Ruby 1.9.x before 1.9.3-p550, 2.0.x before 2.0.0-p594,
   and 2.1.x before 2.1.4 allows remote attackers to cause a denial of service (memory

--- a/rubies/ruby/CVE-2014-8090.yml
+++ b/rubies/ruby/CVE-2014-8090.yml
@@ -3,7 +3,7 @@ engine: ruby
 cve: 2014-8090
 osvdb: 114641
 url: http://www.osvdb.org/show/osvdb/114641
-title: 'CVE-2014-8090 ruby: REXML incomplete fix for CVE-2014-8080'
+title: "CVE-2014-8090 ruby: REXML incomplete fix for CVE-2014-8080"
 date: 2014-11-13
 description: 'The REXML parser in Ruby 1.9.x before 1.9.3 patchlevel 551, 2.0.x before
   2.0.0 patchlevel 598, and 2.1.x before 2.1.5 allows remote attackers to cause a


### PR DESCRIPTION
Since we are already using double-quotes in `patched_versions`, we should prefer double quotes for `title:` values which contain special characters.