### PR TITLE
Ensure that `title:` always parses into a single line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ bundle exec rspec
     cve: 2013-0156
     date: 2013-05-01
     url: https://github.com/rubysec/ruby-advisory-db/issues/123456
-    title: |
+    title:
       Ruby on Rails params_parser.rb Action Pack Type Casting Parameter Parsing
       Remote Code Execution
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Each advisory file contains the advisory information in [YAML] format:
     cve: 2013-0156
     date: 2013-05-01
     url: https://github.com/rubysec/ruby-advisory-db/issues/123456
-    title: |
+    title:
       Ruby on Rails params_parser.rb Action Pack Type Casting Parameter Parsing
       Remote Code Execution
 
@@ -69,9 +69,9 @@ Each advisory file contains the advisory information in [YAML] format:
 * `osvdb` \[Integer\] (optional): Open Sourced Vulnerability Database (OSVDB) ID.
 * `ghsa` \[String\] (optional): GitHub Security Advisory (GHSA) ID.
 * `url` \[String\] (required): The URL to the full advisory.
-* `title` \[String\] (required): The title of the advisory or individual vulnerability.
+* `title` \[String\] (required): The title of the advisory or individual vulnerability. It must be a single line sentence.
 * `date` \[Date\] (required): The public disclosure date of the advisory.
-* `description` \[String\] (required): One or more paragraphs describing the vulnerability.
+* `description` \[String\] (required): One or more paragraphs describing the vulnerability. It may contain multiple paragraphs.
 * `cvss_v2` \[Float\] (optional): The [CVSSv2] score for the vulnerability.
 * `cvss_v3` \[Float\] (optional): The [CVSSv3] score for the vulnerability.
 * `unaffected_versions` \[Array\<String\>\] (optional): The version requirements for the

--- a/gems/activerecord-jdbc-adapter/OSVDB-114854.yml
+++ b/gems/activerecord-jdbc-adapter/OSVDB-114854.yml
@@ -3,7 +3,7 @@ gem: activerecord-jdbc-adapter
 platform: jruby
 osvdb: 114854
 url: http://osvdb.org/show/osvdb/114854
-title: |
+title:
   ActiveRecord-JDBC-Adapter (AR-JDBC) lib/arjdbc/jdbc/adapter.rb sql.gsub()
   Function SQL Injection
 date: 2013-02-25

--- a/gems/auto_awesomplete/OSVDB-132800.yml
+++ b/gems/auto_awesomplete/OSVDB-132800.yml
@@ -2,8 +2,7 @@
 gem: auto_awesomplete
 osvdb: 132800
 url: https://github.com/Tab10id/auto_awesomplete/issues/2
-title: |
-  auto_awesomplete Gem for Ruby allows arbitrary search execution
+title: auto_awesomplete Gem for Ruby allows arbitrary search execution
 date: 2016-01-08
 description: |
   auto_awesomplete Gem for Ruby contains a flaw that is triggered when handling the

--- a/gems/auto_select2/OSVDB-132800.yml
+++ b/gems/auto_select2/OSVDB-132800.yml
@@ -2,8 +2,7 @@
 gem: auto_select2
 osvdb: 132800
 url: https://github.com/Loriowar/auto_select2/issues/4
-title: |
-  auto_select2 Gem for Ruby allows arbitrary search execution
+title: auto_select2 Gem for Ruby allows arbitrary search execution
 date: 2016-01-08
 description: |
   auto_select2 Gem for Ruby contains a flaw that is triggered when handling the

--- a/gems/doorkeeper/CVE-2014-8144.yml
+++ b/gems/doorkeeper/CVE-2014-8144.yml
@@ -4,9 +4,9 @@ cve: 2014-8144
 osvdb: 116010
 ghsa: 685w-vc84-wxcx
 url: https://groups.google.com/forum/#!topic/ruby-security-ann/5_VqJtNc8jw
-title: |
-  Cross-site request forgery (CSRF) vulnerability in doorkeeper 1.4.0
-  and earlier.
+title:
+  Cross-site request forgery (CSRF) vulnerability in doorkeeper 1.4.0 and
+  earlier.
 date: 2014-12-18
 description: |
   Cross-site request forgery (CSRF) vulnerability in doorkeeper 1.4.0

--- a/gems/doorkeeper/OSVDB-118830.yml
+++ b/gems/doorkeeper/OSVDB-118830.yml
@@ -2,9 +2,7 @@
 gem: doorkeeper
 osvdb: 118830
 url: http://www.osvdb.org/show/osvdb/118830
-title: |
-  Doorkeeper Gem for Ruby stores sensitive information
-  in production logs
+title: Doorkeeper Gem for Ruby stores sensitive information in production logs
 date: 2015-02-10
 description: |
   Doorkeeper Gem for Ruby contains a flaw in lib/doorkeeper/engine.rb.

