### PR TITLE
Adding the remaining 18 GHSA-based mruby huntr.dev advisories

### DIFF
--- a/rubies/mruby/CVE-2021-4110.yml
+++ b/rubies/mruby/CVE-2021-4110.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2021-4110
+url: https://huntr.dev/bounties/4ce5dc47-2512-4c87-8609-453adc8cad20
+title: NULL Pointer Dereference in mruby/mruby
+date: 2021-12-15
+description: |
+  mruby is vulnerable to NULL Pointer Dereference
+cvss_v2: 5.0
+cvss_v3: 7.5
+patched_versions:
+ - '~> 3.1.0-rc'
+ - '>= 3.1.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-4110
+  - https://github.com/mruby/mruby/commit/f5e10c5a79a17939af763b1dcf5232ce47e24a34
+  - https://huntr.dev/bounties/4ce5dc47-2512-4c87-8609-453adc8cad20
+  - https://github.com/advisories/GHSA-xvhr-qprg-rjpw

--- a/rubies/mruby/CVE-2021-4188.yml
+++ b/rubies/mruby/CVE-2021-4188.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2021-4188
+url: https://huntr.dev/bounties/78533fb9-f3e0-47c2-86dc-d1f96d5bea28
+title: NULL Pointer Dereference in mruby/mruby
+date: 2021-12-30
+description: |
+  mruby is vulnerable to NULL Pointer Dereference
+cvss_v2: 5.0
+cvss_v3: 7.5
+patched_versions:
+ - '~> 3.1.0-rc'
+ - '>= 3.1.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-4188
+  - https://github.com/mruby/mruby/commit/27d1e0132a0804581dca28df042e7047fd27eaa8
+  - https://huntr.dev/bounties/78533fb9-f3e0-47c2-86dc-d1f96d5bea28
+  - https://github.com/advisories/GHSA-wc43-284g-pqr5

--- a/rubies/mruby/CVE-2022-0080.yml
+++ b/rubies/mruby/CVE-2022-0080.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0080
+url: https://huntr.dev/bounties/59a70392-4864-4ce3-8e35-6ac2111d1e2e
+title: Heap-based Buffer Overflow in mruby/mruby
+date: 2022-01-02
+description: |
+  mruby is vulnerable to Heap-based Buffer Overflow
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '~> 3.1.0-rc'
+ - '>= 3.1.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0080
+  - https://github.com/mruby/mruby/commit/28ccc664e5dcd3f9d55173e9afde77c4705a9ab6
+  - https://huntr.dev/bounties/59a70392-4864-4ce3-8e35-6ac2111d1e2e
+  - https://github.com/advisories/GHSA-8vcc-hrhr-q8hf

--- a/rubies/mruby/CVE-2022-0240.yml
+++ b/rubies/mruby/CVE-2022-0240.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0240
+url: https://huntr.dev/bounties/5857eced-aad9-417d-864e-0bdf17226cbb
+title: NULL Pointer Dereference in mruby/mruby
+date: 2022-01-17
+description: |
+  mruby is vulnerable to NULL Pointer Dereference
+cvss_v2: 5.0
+cvss_v3: 7.5
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0240
+  - https://github.com/mruby/mruby/commit/31fa3304049fc406a201a72293cce140f0557dca
+  - https://huntr.dev/bounties/5857eced-aad9-417d-864e-0bdf17226cbb
+  - https://github.com/advisories/GHSA-r744-r36f-363j

--- a/rubies/mruby/CVE-2022-0326.yml
+++ b/rubies/mruby/CVE-2022-0326.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0326
+url: https://huntr.dev/bounties/795dcbd9-1695-44bb-8c59-ad327c97c976
+title: NULL Pointer Dereference in mruby/mruby
+date: 2022-01-21
+description: |
+  NULL Pointer Dereference in Homebrew mruby prior to 3.2.
+cvss_v2: 4.3
+cvss_v3: 5.5
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0326
+  - https://github.com/mruby/mruby/commit/b611c43a5de061ec21b343967e1b64c45c373d7e
+  - https://huntr.dev/bounties/795dcbd9-1695-44bb-8c59-ad327c97c976
+  - https://github.com/advisories/GHSA-54p3-947h-6fpr

--- a/rubies/mruby/CVE-2022-0481.yml
+++ b/rubies/mruby/CVE-2022-0481.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0481
+url: https://huntr.dev/bounties/54725c8c-87f4-41b6-878c-01d8e0ee7027
+title: NULL Pointer Dereference in mruby/mruby
+date: 2022-02-04
+description: |
+  NULL Pointer Dereference in Homebrew mruby prior to 3.2.
+cvss_v2: 7.8
+cvss_v3: 7.5
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0481
+  - https://github.com/mruby/mruby/commit/ae3c99767a27f5c6c584162e2adc6a5d0eb2c54e
+  - https://huntr.dev/bounties/54725c8c-87f4-41b6-878c-01d8e0ee7027
+  - https://github.com/advisories/GHSA-h8gw-f6pq-8cg5

