### PR TITLE
Adding 12 GHSA-based mruby non-huntr.dev advisories

### DIFF
--- a/rubies/mruby/CVE-2017-9527.yml
+++ b/rubies/mruby/CVE-2017-9527.yml
@@ -1,0 +1,24 @@
+---
+engine: mruby
+cve: 2017-9527
+url: https://github.com/mruby/mruby/issues/3486
+title: Heap use-after-free in mark_context_stack
+date: 2017-06-11
+description: |
+  The mark_context_stack function in gc.c in mruby through 1.2.0
+  allows attackers to cause a denial of service (heap-based
+  use-after-free and application crash) or possibly have unspecified
+  other impact via a crafted .rb file.
+cvss_v2: 7.0
+cvss_v3: 7.8
+patched_versions:
+ - '>= 1.3.0'
+related:
+ url:
+  - (BAD LINK) https://nvd.nist.gov/vuln/detail/CVE-2017-9527
+  - https://github.com/mruby/mruby/issues/3486
+  - https://github.com/mruby/mruby/commit/5c114c91d4ff31859fcd84cf8bf349b737b90d99
+  - https://github.com/advisories/GHSA-fxr6-v647-jgmq
+  - https://lists.debian.org/debian-lts-announce/2022/05/msg00006.html
+  - https://ubuntu.com/security/CVE-2017-9527 (google search)
+  - https://www.rapid7.com/db/vulnerabilities/debian-cve-2017-9527 (google search)

--- a/rubies/mruby/CVE-2018-10191.yml
+++ b/rubies/mruby/CVE-2018-10191.yml
@@ -1,0 +1,23 @@
+---
+engine: mruby
+cve: 2018-10191
+url: https://github.com/mruby/mruby/issues/3995
+title: Use after free caused by integer overflow in environment stack
+date: 2018-04-17
+description: |
+  In versions of mruby up to and including 1.4.0, an integer overflow
+  exists in src/vm.c::mrb_vm_exec() when handling OP_GETUPVAR in the
+  presence of deep scope nesting, resulting in a use-after-free.
+  An attacker that can cause Ruby code to be run can use this to
+  possibly execute arbitrary code.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '>= 1.4.1'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2018-10191
+  - https://github.com/mruby/mruby/issues/3995
+  - https://github.com/mruby/mruby/commit/1905091634a6a2925c911484434448e568330626
+  - https://github.com/advisories/GHSA-444w-xm89-r2p5
+  - https://lists.debian.org/debian-lts-announce/2022/05/msg00006.html

--- a/rubies/mruby/CVE-2018-10199.yml
+++ b/rubies/mruby/CVE-2018-10199.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2018-10199
+url: https://github.com/mruby/mruby/issues/4001
+title: Use after free in File#initilialize_copy
+date: 2018-04-18
+description: |
+  In versions of mruby up to and including 1.4.0, a use-after-free
+  vulnerability exists in src/io.c::File#initilialize_copy(). An
+  attacker that can cause Ruby code to be run can possibly use
+  this to execute arbitrary code.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '>= 1.4.1'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2018-10199
+  - https://github.com/mruby/mruby/issues/4001
+  - https://github.com/mruby/mruby/commit/b51b21fc63c9805862322551387d9036f2b63433
+  - https://github.com/advisories/GHSA-xpq9-m45f-g29q.json

--- a/rubies/mruby/CVE-2018-11743.yml
+++ b/rubies/mruby/CVE-2018-11743.yml
@@ -1,0 +1,22 @@
+---
+engine: mruby
+cve: 2018-11743
+url: https://github.com/mruby/mruby/issues/4027
+title: Use of uninitialized pointer in mrb_hash_keys
+date: 2018-06-05
+description: |
+  The init_copy function in kernel.c in mruby 1.4.1 makes
+  initialize_copy calls for TT_ICLASS objects, which allows attackers
+  to cause a denial of service (mrb_hash_keys uninitialized pointer
+  and application crash) or possibly have unspecified other impact.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '>= 2.0.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2018-11743
+  - https://github.com/mruby/mruby/issues/4027
+  - https://github.com/mruby/mruby/commit/b64ce17852b180dfeea81cf458660be41a78974d
+  - https://github.com/advisories/GHSA-7w9j-h3hj-wc9g
+  - https://lists.debian.org/debian-lts-announce/2022/05/msg00006.html