--- a/gems/ember-source/CVE-2013-4170.yml
+++ b/gems/ember-source/CVE-2013-4170.yml
@@ -2,7 +2,7 @@
 gem: ember-source
 cve: 2013-4170
 url: https://groups.google.com/forum/#!topic/ember-security/dokLVwwxAdM
-title: |
+title:
   Ember.js Potential XSS Exploit When Binding `tagName` to User-Supplied Data
 date: 2013-07-25
 description: |

--- a/gems/ember-source/CVE-2014-0013.yml
+++ b/gems/ember-source/CVE-2014-0013.yml
@@ -3,7 +3,7 @@ gem: ember-source
 cve: 2014-0013
 ghsa: 8xm3-gm7c-5fjx
 url: https://groups.google.com/forum/#!topic/ember-security/2kpXXCxISS4
-title: |
+title:
   Ember.js Potential XSS Exploit With User-Supplied Data When Binding
   Primitive Values
 date: 2014-01-14

--- a/gems/ember-source/CVE-2014-0014.yml
+++ b/gems/ember-source/CVE-2014-0014.yml
@@ -3,7 +3,7 @@ gem: ember-source
 cve: 2014-0014
 ghsa: rcx6-7jp6-pqf2
 url: https://groups.google.com/forum/#!topic/ember-security/PSE4RzTi6l4
-title: |
+title:
   Ember.js Potential XSS Exploit With User-Supplied Data When Using {{group}}
   Helper
 date: 2014-01-14

--- a/gems/flavour_saver/OSVDB-110796.yml
+++ b/gems/flavour_saver/OSVDB-110796.yml
@@ -2,8 +2,7 @@
 gem: flavour_saver
 osvdb: 110796
 url: http://osvdb.org/show/osvdb/110796
-title: |
-  FlavourSaver handlebars helper remote code execution.
+title: FlavourSaver handlebars helper remote code execution.
 date: 2014-09-04
 description: |
   FlavourSaver contains a flaw in helper method dispatch where it uses

--- a/gems/gollum-grit_adapter/CVE-2014-9489.yml
+++ b/gems/gollum-grit_adapter/CVE-2014-9489.yml
@@ -2,7 +2,7 @@
 gem: gollum-grit_adapter
 cve: 2014-9489
 url: https://github.com/gollum/gollum/issues/913
-title: |
+title:
   gollum-grit_adapter Search Functionality Allows Arbitrary Command
   Execution
 date: 2014-12-04

--- a/gems/json-jwt/CVE-2019-18848.yml
+++ b/gems/json-jwt/CVE-2019-18848.yml
@@ -4,9 +4,9 @@ cve: 2019-18848
 ghsa: cff7-6h4q-q5pj
 url: https://github.com/nov/json-jwt/commit/ada16e772906efdd035e3df49cb2ae372f0f948a
 date: 2019-11-14
-title: |
-  json-jwt improper input validation due to lack of element count when
-  splitting string
+title:
+  json-jwt improper input validation due to lack of element count when splitting
+  string
 description: |
   The json-jwt gem before 1.11.0 for Ruby lacks an element count during
   the splitting of a JWE string.

--- a/gems/mail/CVE-2011-0739.yml
+++ b/gems/mail/CVE-2011-0739.yml
@@ -4,9 +4,9 @@ cve: 2011-0739
 osvdb: 70667
 ghsa: cpjc-p7fc-j9xh
 url: https://nvd.nist.gov/vuln/detail/CVE-2011-0739
-title: |
-  Mail Gem for Ruby lib/mail/network/delivery_methods/sendmail.rb Email From:
-  Address Arbitrary Shell Command Injection
+title:
+  "Mail Gem for Ruby lib/mail/network/delivery_methods/sendmail.rb Email From:
+  Address Arbitrary Shell Command Injection"
 date: 2011-01-25
 description: |
   Mail Gem for Ruby contains a flaw related to the failure to properly sanitise

--- a/gems/nokogiri/OSVDB-118481.yml
+++ b/gems/nokogiri/OSVDB-118481.yml
@@ -3,7 +3,7 @@ gem: nokogiri
 platform: jruby
 osvdb: 118481
 url: https://github.com/sparklemotion/nokogiri/pull/1087
-title: |
+title:
   Nokogiri Gem for JRuby XML Document Root Element Handling Memory Consumption
   Remote DoS
 date: 2014-04-30

