### PR TITLE
Fix CVE-2019-5420 patched versions for railties 6.0.0 version

### DIFF
--- a/gems/railties/CVE-2019-5420.yml
+++ b/gems/railties/CVE-2019-5420.yml
@@ -43,5 +43,4 @@ cvss_v3: 9.8
 unaffected_versions:
   - < 5.2.0
 patched_versions:
-  - ~> 5.2.2, >= 5.2.2.1
-  - '>= 6.0.0.beta3'
+  - ~> 5.2.2, >= 5.2.2.1, >= 6.0.0.beta3


### PR DESCRIPTION
Currently the vulnerability is not detected when running Bundler Audit against Railties version 6.0.0.
This was tested against [RailsGoat](https://github.com/OWASP/railsgoat) project using Ruby 2.7.4 in Debian 11.

```
sca:~/ruby/railsgoat$ bundle-audit > /tmp/result.txt
sca:~/ruby/railsgoat$ vim ~/.local/share/ruby-advisory-db/gems/railties/CVE-2019-5420.yml
sca:~/ruby/railsgoat$ bundle-audit > /tmp/result-fix.txt
sca:~/ruby/railsgoat$ git diff -U0 /tmp/result.txt /tmp/result-fix.txt
diff --git a/tmp/result.txt b/tmp/result-fix.txt
index f1766b6..eaa08ab 100644
--- a/tmp/result.txt
+++ b/tmp/result-fix.txt
@@ -563,0 +564,9 @@ Solution: upgrade to '>= 1.4.4'
+Name: railties
+Version: 6.0.0
+CVE: CVE-2019-5420
+GHSA: GHSA-m42h-mh85-4qgc
+Criticality: Critical
+URL: https://groups.google.com/forum/#!topic/rubyonrails-security/IsQKvDqZdKw
+Title: Possible Remote Code Execution Exploit in Rails Development Mode
+Solution: upgrade to '~> 5.2.2, >= 5.2.2.1, >= 6.0.0.beta3'
```

The `Gemfile` and `Gemfile.lock` file:
```
sca:~/ruby/railsgoat$ grep rails Gemfile
gem "rails", "6.0.0"
...snip...
sca:~/ruby/railsgoat$ grep railties Gemfile.lock
...snip...
    railties (6.0.0)
...snip...
```

The fix only move the `>= 6.0.0.beta3` patched version above.