### PR TITLE
6 new and 1 modified 2015+ GHSA-sync'ed files

### DIFF
--- a/gems/actionview/CVE-2016-0752.yml
+++ b/gems/actionview/CVE-2016-0752.yml
@@ -90,4 +90,3 @@ patched_versions:
 - '>= 5.0.0.beta1.1'
 - ~> 4.2.5, >= 4.2.5.1
 - ~> 4.1.14, >= 4.1.14.1
-notes: "'~> 3.2.22.1' is found in gems/actionpack/CVE-2016-0752.yml"

--- a/gems/actionview/CVE-2016-2097.yml
+++ b/gems/actionview/CVE-2016-2097.yml
@@ -84,4 +84,3 @@ unaffected_versions:
 - '>= 4.2.0'
 patched_versions:
 - ~> 4.1.14, >= 4.1.14.2
-notes: "'~> 3.2.22.2' is found in gems/actionpack/CVE-2016-2097.yml"

--- a/gems/actionview/CVE-2016-6316.yml
+++ b/gems/actionview/CVE-2016-6316.yml
@@ -51,4 +51,3 @@ patched_versions:
 - "~> 4.2.7.1"
 - "~> 4.2.8"
 - ">= 5.0.0.1"
-notes: "'~> 3.2.22.3' is found in gems/actionpack/CVE-2016-6316.yml"

--- a/gems/audited/GHSA-hjp3-5g2q-7jww.yml
+++ b/gems/audited/GHSA-hjp3-5g2q-7jww.yml
@@ -34,4 +34,3 @@ related:
     - https://github.com/collectiveidea/audited/pull/669
     - https://github.com/collectiveidea/audited/pull/671
     - https://github.com/advisories/GHSA-hjp3-5g2q-7jww
-notes: 'vulnerableVersionRange: ">= 4.0.0, < 5.3.3";   firstPatchedVersion: 5.3.3'

--- a/gems/audited/GHSA-hjp3-5g2q-7jww.yml
+++ b/gems/audited/GHSA-hjp3-5g2q-7jww.yml
@@ -5,7 +5,7 @@ url: https://github.com/collectiveidea/audited/security/advisories/GHSA-hjp3-5g2
 title: Race Condition leading to logging errors
 date: 2023-05-01
 description: |
-  'In certain setups with threaded web servers, Audited's use of
+  In certain setups with threaded web servers, Audited's use of
   `Thread.current` can incorrectly attributed audits to the wrong user.
 
   Fixed in 5.3.3.
@@ -21,7 +21,7 @@ description: |
     - https://github.com/collectiveidea/audited/pull/669
 
   - And the feature was published in version 5.3.3
-    - RELEASE: https://github.com/collectiveidea/audited/pull/671'
+    - RELEASE: https://github.com/collectiveidea/audited/pull/671
 cvss_v3: 3.1
 unaffected_versions:
   - '< 4.0.0'

--- a/gems/audited/GHSA-hjp3-5g2q-7jww.yml
+++ b/gems/audited/GHSA-hjp3-5g2q-7jww.yml
@@ -1,0 +1,37 @@
+---
+gem: audited
+ghsa: hjp3-5g2q-7jww
+url: https://github.com/collectiveidea/audited/security/advisories/GHSA-hjp3-5g2q-7jww
+title: Race Condition leading to logging errors
+date: 2023-05-01
+description: |
+  'In certain setups with threaded web servers, Audited's use of
+  `Thread.current` can incorrectly attributed audits to the wrong user.
+
+  Fixed in 5.3.3.
+
+  In March, @convisoappsec noticed that the library in question had a
+  Race Condition problem, which caused logs to be registered at times
+  with different users than those who performed the genuine actions.
+
+  - The first issue we identified was from November 2021
+    - https://github.com/collectiveidea/audited/issues/601
+
+  - So the solution was implemented in the following Pull Request
+    - https://github.com/collectiveidea/audited/pull/669
+
+  - And the feature was published in version 5.3.3
+    - RELEASE: https://github.com/collectiveidea/audited/pull/671'
+cvss_v3: 3.1
+unaffected_versions:
+  - '< 4.0.0'
+patched_versions:
+  - '>= 5.3.3'
+related:
+  url:
+    - https://github.com/collectiveidea/audited/security/advisories/GHSA-hjp3-5g2q-7jww
+    - https://github.com/collectiveidea/audited/issues/601
+    - https://github.com/collectiveidea/audited/pull/669
+    - https://github.com/collectiveidea/audited/pull/671
+    - https://github.com/advisories/GHSA-hjp3-5g2q-7jww
+notes: 'vulnerableVersionRange: ">= 4.0.0, < 5.3.3";   firstPatchedVersion: 5.3.3'