--- a/rubies/mruby/CVE-2022-0525.yml
+++ b/rubies/mruby/CVE-2022-0525.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0525
+url: https://huntr.dev/bounties/e19e109f-acf0-4048-8ee8-1b10a870f1e9
+title: Out-of-bounds Read in mruby/mruby
+date: 2022-02-09
+description: |
+  Out-of-bounds Read in Homebrew mruby prior to 3.2.
+cvss_v2: 6.4
+cvss_v3: 9.1
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0525
+  - https://github.com/mruby/mruby/commit/0849a2885f81cfd82134992c06df3ccd59052ac7
+  - https://huntr.dev/bounties/e19e109f-acf0-4048-8ee8-1b10a870f1e9
+  - https://github.com/advisories/GHSA-6cpj-3r2r-v2m4

--- a/rubies/mruby/CVE-2022-0570.yml
+++ b/rubies/mruby/CVE-2022-0570.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0570
+url: https://huntr.dev/bounties/65a7632e-f95b-4836-b1a7-9cb95e5124f1
+title: Heap-based Buffer Overflow in mruby/mruby
+date: 2022-02-14
+description: |
+  Heap-based Buffer Overflow in Homebrew mruby prior to 3.2.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0570
+  - https://github.com/mruby/mruby/commit/38b164ace7d6ae1c367883a3d67d7f559783faad
+  - https://huntr.dev/bounties/65a7632e-f95b-4836-b1a7-9cb95e5124f1
+  - https://github.com/advisories/GHSA-69j8-4j47-xjj7

--- a/rubies/mruby/CVE-2022-0614.yml
+++ b/rubies/mruby/CVE-2022-0614.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0614
+url: https://huntr.dev/bounties/a980ce4d-c359-4425-92c4-e844c0055879
+title: Use of Out-of-range Pointer Offset in mruby/mruby
+date: 2022-02-16
+description: |
+  Use of Out-of-range Pointer Offset in Homebrew mruby prior to 3.2.
+cvss_v2: 4.3
+cvss_v3: 5.5
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0614
+  - https://github.com/mruby/mruby/commit/ff3a5ebed6ffbe3e70481531cfb969b497aa73ad
+  - https://huntr.dev/bounties/a980ce4d-c359-4425-92c4-e844c0055879
+  - https://github.com/advisories/GHSA-rr79-wxqv-v9vq

--- a/rubies/mruby/CVE-2022-0623.yml
+++ b/rubies/mruby/CVE-2022-0623.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0623
+url: https://huntr.dev/bounties/5b908ac7-d8f1-4fcd-9355-85df565f7580
+title: Out-of-bounds Read in mruby/mruby
+date: 2022-02-17
+description: |
+  Out-of-bounds Read in Homebrew mruby prior to 3.2.
+cvss_v2: 6.4
+cvss_v3: 9.1
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0623
+  - https://github.com/mruby/mruby/commit/ff3a5ebed6ffbe3e70481531cfb969b497aa73ad
+  - https://huntr.dev/bounties/5b908ac7-d8f1-4fcd-9355-85df565f7580
+  - https://github.com/advisories/GHSA-ff35-7f56-3w6p

--- a/rubies/mruby/CVE-2022-0630.yml
+++ b/rubies/mruby/CVE-2022-0630.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0630
+url: https://huntr.dev/bounties/f7cdd680-1a7f-4992-b4b8-44b5e4ba3e32
+title: Out-of-bounds Read in mruby/mruby
+date: 2022-02-19
+description: |
+  Out-of-bounds Read in Homebrew mruby prior to 3.2.
+cvss_v2: 5.6
+cvss_v3: 7.1
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0630
+  - https://github.com/mruby/mruby/commit/ff3a5ebed6ffbe3e70481531cfb969b497aa73ad
+  - https://huntr.dev/bounties/f7cdd680-1a7f-4992-b4b8-44b5e4ba3e32
+  - https://github.com/advisories/GHSA-f46c-4g24-cvr4

--- a/rubies/mruby/CVE-2022-0631.yml
+++ b/rubies/mruby/CVE-2022-0631.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0631
+url: https://huntr.dev/bounties/9bdc49ca-6697-4adc-a785-081e1961bf40
+title: Heap-based Buffer Overflow in mruby/mruby
+date: 2022-02-18
+description: |
+  Heap-based Buffer Overflow in Homebrew mruby prior to 3.2.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0631
+  - https://github.com/mruby/mruby/commit/47068ae07a5fa3aa9a1879cdfe98a9ce0f339299
+  - https://huntr.dev/bounties/9bdc49ca-6697-4adc-a785-081e1961bf40
+  - https://github.com/advisories/GHSA-hv83-f8w5-chhv