--- a/gems/paperclip/CVE-2017-0889.yml
+++ b/gems/paperclip/CVE-2017-0889.yml
@@ -3,9 +3,10 @@ gem: paperclip
 cve: 2017-0889
 ghsa: 5jcf-c5rg-rmm8
 url: https://github.com/thoughtbot/paperclip/pull/2435
-title: |
-  Paperclip ruby gem suffers from a Server-Side Request Forgery (SSRF) vulnerability
-  in the Paperclip::UriAdapter and Paperclip::HttpUrlProxyAdapter class.
+title:
+  Paperclip ruby gem suffers from a Server-Side Request Forgery (SSRF)
+  vulnerability in the Paperclip::UriAdapter and
+  Paperclip::HttpUrlProxyAdapter class.
 date: 2018-01-23
 description: |
   Paperclip gem provides multiple ways a file can be uploaded to a web server.

--- a/gems/rack-attack/OSVDB-132234.yml
+++ b/gems/rack-attack/OSVDB-132234.yml
@@ -2,7 +2,7 @@
 gem: rack-attack
 osvdb: 132234
 url: https://github.com/kickstarter/rack-attack/releases/tag/v4.3.1
-title: |
+title:
   rack-attack Gem for Ruby missing normalization before request path
   processing
 date: 2015-12-18

--- a/gems/rubygems-update/CVE-2015-4020.yml
+++ b/gems/rubygems-update/CVE-2015-4020.yml
@@ -3,7 +3,7 @@ gem: rubygems-update
 library: rubygems
 cve: 2015-4020
 url: https://www.trustwave.com/Resources/Security-Advisories/Advisories/TWSL2015-009/?fid=6478
-title: |
+title:
   RubyGems remote_fetcher.rb api_endpoint() Function Missing SRV Record
   Hostname Validation Request Hijacking
 date: 2015-06-08

--- a/gems/sidekiq-pro/OSVDB-126329.yml
+++ b/gems/sidekiq-pro/OSVDB-126329.yml
@@ -2,7 +2,7 @@
 gem: sidekiq-pro
 osvdb: 126329
 url: https://github.com/mperham/sidekiq/commit/a695ff347ae50f641dfc35189131b232ea0aa1db
-title: |
+title:
   Sidekiq Pro Gem for Ruby web/views/batch.erb Class and ErrorMessage Elements
   Reflected XSS
 date: 2015-05-11

--- a/gems/sidekiq-pro/OSVDB-126330.yml
+++ b/gems/sidekiq-pro/OSVDB-126330.yml
@@ -2,8 +2,7 @@
 gem: sidekiq-pro
 osvdb: 126330
 url: https://github.com/mperham/sidekiq/commit/99b12fb50fe244c5a317f03f1bed9b333ec56ebe
-title: |
-  Sidekiq Pro Gem for Ruby web/views/batch{,es}.erb Description Element XSS
+title: Sidekiq Pro Gem for Ruby web/views/batch{,es}.erb Description Element XSS
 date: 2014-10-13
 description: XSS via batch description in Sidekiq::Web
 patched_versions:

--- a/gems/sidekiq/OSVDB-125676.yml
+++ b/gems/sidekiq/OSVDB-125676.yml
@@ -2,7 +2,7 @@
 gem: sidekiq
 osvdb: 125676
 url: https://github.com/mperham/sidekiq/issues/2330
-title: |
+title:
   Sidekiq Gem for Ruby web/views/queue.erb CurrentMessagesInQueue Element
   Reflected XSS
 date: 2015-06-04

--- a/gems/spree/CVE-2008-7310.yml
+++ b/gems/spree/CVE-2008-7310.yml
@@ -4,7 +4,8 @@ cve: 2008-7310
 osvdb: 81505
 ghsa: 7h48-m3rw-vr27
 url: https://spreecommerce.com/blog/security-vulnerability-mass-assignment
-title: "Spree Hash Restriction Weakness URL Parsing Order State Value Manipulation"
+title:
+  Spree Hash Restriction Weakness URL Parsing Order State Value Manipulation
 date: 2008-09-22
 description: |
   Spree contains a hash restriction weakness that occurs when parsing a

--- a/gems/spree/CVE-2008-7311.yml
+++ b/gems/spree/CVE-2008-7311.yml
@@ -4,7 +4,7 @@ cve: 2008-7311
 osvdb: 81506
 ghsa: g466-57gh-cqfw
 url: https://spreecommerce.com/blog/security-vulernability-session-cookie-store
-title: |
+title:
   Spree Hardcoded config.action_controller_session Hash Value Cryptographic
   Protection Weakness
 date: 2008-08-12

--- a/gems/spree/CVE-2010-3978.yml
+++ b/gems/spree/CVE-2010-3978.yml
@@ -4,7 +4,7 @@ cve: 2010-3978
 osvdb: 69098
 ghsa: hwrx-wc75-mgh7
 url: https://spreecommerce.com/blog/json-hijacking-vulnerability