--- a/gems/govuk_tech_docs/GHSA-x2xw-hw8g-6773.yml
+++ b/gems/govuk_tech_docs/GHSA-x2xw-hw8g-6773.yml
@@ -1,0 +1,35 @@
+---
+gem: govuk_tech_docs
+ghsa: x2xw-hw8g-6773
+url: https://github.com/alphagov/tech-docs-gem/security/advisories/GHSA-x2xw-hw8g-6773
+title: govuk_tech_docs vulnerable to unescaped HTML on search results page
+date: 2023-04-11
+description: |-
+  'Impact
+    Pages that are indexed in search results have their entire contents
+    indexed, including any HTML code snippets. These HTML snippets would
+    appear in the search results unsanitised, so it was possible to render
+    arbitrary HTML or run arbitrary scripts.
+
+    This is a low risk security issue; to exploit it, an attacker would
+    need to find a way of committing malicious code to a page indexed by
+    a site that uses tech-docs-gem (which are typically not editable by
+    untrusted users). Their code would also be limited by the relatively
+    short length that's rendered in the corresponding search result.
+    Nevertheless, the XSS would then be triggerable by visiting a
+    pre-constructed URL (/search/index.html?q=some+search+term), which
+    users could be tricked into clicking on through social engineering.
+
+  Patches
+    This has been fixed in v3.3.1. HTML is now sanitised in search results.'
+unaffected_versions:
+  - '< 2.0.2'
+patched_versions:
+  - '>= 3.3.1'
+related:
+  url:
+    - https://github.com/alphagov/tech-docs-gem/security/advisories/GHSA-x2xw-hw8g-6773
+    - https://github.com/alphagov/tech-docs-gem/pull/323
+    - https://github.com/alphagov/tech-docs-gem/releases/tag/v3.3.1
+    - https://github.com/advisories/GHSA-x2xw-hw8g-6773
+notes: 'vulnerableVersionRange: ">= 2.0.2, < 3.3.1";   firstPatchedVersion: 3.3.1'

--- a/gems/govuk_tech_docs/GHSA-x2xw-hw8g-6773.yml
+++ b/gems/govuk_tech_docs/GHSA-x2xw-hw8g-6773.yml
@@ -32,4 +32,3 @@ related:
     - https://github.com/alphagov/tech-docs-gem/pull/323
     - https://github.com/alphagov/tech-docs-gem/releases/tag/v3.3.1
     - https://github.com/advisories/GHSA-x2xw-hw8g-6773
-notes: 'vulnerableVersionRange: ">= 2.0.2, < 3.3.1";   firstPatchedVersion: 3.3.1'

--- a/gems/govuk_tech_docs/GHSA-x2xw-hw8g-6773.yml
+++ b/gems/govuk_tech_docs/GHSA-x2xw-hw8g-6773.yml
@@ -5,7 +5,7 @@ url: https://github.com/alphagov/tech-docs-gem/security/advisories/GHSA-x2xw-hw8
 title: govuk_tech_docs vulnerable to unescaped HTML on search results page
 date: 2023-04-11
 description: |-
-  'Impact
+  Impact
     Pages that are indexed in search results have their entire contents
     indexed, including any HTML code snippets. These HTML snippets would
     appear in the search results unsanitised, so it was possible to render
@@ -21,7 +21,7 @@ description: |-
     users could be tricked into clicking on through social engineering.
 
   Patches
-    This has been fixed in v3.3.1. HTML is now sanitised in search results.'
+    This has been fixed in v3.3.1. HTML is now sanitised in search results.
 unaffected_versions:
   - '< 2.0.2'
 patched_versions:

