### PR TITLE
Add specs to ensure there are no "double reported" advisories.

### DIFF
--- a/spec/advisories_spec.rb
+++ b/spec/advisories_spec.rb
@@ -1,10 +1,15 @@
 require 'spec_helper'
 require 'gem_advisory_example'
 require 'ruby_advisory_example'
+require 'advisory_dir_example'
 
 describe "gems" do
   Dir.glob(File.join(ROOT,'gems/*/*')) do |path|
     include_examples 'Gem Advisory', path
+  end
+
+  Dir.glob(File.join(File.dirname(__FILE__), '../gems/*')) do |dir|
+    include_examples 'Advisory Directory', dir
   end
 
   let(:dir)           { File.join(ROOT,'gems') }
@@ -30,5 +35,9 @@ end
 describe "rubies" do
   Dir.glob(File.join(ROOT, 'rubies/*/*')) do |path|
     include_examples 'Rubies Advisory', path
+  end
+
+  Dir.glob(File.join(File.dirname(__FILE__), '../rubies/*')) do |dir|
+    include_examples 'Advisory Directory', dir
   end
 end

--- a/spec/advisory_dir_example.rb
+++ b/spec/advisory_dir_example.rb
@@ -1,0 +1,27 @@
+require 'rspec'
+require 'date'
+
+shared_examples_for "Advisory Directory" do |dir|
+  describe dir do
+    let(:advisory_paths) { Dir.glob(File.join(dir,'*.yml')) }
+    let(:advisories) do
+      advisory_paths.map do |path|
+        YAML.safe_load_file(path, permitted_classes: [Date])
+      end
+    end
+
+    it "must not contain duplicate CVE IDs" do
+      cve_ids = advisories.map { |advisory| advisory['cve'] }
+      cve_ids.compact!
+
+      expect(cve_ids).to eq(cve_ids.uniq)
+    end
+
+    it "must not contain duplicate GHSA IDs" do
+      ghsa_ids = advisories.map { |advisory| advisory['ghsa'] }.compact
+      ghsa_ids.compact!
+
+      expect(ghsa_ids).to eq(ghsa_ids.uniq)
+    end
+  end
+end


### PR DESCRIPTION
All advisory files must contain a unique CVE ID and GHSA ID *per* directory. This addresses issue #580.