### PR TITLE
First group of osvdb changes

### DIFF
--- a/gems/activemodel/OSVDB-96396.yml
+++ b/gems/activemodel/OSVDB-96396.yml
@@ -1,0 +1,17 @@
+---
+gem: activemodel
+framework: rails
+osvdb: 96396
+url: https://github.com/rails/rails/pull/8122
+title: Don't allow confirmation to pass if confirmation value is nil and doesn't match value.
+date: 2012-05-11
+description: |
+  Don't allow confirmation to pass if confirmation value is
+  nil and doesn't match value.
+notes: "Never patched; PR#8122 is closed but not merged"
+related:
+  url:
+    - https://github.com/rails/rails/pull/8122
+    - https://github.com/rails/rails/pull/8122/commits/e8a50aa1c1f9d04c21b54e983f9a090d4b42c8eb
+    - https://github.com/rails/rails/commit/e8a50aa1c1f9d04c21b54e983f9a090d4b42c8eb
+    - https://github.com/rubysec/ruby-advisory-db/issues/178

--- a/gems/brbackup/CVE-2014-5004.yml
+++ b/gems/brbackup/CVE-2014-5004.yml
@@ -3,11 +3,21 @@ gem: brbackup
 cve: 2014-5004
 osvdb: 108901
 ghsa: vqcm-7f7f-r539
-url: https://nvd.nist.gov/vuln/detail/CVE-2014-5004
+url: http://www.vapid.dhs.org/advisories/brbackup-0.1.1.html
 title: brbackup Gem for Ruby Process List Local Plaintext Password Disclosure
 date: 2014-07-09
 description: |
   brbackup Gem for Ruby contains a flaw that is due to the program exposing
   password information in plaintext in the process list. This may allow a
   local attacker to gain access to password information.
+cvss_v2: 2.1
 cvss_v3: 7.8
+notes: "Never patched"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-5004
+    - http://www.vapid.dhs.org/advisories/brbackup-0.1.1.html
+    - http://www.openwall.com/lists/oss-security/2014/07/10/6
+    - http://www.openwall.com/lists/oss-security/2014/07/17/5
+    - http://www.securityfocus.com/bid/68506
+    - https://web.archive.org/web/20200229055655/https://www.securityfocus.com/bid/68506/

--- a/gems/jruby-sandbox/OSVDB-106279.yml
+++ b/gems/jruby-sandbox/OSVDB-106279.yml
@@ -2,11 +2,15 @@
 gem: jruby-sandbox
 platform: jruby
 osvdb: 106279
-url: http://www.phenoelit.org/stuff/jruby-sandbox.txt
+url: https://www.exploit-db.com/exploits/33028
 title: jruby-sandbox Java Class Importation Sandbox Bypass
 date: 2014-04-24
 description: |
   jruby-sandbox contains a flaw that is triggered when importing Java Classes.
   This may allow a remote attacker to bypass the sandbox for code execution.
 patched_versions:
-  - '>= 0.2.3'
+  - ">= 0.2.3"
+related:
+  url:
+    - https://www.exploit-db.com/exploits/33028
+    - https://security.snyk.io/vuln/SNYK-RUBY-JRUBYSANDBOX-20156

--- a/rubies/jruby/OSVDB-94644.yml
+++ b/rubies/jruby/OSVDB-94644.yml
@@ -1,7 +1,7 @@
 ---
 engine: jruby
 osvdb: 94644
-url: http://www.osvdb.org/show/osvdb/94644
+url: https://www.jruby.org/2011/05/24/jruby-1-6-2.html
 title: JRuby Null Byte Request Arbitrary File Access
 date: 2010-05-26
 description: |
@@ -9,4 +9,8 @@ description: |
   for null byte requests in certain file operations. This may allow a remote
   attacker to gain access to arbitrary files. No further details are available.
 patched_versions:
-  - '>= 1.6.2'
+  - ">= 1.6.2"
+related:
+  url:
+    - https://www.jruby.org/2011/05/24/jruby-1-6-2.html
+    - http://www.osvdb.org/show/osvdb/94644

--- a/rubies/rbx/CVE-2012-5372.yml
+++ b/rubies/rbx/CVE-2012-5372.yml
@@ -2,7 +2,8 @@
 engine: rbx
 cve: 2012-5372
 osvdb: 87861
-url: http://www.osvdb.org/show/osvdb/87861
+ghsa: 9f35-5wj4-v27g
+url: http://www.ocert.org/advisories/ocert-2012-001.html
 title: Rubinius MurmurHash3 Implementation Hash Collision Remote DoS
 date: 2012-11-23
 description: |
@@ -14,4 +15,17 @@ description: |
   This will result in a loss of availability for the program.
 cvss_v2: 5.0
 patched_versions:
