### PR TITLE
Two GHSA-based mruby advisories: One with huntr.dev data; one without

### DIFF
--- a/rubies/mruby/CVE-2021-46023.yml
+++ b/rubies/mruby/CVE-2021-46023.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2021-46023
+url: https://nvd.nist.gov/vuln/detail/CVE-2021-46023
+title: https://github.com/mruby/mruby/issues/5613
+date: 2023-02-14
+description: |
+  An Untrusted Pointer Dereference was discovered in function
+  mrb_vm_exec in mruby before 3.1.0-rc. The vulnerability causes
+  a segmentation fault and application crash.
+cvss_v3: 7.5
+patched_versions:
+ - '~> 3.1.0-rc'
+ - '>= 3.1.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-46023
+  - https://github.com/mruby/mruby/issues/5613
+  - https://github.com/advisories/GHSA-4g9q-c75g-jq7q
+  - https://github.com/mruby/mruby/pull/5619
+  - https://github.com/mruby/mruby/pull/5620

--- a/rubies/mruby/CVE-2022-1934.yml
+++ b/rubies/mruby/CVE-2022-1934.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-1934
+url: https://huntr.dev/bounties/99e6df06-b9f7-4c53-a722-6bb89fbfb51f
+title: Use-After-Free in function hash_new_from_values in mruby/mruby
+date: 2022-05-31
+description: |
+  Use After Free in GitHub repository mruby/mruby prior to 3.2.
+cvss_v2: 4.6
+cvss_v3: 7.8
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-1934
+  - https://github.com/mruby/mruby/commit/aa7f98dedb68d735a1665d3a289036c88b0c47ce
+  - https://huntr.dev/bounties/99e6df06-b9f7-4c53-a722-6bb89fbfb51f
+  - https://github.com/advisories/GHSA-hp4r-26gw-f2r8.json


### PR DESCRIPTION
Two GHSA-based mruby advisories.
* One with huntr.dev data; one without  huntr.dev data.
* 37 more mruby advisories to go after these two.