--- a/rubies/mruby/CVE-2018-12247.yml
+++ b/rubies/mruby/CVE-2018-12247.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2018-12247
+url: https://github.com/mruby/mruby/issues/4036
+title: Null pointer dereference in mrb_class
+date: 2018-06-12
+description: |
+  An issue was discovered in mruby 1.4.1. There is a NULL pointer
+  dereference in mrb_class, related to certain .clone usage, because
+  mrb_obj_clone in kernel.c copies flags other than the
+  MRB_FLAG_IS_FROZEN flag (e.g., the embedded flag).
+cvss_v2: 5.0
+cvss_v3: 7.5
+patched_versions:
+ - '>= 2.0.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2018-12247
+  - https://github.com/mruby/mruby/issues/4036
+  - https://github.com/mruby/mruby/commit/55edae0226409de25e59922807cb09acb45731a2
+  - https://github.com/advisories/GHSA-8j6c-c99j-fh4c

--- a/rubies/mruby/CVE-2018-12248.yml
+++ b/rubies/mruby/CVE-2018-12248.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2018-12248
+url: https://github.com/mruby/mruby/issues/4038
+title: Heap buffer overflow in OP_ENTER
+date: 2018-06-12
+description: |
+  An issue was discovered in mruby 1.4.1. There is a
+  heap-based buffer over-read associated with OP_ENTER because
+  a heap-based mrbgems/mruby-fiber/src/fiber.c does not extend
+  the stack in cases of many arguments to fiber.
+cvss_v2: 5.0
+cvss_v3: 7.5
+patched_versions:
+ - '>= 2.0.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2018-12248
+  - https://github.com/mruby/mruby/issues/4038
+  - https://github.com/mruby/mruby/commit/778500563a9f7ceba996937dc886bd8cde29b42b
+  - https://github.com/advisories/GHSA-96p2-24jg-gc5w

--- a/rubies/mruby/CVE-2018-12249.yml
+++ b/rubies/mruby/CVE-2018-12249.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2018-12249
+url: https://github.com/mruby/mruby/issues/4037
+title: Null pointer dereference in mrb_class_real
+date: 2018-06-12
+description: |
+  An issue was discovered in mruby 1.4.1. There is a NULL pointer
+  dereference in mrb_class_real because "class BasicObject" is
+  not properly supported in class.c.
+cvss_v2: 5.0
+cvss_v3: 7.5
+patched_versions:
+ - '>= 2.0.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2018-12249
+  - https://github.com/mruby/mruby/issues/4037
+  - https://github.com/mruby/mruby/commit/faa4eaf6803bd11669bc324b4c34e7162286bfa3
+  - https://github.com/advisories/GHSA-3h2j-h4g8-5pmr
+  - https://lists.debian.org/debian-lts-announce/2022/05/msg00006.html

--- a/rubies/mruby/CVE-2018-14337.yml
+++ b/rubies/mruby/CVE-2018-14337.yml
@@ -1,0 +1,22 @@
+---
+engine: mruby
+cve: 2018-14337
+url: https://github.com/mruby/mruby/issues/4062
+title: Signed integer overflow in mrb_str_format
+date: 2018-07-17
+description: |
+  The CHECK macro in mrbgems/mruby-sprintf/src/sprintf.c in mruby
+  1.4.1 contains a signed integer overflow, possibly leading to
+  out-of-bounds memory access because the mrb_str_resize function
+  in string.c does not check for a negative length.
+cvss_v2: 5.0
+cvss_v3: 7.5
+patched_versions:
+ - '>= 2.0.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2018-14337
+  - https://github.com/mruby/mruby/issues/4062
+  - https://lists.debian.org/debian-lts-announce/2022/05/msg00006.html
+  - https://github.com/advisories/GHSA-hrqc-789v-hchf
+  - https://github.com/mruby/mruby/commit/180f39bf4c5246ff77ef71011a75e7669019afab