--- a/gems/kitchen-terraform/CVE-2023-30618.yml
+++ b/gems/kitchen-terraform/CVE-2023-30618.yml
@@ -1,0 +1,34 @@
+---
+gem: kitchen-terraform
+cve: 2023-30618
+ghsa: 65g2-x53q-cmf6
+url: https://github.com/newcontext-oss/kitchen-terraform/security/advisories/GHSA-65g2-x53q-cmf6
+title: Sensitive Terraform Output Values Printed At Info Logging Level In Kitchen-Terraform
+date: 2023-04-24
+description: |-
+  Summary
+    Kitchen-Terraform v7.0.0 introduced a regression which caused all
+    Terraform output values, including sensitive values, to be printed
+    at the `info` logging level during the `kitchen converge` action.
+    Prior to v7.0.0, the output values were printed at the `debug` level
+    to avoid writing sensitive values to the terminal by default.
+
+  ### Original Report
+    @brettcurtis:
+      Hopefully, I'm not doing something stupid here, but I'm seeing
+      sensitive outputs printed in the kitchen output. You can check
+      this action for an example: https://github.com/osinfra-io/terraform-google-project/actions/runs/4700065515/jobs/8334277309#step:5:215
+
+      It's not really a sensitive value just used it as an example.
+cvss_v3: 3.2
+unaffected_versions:
+  - '< 7.0.0'
+patched_versions:
+  - '>= 7.0.1'
+related:
+  url:
+    - https://github.com/newcontext-oss/kitchen-terraform/security/advisories/GHSA-65g2-x53q-cmf6
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-30618
+    - https://github.com/newcontext-oss/kitchen-terraform/commit/3d20d60e7a891e2dd747df995a31226fa0b4ac48
+    - https://github.com/advisories/GHSA-65g2-x53q-cmf6
+notes: 'vulnerableVersionRange: ">= 7.0.0, < 7.0.1"; firstPatchedVersion: 7.0.1'

--- a/gems/kitchen-terraform/CVE-2023-30618.yml
+++ b/gems/kitchen-terraform/CVE-2023-30618.yml
@@ -31,4 +31,3 @@ related:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-30618
     - https://github.com/newcontext-oss/kitchen-terraform/commit/3d20d60e7a891e2dd747df995a31226fa0b4ac48
     - https://github.com/advisories/GHSA-65g2-x53q-cmf6
-notes: 'vulnerableVersionRange: ">= 7.0.0, < 7.0.1"; firstPatchedVersion: 7.0.1'

--- a/gems/pay/CVE-2023-30614.yml
+++ b/gems/pay/CVE-2023-30614.yml
@@ -1,0 +1,29 @@
+---
+gem: pay
+cve: 2023-30614
+ghsa: cqf3-vpx7-rxhw
+url: https://github.com/pay-rails/pay/security/advisories/GHSA-cqf3-vpx7-rxhw
+title: Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS) in Pay
+date: 2023-04-20
+description: |
+  Impact
+    A payments info page of Pay is susceptible to reflected Cross-site
+    scripting. An attacker could create a working URL that renders a
+    javascript link to a user on a Rails application that integrates
+    Pay. This URL could be distributed via email to specifically target
+    certain individuals. If the targeted application contains a
+    functionality to submit user-generated content (such as comments)
+    the attacker could even distribute the URL using that functionality.
+  Patches
+    This has been patched in version 6.3.2 and above.
+    Pay will now sanitize the `back` parameter and only permit relative paths.
+cvss_v3: 7.1
+patched_versions:
+  - '>= 6.3.2'
+related:
+  url:
+    - https://github.com/pay-rails/pay/security/advisories/GHSA-cqf3-vpx7-rxhw
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-30614
+    - https://github.com/pay-rails/pay/commit/5d6283a24062bd272a524ec48415f536a67ad57f
+    - https://github.com/pay-rails/pay/commit/c067771d8c7514acde4b948b474caf054bb0e25d
+    - https://github.com/advisories/GHSA-cqf3-vpx7-rxhw