--- a/rubies/mruby/CVE-2022-0632.yml
+++ b/rubies/mruby/CVE-2022-0632.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0632
+url: https://huntr.dev/bounties/3e5bb8f6-30fd-4553-86dd-761e9459ce1b
+title: NULL Pointer Dereference in mruby/mruby
+date: 2022-02-19
+description: |
+  NULL Pointer Dereference in Homebrew mruby prior to 3.2.
+cvss_v2: 4.3
+cvss_v3: 5.5
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0632
+  - https://github.com/mruby/mruby/commit/44f591aa8f7091e6ca6cb418e428ae6d4ceaf77d
+  - https://huntr.dev/bounties/3e5bb8f6-30fd-4553-86dd-761e9459ce1b
+  - https://github.com/advisories/GHSA-3xxj-pcr2-rvh7

--- a/rubies/mruby/CVE-2022-0717.yml
+++ b/rubies/mruby/CVE-2022-0717.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0717
+url: https://huntr.dev/bounties/27a851a5-7ebf-409b-854f-b2614771e8f9
+title: Out-of-bounds Read in mruby/mruby
+date: 2022-02-23
+description: |
+  Out-of-bounds Read in GitHub repository mruby/mruby prior to 3.2.
+cvss_v2: 6.4
+cvss_v3: 9.1
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0717
+  - https://github.com/mruby/mruby/commit/f72315575f78a9a773adbce0ee7d3ec33434cb76
+  - https://huntr.dev/bounties/27a851a5-7ebf-409b-854f-b2614771e8f9
+  - https://github.com/advisories/GHSA-9543-hpcg-326v

--- a/rubies/mruby/CVE-2022-0890.yml
+++ b/rubies/mruby/CVE-2022-0890.yml
@@ -1,0 +1,19 @@
+---
+engine: mruby
+cve: 2022-0890
+url: https://huntr.dev/bounties/68e09ec1-6cc7-48b8-981d-30f478c70276
+title: NULL Pointer Dereference in mruby/mruby
+date: 2022-03-10
+description: |
+  NULL Pointer Dereference in GitHub repository mruby/mruby prior to 3.2.
+cvss_v2: 7.1
+cvss_v3: 5.5
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-0890
+  - https://github.com/mruby/mruby/commit/da48e7dbb20024c198493b8724adae1b842083aa
+  - https://huntr.dev/bounties/68e09ec1-6cc7-48b8-981d-30f478c70276
+  - https://github.com/advisories/GHSA-j279-7379-x7mj

--- a/rubies/mruby/CVE-2022-1071.yml
+++ b/rubies/mruby/CVE-2022-1071.yml
@@ -1,0 +1,20 @@
+---
+engine: mruby
+cve: 2022-1071
+url: https://huntr.dev/bounties/6597ece9-07af-415b-809b-919ce0a17cf3
+title: User after free in mrb_vm_exec in mruby/mruby
+date: 2022-03-26
+description: |
+  User after free in mrb_vm_exec in GitHub repository mruby/mruby
+  prior to 3.2.
+cvss_v2: 6.8
+cvss_v3: 8.2
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-1071
+  - https://github.com/mruby/mruby/commit/aaa28a508903041dd7399d4159a8ace9766b022f
+  - https://huntr.dev/bounties/6597ece9-07af-415b-809b-919ce0a17cf3
+  - https://github.com/advisories/GHSA-pv86-xgr9-75fj

--- a/rubies/mruby/CVE-2022-1106.yml
+++ b/rubies/mruby/CVE-2022-1106.yml
@@ -1,0 +1,20 @@
+---
+engine: mruby
+cve: 2022-1106
+url: https://huntr.dev/bounties/16b9d0ea-71ed-41bc-8a88-2deb4c20be8f
+title: Use after free in mrb_vm_exec in mruby/mruby
+date: 2022-03-27
+description: |
+  Use after free in mrb_vm_exec in GitHub repository mruby/mruby
+  prior to 3.2.
+cvss_v2: 6.4
+cvss_v3: 9.1
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-1106
+  - https://github.com/mruby/mruby/commit/7f5a490d09f4d56801ac3a3e4e39e03e1471b44c
+  - https://huntr.dev/bounties/16b9d0ea-71ed-41bc-8a88-2deb4c20be8f
+  - https://github.com/advisories/GHSA-r2j8-v967-j6h6