--- a/rubies/mruby/CVE-2020-15866.yml
+++ b/rubies/mruby/CVE-2020-15866.yml
@@ -1,0 +1,22 @@
+---
+engine: mruby
+cve: 2020-15866
+url: https://github.com/mruby/mruby/issues/5042
+title: Heap buffer overflow in mruby interpreter
+date: 2020-07-21
+description: |
+  muby through 2.1.2-rc has a heap-based buffer overflow in the
+  mrb_yield_with_class function in vm.c because of incorrect VM
+  stack handling. It can be triggered via the stack_copy function.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '~> 3.0.0-preview'
+ - '>= 3.0.0'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2020-15866
+  - https://github.com/mruby/mruby/issues/5042
+  - https://lists.debian.org/debian-lts-announce/2022/05/msg00006.html
+  - https://github.com/advisories/GHSA-4f9x-p86g-x88m
+  - https://github.com/mruby/mruby/commit/6334949ba69363cb909a57d6871895bd6d98bb6b

--- a/rubies/mruby/CVE-2020-6838.yml
+++ b/rubies/mruby/CVE-2020-6838.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2020-6838
+url: https://github.com/mruby/mruby/issues/4926
+title: heap use after free in hash_values_at in mrbgems/mruby-hash-ext/src/hash-ext.c
+date: 2020-01-11
+description: |
+  In mruby 2.1.0, there is a use-after-free in hash_values_at in
+  mrbgems/mruby-hash-ext/src/hash-ext.c.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '~> 2.1.1-rc'
+ - '>= 2.1.1'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2020-6838
+  - https://github.com/mruby/mruby/issues/4926
+  - https://github.com/advisories/GHSA-97qv-pm76-mg98
+  - https://github.com/mruby/mruby/issues/5004
+  - https://github.com/mruby/mruby/commit/70e574689664c10ed2c47581999cc2ce3e3c5afb

--- a/rubies/mruby/CVE-2020-6839.yml
+++ b/rubies/mruby/CVE-2020-6839.yml
@@ -1,0 +1,20 @@
+---
+engine: mruby
+cve: 2020-6839
+url: https://github.com/mruby/mruby/issues/4929
+title: stack overflow in mrb_str_len_to_dbl in src/string.c
+date: 2020-01-11
+description: |
+  In mruby 2.1.0, there is a stack-based buffer overflow in
+   mrb_str_len_to_dbl in string.c.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '~> 2.1.1-rc'
+ - '>= 2.1.2'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2020-6839
+  - https://github.com/mruby/mruby/issues/4929
+  - https://github.com/advisories/GHSA-24vp-v896-cq3c
+  - https://github.com/mruby/mruby/commit/2124b9b4c95e66e63b1eb26a8dab49753b82fd6c

--- a/rubies/mruby/CVE-2020-6840.yml
+++ b/rubies/mruby/CVE-2020-6840.yml
@@ -1,0 +1,21 @@
+---
+engine: mruby
+cve: 2020-6840
+url: https://github.com/mruby/mruby/issues/4927
+title: heap use after free in hash_slice in mrbgems/mruby-hash-ext/src/hash-ext.c
+date: 2020-01-11
+description: |
+  In mruby 2.1.0, there is a use-after-free in hash_slice in
+  mrbgems/mruby-hash-ext/src/hash-ext.c.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+ - '~> 2.1.1-rc'
+ - '>= 2.1.1'
+related:
+ url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2020-6840
+  - https://github.com/mruby/mruby/issues/4927
+  - https://github.com/advisories/GHSA-4v2f-5xhv-8ff4
+  - https://github.com/mruby/mruby/issues/5004
+  - https://github.com/mruby/mruby/commit/70e574689664c10ed2c47581999cc2ce3e3c5afb


### PR DESCRIPTION
Adding 12 GHSA-based mruby non-huntr.dev advisories
yamllint and "rake" are green.