-title: |
+title:
   Spree Multiple Script JSON Request Validation Weakness Remote Information
   Disclosure
 date: 2010-11-02

--- a/gems/spree/CVE-2013-2506.yml
+++ b/gems/spree/CVE-2013-2506.yml
@@ -3,7 +3,7 @@ gem: spree
 cve: 2013-2506
 osvdb: 90865
 url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
-title: |
+title:
   Spree app/models/spree/user.rb Mass Role Assignment Remote Privilege
   Escalation
 date: 2013-02-21

--- a/gems/spree/OSVDB-125699.yml
+++ b/gems/spree/OSVDB-125699.yml
@@ -2,7 +2,7 @@
 gem: spree
 osvdb: 125699
 url: https://spreecommerce.com/blog/security-updates-2015-7-28
-title: |
+title:
   Spree RABL templates rendering allows Arbitrary Code Execution and File
   Disclosure
 date: 2015-07-28

--- a/gems/spree/OSVDB-125701.yml
+++ b/gems/spree/OSVDB-125701.yml
@@ -2,7 +2,7 @@
 gem: spree
 osvdb: 125701
 url: https://spreecommerce.com/blog/security-updates-2015-7-20
-title: |
+title:
   Spree RABL templates rendering allows Arbitrary Code Execution and File
   Disclosure
 date: 2015-07-20

--- a/gems/spree/OSVDB-125712.yml
+++ b/gems/spree/OSVDB-125712.yml
@@ -2,8 +2,7 @@
 gem: spree
 osvdb: 125712
 url: https://spreecommerce.com/blog/security-issue-all-versions
-title: |
-  Product Scopes could allow for unauthenticated remote command execution
+title: Product Scopes could allow for unauthenticated remote command execution
 date: 2012-07-02
 description: |
   Product Scopes could allow for unauthenticated remote command execution.

--- a/gems/spree/OSVDB-125713.yml
+++ b/gems/spree/OSVDB-125713.yml
@@ -2,8 +2,7 @@
 gem: spree
 osvdb: 125713
 url: https://spreecommerce.com/blog/security-issue-all-versions
-title: |
-  Potential XSS vulnerability related to the analytics dashboard
+title: Potential XSS vulnerability related to the analytics dashboard
 date: 2012-07-02
 description: |
   Spree has a flaw in its analytics dashboard where keywords are not escaped,

--- a/gems/spree/OSVDB-76011.yml
+++ b/gems/spree/OSVDB-76011.yml
@@ -2,7 +2,7 @@
 gem: spree
 osvdb: 76011
 url: https://spreecommerce.com/blog/remote-command-product-group
-title: |
+title:
   Spree Search ProductScope Class search[send][] Parameter Arbitrary Command
   Execution
 date: 2011-10-05

--- a/gems/spree_auth/CVE-2013-2506.yml
+++ b/gems/spree_auth/CVE-2013-2506.yml
@@ -3,7 +3,7 @@ gem: spree_auth
 cve: 2013-2506
 osvdb: 90865
 url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
-title: |
+title:
   Spree app/models/spree/user.rb Mass Role Assignment Remote Privilege
   Escalation
 date: 2013-02-21

--- a/rubies/ruby/CVE-2011-3009.yml
+++ b/rubies/ruby/CVE-2011-3009.yml
@@ -2,7 +2,7 @@
 engine: ruby
 cve: 2011-3009
 url: https://osdir.com/ml/lang-ruby-core/2011-01/msg00917.html
-title: |
+title:
   Ruby Properly initialize the random number generator when forking new process
 date: 2011-07-02
 description: |

--- a/rubies/ruby/CVE-2012-4481.yml
+++ b/rubies/ruby/CVE-2012-4481.yml
@@ -2,7 +2,7 @@
 engine: ruby
 cve: 2012-4481
 url: http://www.openwall.com/lists/oss-security/2012/10/05/2
-title: |
+title:
   Ruby incomplete fix for CVE-2011-1005 for NameError#to_s method when used on
   objects
 date: 2012-10-05

--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -110,6 +110,10 @@ shared_examples_for 'Advisory' do |path|
 
       it { is_expected.to be_kind_of(String) }
       it { is_expected.not_to be_empty }
+
+      it "must be one line" do
+        is_expected.to_not include("\n")
+      end
     end
 
     describe "date" do


### PR DESCRIPTION
The `title:` attribute should not contain multiple lines or any new-line characters, and should be parsed as a single line sentence. This PR adds a spec to enforce this, removes `title: |` in favor of `title:`, and updates the `README.md` and `CONTRIBUTING.md` files.