--- a/rubies/mruby/CVE-2022-1201.yml
+++ b/rubies/mruby/CVE-2022-1201.yml
@@ -1,0 +1,22 @@
+---
+engine: mruby
+cve: 2022-1201
+url: https://huntr.dev/bounties/6f930add-c9d8-4870-ae56-d4bd8354703b
+title: NULL Pointer Dereference in mrb_vm_exec with super in mruby/mruby
+date: 2022-04-02
+description: |
+  NULL Pointer Dereference in mrb_vm_exec with super in GitHub
+  repository mruby/mruby prior to 3.2. This vulnerability is capable
+  of making the mruby interpreter crash, thus affecting the
+  availability of the system.
+cvss_v2: 4.9
+cvss_v3: 6.5
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-1201
+  - https://github.com/mruby/mruby/commit/00acae117da1b45b318dc36531a7b0021b8097ae
+  - https://huntr.dev/bounties/6f930add-c9d8-4870-ae56-d4bd8354703b
+  - https://github.com/advisories/GHSA-p2wj-9vfc-2xj7

--- a/rubies/mruby/CVE-2022-1212.yml
+++ b/rubies/mruby/CVE-2022-1212.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2022-1212
+url: https://huntr.dev/bounties/9fcc06d0-08e4-49c8-afda-2cae40946abe
+title: Use-After-Free in str_escape in mruby/mruby in mruby/mruby
+date: 2022-04-05
+description: |
+  Use-After-Free in str_escape in mruby/mruby in GitHub repository
+  mruby/mruby prior to 3.2. Possible arbitrary code execution if
+  being exploited.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-1212
+  - https://github.com/mruby/mruby/commit/3cf291f72224715942beaf8553e42ba8891ab3c6
+  - https://huntr.dev/bounties/9fcc06d0-08e4-49c8-afda-2cae40946abe
+  - https://github.com/advisories/GHSA-xh66-6mj6-94rg

--- a/rubies/mruby/CVE-2022-1276.yml
+++ b/rubies/mruby/CVE-2022-1276.yml
@@ -1,0 +1,20 @@
+---
+engine: mruby
+cve: 2022-1276
+url: https://huntr.dev/bounties/6ea041d1-e2aa-472c-bf3e-da5fa8726c25
+title: Out-of-bounds Read in mrb_get_args in mruby/mruby
+date: 2022-04-10
+description: |
+  Out-of-bounds Read in mrb_get_args in GitHub repository mruby/mruby
+  prior to 3.2. Possible arbitrary code execution if being exploited.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-1276
+  - https://github.com/mruby/mruby/commit/c8c083cb750606b2da81582cd8e43b442bb143e6
+  - https://huntr.dev/bounties/6ea041d1-e2aa-472c-bf3e-da5fa8726c25
+  - https://github.com/advisories/GHSA-66hc-pc5r-hwjr

--- a/rubies/mruby/CVE-2022-1286.yml
+++ b/rubies/mruby/CVE-2022-1286.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2022-1286
+url: https://huntr.dev/bounties/f918376e-b488-4113-963d-ffe8716e4189
+title: heap-buffer-overflow in mrb_vm_exec in mruby/mruby in mruby/mruby
+date: 2022-04-10
+description: |
+  heap-buffer-overflow in mrb_vm_exec in mruby/mruby in GitHub
+  repository mruby/mruby prior to 3.2. Possible arbitrary code
+  execution if being exploited.
+cvss_v2: 7.5
+cvss_v3: 9.18
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-1286
+  - https://github.com/mruby/mruby/commit/b1d0296a937fe278239bdfac840a3fd0e93b3ee9
+  - https://huntr.dev/bounties/f918376e-b488-4113-963d-ffe8716e4189
+  - https://github.com/advisories/GHSA-6c7w-5xfj-j2mc

--- a/rubies/mruby/CVE-2022-1427.yml
+++ b/rubies/mruby/CVE-2022-1427.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2022-1427
+url: https://huntr.dev/bounties/23b6f0a9-64f5-421e-a55f-b5b7a671f301
+title: Out-of-bounds Read in mrb_obj_is_kind_of in in mruby/mruby
+date: 2022-04-23
+description: |
+  Out-of-bounds Read in mrb_obj_is_kind_of in in GitHub repository
+  mruby/mruby prior to 3.2. # Impact: Possible arbitrary code
+  execution if being exploited.
+cvss_v2: 4.6
+cvss_v3: 7.8
+patched_versions:
+ - '~> 3.2.0-rc'
+ - '>= 3.2.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-1427
+  - https://github.com/mruby/mruby/commit/a4d97934d51cb88954cc49161dc1d151f64afb6b
+  - https://huntr.dev/bounties/23b6f0a9-64f5-421e-a55f-b5b7a671f301
+  - https://github.com/advisories/GHSA-45gc-6g92-9g2j


### PR DESCRIPTION
Adding the remaining 18 GHSA-based mruby huntr.dev advisories.
They are all similar (between 19-22 lines per file).
yamllint and "rake" are green.