### PR TITLE
One more early ruby CVE advisory

### DIFF
--- a/rubies/ruby/CVE-2006-3694.yml
+++ b/rubies/ruby/CVE-2006-3694.yml
@@ -1,0 +1,40 @@
+---
+engine: ruby
+cve: 2006-3694
+ghsa: rx2v-jmvm-3c4h
+url: http://www.ubuntu.com/usn/usn-325-1
+title: ruby1.8 vulnerability
+date: 2006-07-21
+description: |
+  Multiple unspecified vulnerabilities in Ruby before 1.8.5 allow
+  remote attackers to bypass safe level checks via unspecified
+  vectors involving (1) the alias function and
+  (2) directory operations.
+cvss_v2: 6.4
+unaffected_versions:
+  - "< 1.8.2"
+patched_versions:
+  - ">= 1.8.5"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2006-3694
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/27725
+    - http://jvn.jp/jp/JVN%2313947696/index.html
+    - http://jvn.jp/jp/JVN%2383768862/index.html
+    - http://lists.freebsd.org/pipermail/freebsd-security/2006-July/003907.html
+    - http://lists.freebsd.org/pipermail/freebsd-security/2006-July/003915.html
+    - http://www.debian.org/security/2006/dsa-1139
+    - http://www.debian.org/security/2006/dsa-1157
+    - http://www.osvdb.org/27144
+    - http://www.osvdb.org/27145
+    - http://www.ubuntu.com/usn/usn-325-1
+    - https://access.redhat.com/errata/RHSA-2006:0604
+    - https://web.archive.org/web/20111224164224/http://secunia.com/advisories/21009
+    - https://web.archive.org/web/20130417170234/http://secunia.com/advisories/21233
+    - https://web.archive.org/web/20130417170234/http://secunia.com/advisories/21236
+    - https://web.archive.org/web/20060814000449/http://secunia.com/advisories/21272
+    - https://web.archive.org/web/20060813235659/http://secunia.com/advisories/21337
+    - https://web.archive.org/web/20060916180623/http://secunia.com/advisories/21598
+    - https://web.archive.org/web/20070501082523/http://secunia.com/advisories/21657
+    - https://web.archive.org/web/20070911143211/http://secunia.com/advisories/21749
+    - https://web.archive.org/web/20101223093859/http://www.securityfocus.com/bid/18944


### PR DESCRIPTION
Found another ruby CVE advisory from 2006.
Built the file, ran "yamllint" (green) and "rake" (green).

In NVD link, saw only 1.8.2, 1.8.3, and 1.8.4 mentioned.