-  - '>= 1.3.1'
+  - ">= 1.3.1"
+related:
+  osvdb:
+    - 78119
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-5372
+    - https://github.com/rubinius/rubinius/commit/a9a40fc6a1256bcf6382631b710430105c5dd868
+    - https://github.com/advisories/GHSA-GHSA-9f35-5wj4-v27g
+    - http://2012.appsec-forum.ch/conferences/#c17
+    - http://www.ocert.org/advisories/ocert-2012-001.html
+    - https://web.archive.org/web/20200229110821/http://www.securityfocus.com/bid/56670
+    - https://web.archive.org/web/20121223202152/https://www.131002.net/data/talks/appsec12_slides.pdf
+    - http://www.osvdb.org/show/osvdb/87861
+    - http://www.osvdb.org/show/osvdb/78119

--- a/rubies/ruby/CVE-2006-3694.yml
+++ b/rubies/ruby/CVE-2006-3694.yml
@@ -1,0 +1,40 @@
+---
+engine: ruby
+cve: 2006-3694
+ghsa: rx2v-jmvm-3c4h
+url: http://www.ubuntu.com/usn/usn-325-1
+title: ruby1.8 vulnerability
+date: 2006-07-21
+description: |
+  Multiple unspecified vulnerabilities in Ruby before 1.8.5 allow
+  remote attackers to bypass safe level checks via unspecified
+  vectors involving (1) the alias function and
+  (2) directory operations.
+cvss_v2: 6.4
+unaffected_versions:
+  - "< 1.8.2"
+patched_versions:
+  - ">= 1.8.5"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2006-3694
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/27725
+    - http://jvn.jp/jp/JVN%2313947696/index.html
+    - http://jvn.jp/jp/JVN%2383768862/index.html
+    - http://lists.freebsd.org/pipermail/freebsd-security/2006-July/003907.html
+    - http://lists.freebsd.org/pipermail/freebsd-security/2006-July/003915.html
+    - http://www.debian.org/security/2006/dsa-1139
+    - http://www.debian.org/security/2006/dsa-1157
+    - http://www.osvdb.org/27144
+    - http://www.osvdb.org/27145
+    - http://www.ubuntu.com/usn/usn-325-1
+    - https://access.redhat.com/errata/RHSA-2006:0604
+    - https://web.archive.org/web/20111224164224/http://secunia.com/advisories/21009
+    - https://web.archive.org/web/20130417170234/http://secunia.com/advisories/21233
+    - https://web.archive.org/web/20130417170234/http://secunia.com/advisories/21236
+    - https://web.archive.org/web/20060814000449/http://secunia.com/advisories/21272
+    - https://web.archive.org/web/20060813235659/http://secunia.com/advisories/21337
+    - https://web.archive.org/web/20060916180623/http://secunia.com/advisories/21598
+    - https://web.archive.org/web/20070501082523/http://secunia.com/advisories/21657
+    - https://web.archive.org/web/20070911143211/http://secunia.com/advisories/21749
+    - https://web.archive.org/web/20101223093859/http://www.securityfocus.com/bid/18944

--- a/spec/schemas/ruby.yml
+++ b/spec/schemas/ruby.yml
@@ -5,6 +5,8 @@ mapping:
     type: str
     required: true
     enum: [jruby, rbx, ruby, mruby]
+  "platform":
+    type: str
   "cve":
     type: str
     pattern: /\d+-\d+/
@@ -41,8 +43,24 @@ mapping:
   "related":
     type: map
     mapping:
+      "cve":
+        type: seq
+        sequence:
+          - type: str
+            pattern: /\d+-\d+/
+      "ghsa":
+        type: seq
+        sequence:
+          - type: str
+            pattern: /[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/
+      "osvdb":
+        type: seq
+        sequence:
+          - type: int
       "url":
         type: seq
         sequence:
           - type: str
             pattern: /https?:\/\//
+  "notes":
+    type: str


### PR DESCRIPTION
This is a cross-section of modified/new OSVDB-related advisories (6 files).
```
Goal 1.* : OSVDB-*/Modified/JRuby-related
	modified:   rubies/jruby/OSVDB-94644.yml
	modified:   gems/jruby-sandbox/OSVDB-106279.yml

Goals: 1(3), 2(3) : Updated ruby schema file to match README file.
	modified:   spec/schemas/ruby.yml

Goal: 1(8) : OSVDB-*/NEW
	gems/activemodel/OSVDB-96396.yml

Goal 2.* : CVE-*/Modified/rbx
	modified:   rubies/rbx/CVE-2012-5372.yml

Goal 2.* : CVE-*/Modified/Gems
	modified:   gems/brbackup/CVE-2014-5004.yml
```
More info (include my GOALs) at https://gist.github.com/jasnow/124ec2d0c7ac2f95bc238734f918e727 