--- a/gems/sha3/CVE-2022-37454.yml
+++ b/gems/sha3/CVE-2022-37454.yml
@@ -1,0 +1,48 @@
+---
+gem: sha3
+cve: 2022-37454
+ghsa: 6w4m-2xhg-2658
+url: https://github.com/XKCP/XKCP/security/advisories/GHSA-6w4m-2xhg-2658
+title: Buffer overflow in sponge queue functions
+date: 2023-04-26
+description: |
+  Impact
+    The Keccak sponge function interface accepts partial inputs to be
+    absorbed and partial outputs to be squeezed. A buffer can overflow
+    when partial data with some specific sizes are queued, where at
+    least one of them has a length of 2^32 - 200 bytes or more.
+  Patches
+    Yes, see commit [fdc6fef0](https://github.com/XKCP/XKCP/commit/fdc6fef075f4e81d6b1bc38364248975e08e340a).
+  Workarounds
+    The problem can be avoided by limiting the size of the partial
+    input data (or partial output digest) below 2^32 - 200 bytes.
+    Multiple calls to the queue system can be chained at a higher
+    level to retain the original functionality. Alternatively, one
+    can process the entire input (or produce the entire output) at
+    once, avoiding the queuing functions altogether.
+  References
+    See [issue #105](https://github.com/XKCP/XKCP/issues/105) for more details.
+cvss_v3: 9.8
+patched_versions:
+  - '>= 1.0.5'
+related:
+  url:
+    - https://github.com/XKCP/XKCP/security/advisories/GHSA-6w4m-2xhg-2658
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-37454
+    - https://github.com/XKCP/XKCP/issues/105
+    - https://github.com/johanns/sha3/issues/17
+    - https://github.com/tiran/pysha3/issues/29
+    - https://github.com/XKCP/XKCP/commit/fdc6fef075f4e81d6b1bc38364248975e08e340a
+    - https://github.com/johanns/sha3/commit/5f2e8118a62831911703c8753ff2435c3b5d7312
+    - https://csrc.nist.gov/projects/hash-functions/sha-3-project
+    - https://eprint.iacr.org/2023/331
+    - https://lists.debian.org/debian-lts-announce/2022/10/msg00041.html
+    - https://lists.debian.org/debian-lts-announce/2022/11/msg00000.html
+    - https://mouha.be/sha-3-buffer-overflow/
+    - https://www.debian.org/security/2022/dsa-5267
+    - https://www.debian.org/security/2022/dsa-5269
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3ALQ6BDDPX5HU5YBQOBMDVAA2TSGDKIJ
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CMIEXLMTW5GO36HTFFWIPB3OHZXCT3G4/
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CMIEXLMTW5GO36HTFFWIPB3OHZXCT3G4
+    - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3ALQ6BDDPX5HU5YBQOBMDVAA2TSGDKIJ
+    - https://github.com/advisories/GHSA-6w4m-2xhg-2658

--- a/gems/sidekiq/CVE-2023-1892.yml
+++ b/gems/sidekiq/CVE-2023-1892.yml
@@ -1,0 +1,22 @@
+---
+gem: sidekiq
+cve: 2023-1892
+ghsa: h3r8-h5qw-4r35
+url: https://github.com/sidekiq/sidekiq/commit/458fdf74176a9881478c48dc5cf0269107b22214
+title: 'sidekiq vulnerable to cross-site scripting '
+date: 2023-04-21
+description: |
+  sidekiq from 7.0.4 to 7.0.7 is vulnerable to reflected cross-site scripting.
+  A fix was released in version 7.0.8.
+unaffected_versions:
+  - '< 7.0.4'
+patched_versions:
+  - '>= 7.0.8'
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-1892
+    - https://github.com/sidekiq/sidekiq/commit/458fdf74176a9881478c48dc5cf0269107b22214
+    - https://huntr.dev/bounties/e35e5653-c429-4fb8-94a3-cbc123ae4777
+    - https://github.com/sidekiq/sidekiq/blob/main/Changes.md#708
+    - https://github.com/advisories/GHSA-h3r8-h5qw-4r35
+notes: 'vulnerableVersionRange: ">= 7.0.4, < 7.0.8";   firstPatchedVersion: 7.0.8'

--- a/gems/sidekiq/CVE-2023-1892.yml
+++ b/gems/sidekiq/CVE-2023-1892.yml
@@ -19,4 +19,3 @@ related:
     - https://huntr.dev/bounties/e35e5653-c429-4fb8-94a3-cbc123ae4777
     - https://github.com/sidekiq/sidekiq/blob/main/Changes.md#708
     - https://github.com/advisories/GHSA-h3r8-h5qw-4r35
-notes: 'vulnerableVersionRange: ">= 7.0.4, < 7.0.8";   firstPatchedVersion: 7.0.8'

--- a/gems/uri/CVE-2023-28755.yml
+++ b/gems/uri/CVE-2023-28755.yml
@@ -3,16 +3,17 @@ gem: uri
 cve: 2023-28755
 ghsa: hv5j-3h9f-99c2
 url: https://github.com/advisories/GHSA-hv5j-3h9f-99c2
-date: 2023-03-31
 title: Ruby URI component ReDoS issue
+date: 2023-03-31
 description: |
   A ReDoS issue was discovered in the URI component through 0.12.0 in
   Ruby through 3.2.1. The URI parser mishandles invalid URLs that have
   specific characters. It causes an increase in execution time for parsing
   strings to URI objects. The fixed versions are 0.12.1, 0.11.1,
   0.10.2 and 0.10.0.1.
+cvss_v3: 7.5
 patched_versions:
-  - ~> 0.10.0.1
-  - ~> 0.10.2
-  - ~> 0.11.1
-  - ">= 0.12.1"
+- "~> 0.10.0.1"
+- "~> 0.10.2"
+- "~> 0.11.1"
+- ">= 0.12.1"


### PR DESCRIPTION
6 new and 1 modified 2015+ GHSA-sync'ed files

* Ran the unchanged "lib/sync_github_advisories" to get the most recent files in the query.
* Did minor reformatting (line wrapping) but no new content.
* Ran "yamllint" and "rake" (both clean/green).
