### PR TITLE
Updating advisories with osvdb.org in "url:" field

### DIFF
--- a/gems/RedCloth/CVE-2012-6684.yml
+++ b/gems/RedCloth/CVE-2012-6684.yml
@@ -1,19 +1,27 @@
 ---
 gem: RedCloth
 cve: 2012-6684
+ghsa: r23g-3qw4-gfh2
 osvdb: 115941
 url: https://co3k.org/blog/redcloth-unfixed-xss-en
 title: "CVE-2012-6684 rubygem-RedCloth: XSS vulnerability"
 date: 2012-02-29
 description: |
-  'Cross-site scripting (XSS) vulnerability in the RedCloth library 4.2.9
-  for Ruby and earlier allows remote attackers to inject arbitrary web script or HTML
-  via a javascript: URI.'
+  Cross-site scripting (XSS) vulnerability in the RedCloth library 4.2.9
+  for Ruby and earlier allows remote attackers to inject arbitrary
+  web script or HTML via a javascript: URI.
 cvss_v2: 4.3
 patched_versions:
-  - '>= 4.3.0'
+  - ">= 4.3.0"
 related:
   url:
-    - https://github.com/jgarber/redcloth/commit/2f6dab4d6aea5cee778d2f37a135637fe3f1573c
+    - http://co3k.org/blog/redcloth-unfixed-xss-en
     - https://gist.github.com/co3k/75b3cb416c342aa1414c
+    - https://github.com/jgarber/redcloth/commit/2f6dab4d6aea5cee778d2f37a135637fe3f1573c
+    - https://github.com/jgarber/redcloth/commit/b24f03db023d1653d60dd33b28e09317cd77c6a0
     - https://jgarber.lighthouseapp.com/projects/13054-redcloth/tickets/243-xss
+    - https://web.archive.org/web/20150128115714/http://jgarber.lighthouseapp.com/projects/13054-redcloth/tickets/243-xss
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-6684
+    - https://github.com/advisories/GHSA-r23g-3qw4-gfh2
+    - http://seclists.org/fulldisclosure/2014/Dec/50
+    - http://www.debian.org/security/2015/dsa-3168

--- a/gems/activerecord-jdbc-adapter/OSVDB-114854.yml
+++ b/gems/activerecord-jdbc-adapter/OSVDB-114854.yml
@@ -2,7 +2,7 @@
 gem: activerecord-jdbc-adapter
 platform: jruby
 osvdb: 114854
-url: http://osvdb.org/show/osvdb/114854
+url: https://github.com/jruby/activerecord-jdbc-adapter/issues/322
 title:
   ActiveRecord-JDBC-Adapter (AR-JDBC) lib/arjdbc/jdbc/adapter.rb sql.gsub()
   Function SQL Injection
@@ -15,6 +15,13 @@ description: |
   manipulate SQL queries in the back-end database, allowing for the
   manipulation or disclosure of arbitrary data.
 unaffected_versions:
-  - < 1.2.6
+  - "< 1.2.6"
 patched_versions:
-  - '>= 1.2.8'
+  - ">= 1.2.8"
+related:
+  url:
+    - https://github.com/jruby/activerecord-jdbc-adapter/issues/322
+    - https://github.com/jruby/activerecord-jdbc-adapter/blob/master/lib/arjdbc/jdbc/adapter.rb
+    - https://security.snyk.io/vuln/SNYK-RUBY-ACTIVERECORDJDBCADAPTER-20076
+    - https://my.diffend.io/gems/activerecord-jdbc-adapter/1.2.5/1.2.8
+    - http://osvdb.org/show/osvdb/114854

--- a/gems/activerecord-oracle_enhanced-adapter/OSVDB-95376.yml
+++ b/gems/activerecord-oracle_enhanced-adapter/OSVDB-95376.yml
@@ -1,7 +1,7 @@
 ---
 gem: activerecord-oracle_enhanced-adapter
 osvdb: 95376
-url: http://osvdb.org/show/osvdb/95376
+url: https://www.versioneye.com/Ruby/activerecord-oracle_enhanced-adapter/1.1.6
 title: Oracle "enhanced" ActiveRecord Gem for Ruby :limit / :offset SQL Injection
 date: 2008-10-10
 description: |
@@ -12,4 +12,9 @@ description: |
   queries in the back-end database, allowing for the manipulation or disclosure
   of arbitrary data.
 patched_versions:
-  - '>= 1.1.8'
+  - ">= 1.1.8"
+related:
+  url:
+    - https://www.versioneye.com/Ruby/activerecord-oracle_enhanced-adapter/1.1.6
+    - https://security.snyk.io/vuln/SNYK-RUBY-ACTIVERECORDORACLEENHANCEDADAPTER-20006
+    - http://osvdb.org/show/osvdb/95376

--- a/gems/activeresource/OSVDB-95749.yml
+++ b/gems/activeresource/OSVDB-95749.yml
@@ -1,9 +1,9 @@
 ---
 gem: activeresource
 osvdb: 95749
-url: http://osvdb.org/show/osvdb/95749
-title: activeresource Gem for Ruby lib/active_resource/connection.rb request Function
-  Multiple Variable Format String
+url: https://my.diffend.io/gems/activeresource/versions/2.1.0
+title: activeresource Gem for Ruby lib/active_resource/connection.rb
+  request Function Multiple Variable Format String
 date: 2008-08-15
 description: |
   activeresource contains a format string flaw in the request function of
@@ -13,4 +13,9 @@ description: |
   allow a remote attacker to cause a denial of service or potentially execute
   arbitrary code.
 patched_versions:
-  - '>= 2.2.0'
+  - ">= 2.2.0"
+related:
+  url:
+    - https://my.diffend.io/gems/activeresource/versions/2.1.0
+    - https://security.snyk.io/vuln/SNYK-RUBY-ACTIVERESOURCE-20004
+    - http://osvdb.org/show/osvdb/95749

--- a/gems/as/OSVDB-112683.yml
+++ b/gems/as/OSVDB-112683.yml
@@ -1,10 +1,16 @@
 ---
 gem: as
 osvdb: 112683
-url: http://osvdb.org/show/osvdb/112683
+url: https://security.snyk.io/vuln/SNYK-RUBY-AS-20195
 title: as Gem for Ruby Process List Local Plaintext Credentials Disclosure
 date: 2014-09-25
 description: |
   as Gem for Ruby contains a flaw that is due to the program displaying
   credential information in plaintext in the process list. This may
   allow a local attacker to gain access to credential information.
+notes: "Never patched"
+related:
+  url:
+    - https://security.snyk.io/vuln/SNYK-RUBY-AS-20195
+    - http://osvdb.org/show/osvdb/112683
+# FYI: rubygem.org Homepage is 404"

--- a/gems/auto_awesomplete/OSVDB-132800.yml
+++ b/gems/auto_awesomplete/OSVDB-132800.yml
@@ -1,10 +1,17 @@
 ---
 gem: auto_awesomplete
 osvdb: 132800
-url: https://github.com/Tab10id/auto_awesomplete/issues/2
+url: https://www.openwall.com/lists/oss-security/2016/01/11/2
 title: auto_awesomplete Gem for Ruby allows arbitrary search execution
 date: 2016-01-08
 description: |
-  auto_awesomplete Gem for Ruby contains a flaw that is triggered when handling the
-  'params[:default_class_name]' option. This allows users to search any object
-  of all given ActiveRecord classes.
+  auto_awesomplete Gem for Ruby contains a flaw that is triggered
+  when handling the 'params[:default_class_name]' option. This
+  allows users to search any object of all given ActiveRecord classes.
+notes: "Never patched"
+related:
+  url:
+    - https://www.openwall.com/lists/oss-security/2016/01/11/2
+    - https://github.com/Tab10id/auto_awesomplete/issues/2
+    - https://github.com/rubysec/ruby-advisory-db/issues/224
+    - https://github.com/rubysec/ruby-advisory-db/pull/227

--- a/gems/auto_select2/OSVDB-132800.yml
+++ b/gems/auto_select2/OSVDB-132800.yml
@@ -1,12 +1,20 @@
 ---
 gem: auto_select2
 osvdb: 132800
-url: https://github.com/Loriowar/auto_select2/issues/4
+url: https://www.openwall.com/lists/oss-security/2016/01/11/2
 title: auto_select2 Gem for Ruby allows arbitrary search execution
 date: 2016-01-08
 description: |
-  auto_select2 Gem for Ruby contains a flaw that is triggered when handling the
-  'params[:default_class_name]' option. This allows users to search any object
-  of all given ActiveRecord classes.
+  auto_select2 Gem for Ruby contains a flaw that is triggered
+  when handling the 'params[:default_class_name]' option. This
+  allows users to search any object of all given ActiveRecord classes.
 patched_versions:
-  - '>= 0.5.0'
+  - ">= 0.5.0"
+related:
+  url:
+    - https://www.openwall.com/lists/oss-security/2016/01/11/2
+    - https://github.com/Loriowar/auto_select2/issues/4
+    - https://github.com/bkocherov/auto_select2/commit/c283ba5b2ad828c3b7414565ae66cd0d86f5a5df
+    - https://github.com/rubysec/ruby-advisory-db/issues/224
+    - https://github.com/rubysec/ruby-advisory-db/pull/227
+    - https://github.com/Tab10id/auto_awesomplete/issues/2

--- a/gems/backup_checksum/OSVDB-108570.yml
+++ b/gems/backup_checksum/OSVDB-108570.yml
@@ -1,11 +1,18 @@
 ---
 gem: backup_checksum
 osvdb: 108570
-url: http://osvdb.org/show/osvdb/108570
-title: backup_checksum Gem for Ruby /lib/backup/cli/utility.rb Metacharacter Handling
-  Remote Command Execution
+url: https://www.openwall.com/lists/oss-security/2014/07/07/12
+title: backup_checksum Gem for Ruby /lib/backup/cli/utility.rb
+  Metacharacter Handling Remote Command Execution
 date: 2014-06-30
 description: |
   backup_checksum Gem for Ruby contains a flaw in /lib/backup/cli/utility.rb
   that is triggered when handling metacharacters. This may allow a remote
   attacker to execute arbitrary commands.
+notes: "Never patched"
+related:
+  url:
+    - https://www.openwall.com/lists/oss-security/2014/07/07/12
+    - https://my.diffend.io/gems/backup_checksum/3.0.23
+    - https://github.com/backup/backup
+    - http://osvdb.org/show/osvdb/108570

--- a/gems/bcrypt-ruby/OSVDB-62067.yml
+++ b/gems/bcrypt-ruby/OSVDB-62067.yml
@@ -7,14 +7,24 @@ title: bcrypt-ruby Gem for Ruby incorrect encoding of non US-ASCII characters (J
   only)
 date: 2010-02-01
 description: |
+  In https://security.snyk.io/vuln/SNYK-RUBY-BCRYPT-20009, found
+  "The advisory has been revoked - it doesn't affect any version of package bcrypt"
+
   bcrypt-ruby Gem for Ruby suffered from a bug related to character
   encoding that substantially reduced the entropy of hashed passwords
   containing non US-ASCII characters. An incorrect encoding step
-  transparently replaced such characters by '?' prior to hashing. In the
-  worst case of a password consisting solely of non-US-ASCII characters,
-  this would cause its hash to be equivalent to all other such passwords
-  of the same length. This issue only affects the JRuby implementation.
+  transparently replaced such characters by '?' prior to hashing.
+  In the worst case of a password consisting solely of non-US-ASCII
+  characters, this would cause its hash to be equivalent to all other
+  such passwords of the same length.
+
+  This issue only affects the JRuby implementation.
 
   This gem has been renamed. Please use "bcrypt" from now on.
 patched_versions:
-  - '>= 2.1.4'
+  - ">= 2.1.4"
+related:
+  url:
+    - https://github.com/jeremyh/jBCrypt
+    - http://www.mindrot.org/files/jBCrypt/internat.adv
+    - https://github.com/bcrypt-ruby/bcrypt-ruby/blob/master/ext/jruby/bcrypt_jruby/BCrypt.java

--- a/gems/bcrypt/OSVDB-62067.yml
+++ b/gems/bcrypt/OSVDB-62067.yml
@@ -7,12 +7,22 @@ title: bcrypt-ruby Gem for Ruby incorrect encoding of non US-ASCII characters (J
   only)
 date: 2010-02-01
 description: |
+  In https://security.snyk.io/vuln/SNYK-RUBY-BCRYPT-20009, found
+  "The advisory has been revoked - it doesn't affect any version of package bcrypt"
+
   bcrypt-ruby Gem for Ruby suffered from a bug related to character
   encoding that substantially reduced the entropy of hashed passwords
   containing non US-ASCII characters. An incorrect encoding step
-  transparently replaced such characters by '?' prior to hashing. In the
-  worst case of a password consisting solely of non-US-ASCII characters,
-  this would cause its hash to be equivalent to all other such passwords
-  of the same length. This issue only affects the JRuby implementation.
+  transparently replaced such characters by '?' prior to hashing.
+  In the worst case of a password consisting solely of non-US-ASCII
+  characters, this would cause its hash to be equivalent to all other
+  such passwords of the same length.
+
+  This issue only affects the JRuby implementation.
 patched_versions:
-  - '>= 2.1.4'
+  - ">= 2.1.4"
+related:
+  url:
+    - https://github.com/jeremyh/jBCrypt
+    - http://www.mindrot.org/files/jBCrypt/internat.adv
+    - https://github.com/bcrypt-ruby/bcrypt-ruby/blob/master/ext/jruby/bcrypt_jruby/BCrypt.java

--- a/gems/brbackup/CVE-2014-5004.yml
+++ b/gems/brbackup/CVE-2014-5004.yml
@@ -3,11 +3,21 @@ gem: brbackup
 cve: 2014-5004
 osvdb: 108901
 ghsa: vqcm-7f7f-r539
-url: https://nvd.nist.gov/vuln/detail/CVE-2014-5004
+url: http://www.vapid.dhs.org/advisories/brbackup-0.1.1.html
 title: brbackup Gem for Ruby Process List Local Plaintext Password Disclosure
 date: 2014-07-09
 description: |
   brbackup Gem for Ruby contains a flaw that is due to the program exposing
   password information in plaintext in the process list. This may allow a
   local attacker to gain access to password information.
+cvss_v2: 2.1
 cvss_v3: 7.8
+notes: "Never patched"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-5004
+    - http://www.vapid.dhs.org/advisories/brbackup-0.1.1.html
+    - http://www.openwall.com/lists/oss-security/2014/07/10/6
+    - http://www.openwall.com/lists/oss-security/2014/07/17/5
+    - http://www.securityfocus.com/bid/68506
+    - https://web.archive.org/web/20200229055655/https://www.securityfocus.com/bid/68506/

--- a/gems/brbackup/OSVDB-108899.yml
+++ b/gems/brbackup/OSVDB-108899.yml
@@ -1,7 +1,7 @@
 ---
 gem: brbackup
 osvdb: 108899
-url: http://osvdb.org/show/osvdb/108899
+url: https://www.openwall.com/lists/oss-security/2014/07/10/6
 title: brbackup Gem for Ruby /lib/brbackup.rb name Parameter SQL Injection
 date: 2014-07-09
 description: |
@@ -10,3 +10,10 @@ description: |
   properly sanitizing user-supplied input to the 'name' parameter. This may
   allow a remote attacker to inject or manipulate SQL queries in the back-end
   database, allowing for the manipulation or disclosure of arbitrary data.
+notes: "Never patched"
+related:
+  url:
+    - https://www.openwall.com/lists/oss-security/2014/07/10/6
+    - https://raw.githubusercontent.com/codesake/codesake-dawn/master/Roadmap.md
+    - https://github.com/tongueroo/brbackup/blob/master/lib/brbackup.rb
+    - http://osvdb.org/show/osvdb/108899

--- a/gems/brbackup/OSVDB-108900.yml
+++ b/gems/brbackup/OSVDB-108900.yml
@@ -1,12 +1,18 @@
 ---
 gem: brbackup
 osvdb: 108900
-url: http://osvdb.org/show/osvdb/108900
-title: brbackup Gem for Ruby dbuser Variable Shell Metacharacter Injection Remote
-  Command Execution
+url: https://www.openwall.com/lists/oss-security/2014/07/10/6
+title: brbackup Gem for Ruby dbuser Variable Shell Metacharacter
+  Injection Remote Command Execution
 date: 2014-07-09
 description: |
   brbackup Gem for Ruby contains a flaw that is triggered as input passed
   via the 'dbuser' variable is not properly sanitized. This may allow a
   remote attacker to inject shell metacharacters and execute arbitrary
   commands.
+notes: "Never patched"
+related:
+  url:
+    - https://www.openwall.com/lists/oss-security/2014/07/10/6
+    - https://raw.githubusercontent.com/codesake/codesake-dawn/master/Roadmap.md
+    - http://osvdb.org/show/osvdb/108900

--- a/gems/builder/OSVDB-95668.yml
+++ b/gems/builder/OSVDB-95668.yml
@@ -1,7 +1,7 @@
 ---
 gem: builder
 osvdb: 95668
-url: http://osvdb.org/show/osvdb/95668
+url: https://my.diffend.io/gems/builder/2.1.1/2.1.2
 title: Builder Gem for Ruby Tag Name Handling Private Method Exposure
 date: 2007-06-15
 description: |
@@ -10,4 +10,8 @@ description: |
   method with that name. With a specially crafted file, a context-dependent
   attacker can call private methods and manipulate data.
 patched_versions:
-  - '>= 2.1.2'
+  - ">= 2.1.2"
+related:
+  url:
+    - https://my.diffend.io/gems/builder/2.1.1/2.1.2
+    - http://osvdb.org/show/osvdb/95668

--- a/gems/bundler/OSVDB-115090.yml
+++ b/gems/bundler/OSVDB-115090.yml
@@ -1,7 +1,7 @@
 ---
 gem: bundler
 osvdb: 115090
-url: http://www.osvdb.org/show/osvdb/115090
+url: https://github.com/rubygems/bundler/releases/tag/v1.3.0.pre.8
 title: Bundler Gem for Ruby Missing SSL Certificate Validation MitM Spoofing
 date: 2013-02-12
 description: |
@@ -10,4 +10,10 @@ description: |
   an attacker with the ability to intercept network traffic (e.g. MiTM, DNS
   cache poisoning) can disclose and optionally manipulate transmitted data.
 patched_versions:
-  - '>= 1.3.0.pre.8'
+  - ">= 1.3.0.pre.8"
+related:
+  url:
+    - https://github.com/rubygems/bundler/releases/tag/v1.3.0.pre.8
+    - https://my.diffend.io/gems/bundler/1.3.0.pre.7/1.3.0.pre.8
+    - https://my.diffend.io/gems/bundler/versions/1.0.0.beta.8
+    - http://www.osvdb.org/show/osvdb/115090

--- a/gems/bundler/OSVDB-115091.yml
+++ b/gems/bundler/OSVDB-115091.yml
@@ -1,13 +1,19 @@
 ---
 gem: bundler
 osvdb: 115091
-url: http://www.osvdb.org/show/osvdb/115091
-title: Bundler Gem for Ruby Redirection Remote HTTP Basic Authentication Credential
-  Disclosure
+url: https://github.com/rubygems/bundler/releases/tag/v1.3.0.pre.8
+title: Bundler Gem for Ruby Redirection Remote
+  HTTP Basic Authentication Credential Disclosure
 date: 2013-02-12
 description: |
   Bundler Gem for Ruby contains a flaw that is triggered during the
-  redirection to other hosts. This may allow a remote attacker to gain access
-  to HTTP basic authentication credential information.
+  redirection to other hosts. This may allow a remote attacker to
+  gain access to HTTP basic authentication credential information.
 patched_versions:
-  - '>= 1.3.0.pre.8'
+  - ">= 1.3.0.pre.8"
+related:
+  url:
+    - https://github.com/rubygems/bundler/releases/tag/v1.3.0.pre.8
+    - https://my.diffend.io/gems/bundler/1.3.0.pre.7/1.3.0.pre.8
+    - https://my.diffend.io/gems/bundler/versions/1.0.0.beta.8
+    - http://www.osvdb.org/show/osvdb/115091

--- a/gems/bundler/OSVDB-115917.yml
+++ b/gems/bundler/OSVDB-115917.yml
@@ -1,13 +1,21 @@
 ---
 gem: bundler
 osvdb: 115917
-url: http://www.osvdb.org/show/osvdb/115917
-title: Bundler Gem for Ruby install Command Process Listing Local Plaintext Credential
-  Disclosure
+url: https://my.diffend.io/gems/bundler/versions/1.0.0.beta.8
+title: Bundler Gem for Ruby install Command Process Listing
+  Local Plaintext Credential Disclosure
 date: 2011-09-20
 description: |
   Bundler Gem for Ruby contains a flaw that is due to the program listing
   credential information in plaintext in the install command process listing.
   This may allow a local attacker to gain access to credential information.
 patched_versions:
-  - '>= 1.1.rc'
+  - ">= 1.1.rc"
+related:
+  url:
+    - https://my.diffend.io/gems/bundler/versions/1.0.0.beta.8
+    - https://my.diffend.io/gems/bundler/versions/1.1.rc
+    - https://github.com/rubygems/bundler/commit/95bb14483cf8af857dc901c22db48cd3057d243e
+    - https://github.com/rubygems/bundler/pull/1463
+    - https://github.com/rubygems/bundler/issues/1440
+    - http://www.osvdb.org/show/osvdb/115917

--- a/gems/cap-strap/OSVDB-108575.yml
+++ b/gems/cap-strap/OSVDB-108575.yml
@@ -1,10 +1,16 @@
 ---
 gem: cap-strap
 osvdb: 108575
-url: http://osvdb.org/show/osvdb/108575
+url: https://www.openwall.com/lists/oss-security/2014/07/07/9
 title: cap-strap Gem for Ruby Hardcoded Password Crypt Hash Salt Weakness
 date: 2014-06-30
 description: |
   cap-strap Gem for Ruby contains a flaw that is due to the application
-  using a hardcoded default 'sa' salt for password encryption. This may allow a local
-  attacker to more easily decrypt passwords.
+  using a hardcoded default 'sa' salt for password encryption. This may
+  allow a local attacker to more easily decrypt passwords.
+notes: "Never patched"
+related:
+  url:
+    - https://www.openwall.com/lists/oss-security/2014/07/07/9
+    - https://github.com/substantial/cap-strap
+    - http://osvdb.org/show/osvdb/108575

--- a/gems/curb/OSVDB-114600.yml
+++ b/gems/curb/OSVDB-114600.yml
@@ -1,12 +1,17 @@
 ---
 gem: curb
 osvdb: 114600
-url: http://osvdb.org/show/osvdb/114600
+url: https://my.diffend.io/gems/curb/versions/0.6.4.0
 title: curb Gem for Ruby Empty http_put Body Handling Remote DoS
 date: 2010-08-12
 description: |
-  curb Gem for Ruby contains a flaw that is triggered when handling an empty
-  http_put body. This may allow a remote attacker to crash an application
-  linked against the library.
+  curb Gem for Ruby contains a flaw that is triggered when handling
+  an empty http_put body. This may allow a remote attacker to crash
+  an application linked against the library.
 patched_versions:
-  - '>= 0.7.8'
+  - ">= 0.7.8"
+related:
+  url:
+    - https://my.diffend.io/gems/curb/versions/0.6.4.0
+    - https://my.diffend.io/gems/curb/0.7.7.1/0.7.8
+    - http://osvdb.org/show/osvdb/114600

--- a/gems/devise/OSVDB-114435.yml
+++ b/gems/devise/OSVDB-114435.yml
@@ -11,5 +11,12 @@ description: |
   If an attacker has knowledge of said token, a specially crafted request can
   be made to it, allowing the attacker to conduct CSRF attacks.
 patched_versions:
-  - ~> 2.2.5
-  - '>= 3.0.1'
+  - "~> 2.2.5"
+  - ">= 3.0.1"
+related:
+  url:
+    - http://blog.plataformatec.com.br/2013/08/csrf-token-fixation-attacks-in-devise
+    - https://github.com/heartcombo/devise/commit/747751a20f50aa8814dcd3eb9a3648f00ab6a707
+    - https://github.com/heartcombo/devise/compare/v3.0.0...v3.0.1
+    - https://my.diffend.io/gems/devise/3.0.0/3.0.1
+    - https://security.snyk.io/vuln/SNYK-RUBY-DEVISE-20103

--- a/gems/doorkeeper/OSVDB-118830.yml
+++ b/gems/doorkeeper/OSVDB-118830.yml
@@ -1,7 +1,7 @@
 ---
 gem: doorkeeper
 osvdb: 118830
-url: http://www.osvdb.org/show/osvdb/118830
+url: https://www.versioneye.com/Ruby/doorkeeper/2.1.1
 title: Doorkeeper Gem for Ruby stores sensitive information in production logs
 date: 2015-02-10
 description: |
@@ -10,5 +10,17 @@ description: |
   production logs. This may allow a local attacker to gain access to
   sensitive information.
 patched_versions:
-  - ~> 1.4.2
-  - '>= 2.1.2'
+  - "~> 1.4.2"
+  - ">= 2.1.2"
+related:
+  url:
+    - https://www.versioneye.com/Ruby/doorkeeper/2.1.1
+    - https://github.com/doorkeeper-gem/doorkeeper/commit/d6bca5f32b741b8cee83a4aeb818338b919181fe
+    - https://github.com/doorkeeper-gem/doorkeeper/blob/main/lib/doorkeeper/engine.rb
+    - https://github.com/doorkeeper-gem/doorkeeper/issues/576
+    - https://github.com/rubysec/ruby-advisory-db/pull/128
+    - https://my.diffend.io/gems/doorkeeper/versions/0.3.0
+    - https://security.snyk.io/vuln/SNYK-RUBY-DOORKEEPER-20206
+    - https://www.mend.io/vulnerability-database/WS-2015-0039
+    - http://www.osvdb.org/show/osvdb/118830
+notes: "Issue #576 backported to 1.4.x on March 2, 2015."

--- a/gems/dragonfly/OSVDB-110439.yml
+++ b/gems/dragonfly/OSVDB-110439.yml
@@ -1,13 +1,19 @@
 ---
 gem: dragonfly
 osvdb: 110439
-url: http://osvdb.org/show/osvdb/110439
+url: https://github.com/markevans/dragonfly/compare/v1.0.6...v1.0.7
 title: Dragonfly Gem for Ruby Image Uploading & Processing Remote Command Execution
 date: 2014-08-25
 description: |
-  Dragonfly Gem for Ruby contains a flaw in Uploading & Processing that is due
-  to the gem failing to restrict arbitrary commands to imagemagicks convert.
-  This may allow a remote attacker to gain read/write access to the filesystem
-  and execute arbitrary commands.
+  Dragonfly Gem for Ruby contains a flaw in Uploading & Processing
+  that is due to the gem failing to restrict arbitrary commands to
+  imagemagicks convert. This may allow a remote attacker to gain
+  read/write access to the filesystem and execute arbitrary commands.
 patched_versions:
-  - '>= 1.0.7'
+  - ">= 1.0.7"
+related:
+  url:
+    - https://github.com/markevans/dragonfly/compare/v1.0.6...v1.0.7
+    - https://security.snyk.io/vuln/SNYK-RUBY-DRAGONFLY-20193
+    - https://www.mend.io/vulnerability-database/WS-2014-0016
+    - http://osvdb.org/show/osvdb/110439

--- a/gems/dragonfly/OSVDB-110439.yml
+++ b/gems/dragonfly/OSVDB-110439.yml
@@ -1,7 +1,7 @@
 ---
 gem: dragonfly
 osvdb: 110439
-url: https://github.com/markevans/dragonfly/compare/v1.0.6...v1.0.7
+url: https://security.snyk.io/vuln/SNYK-RUBY-DRAGONFLY-20193
 title: Dragonfly Gem for Ruby Image Uploading & Processing Remote Command Execution
 date: 2014-08-25
 description: |

--- a/gems/dragonfly/OSVDB-97854.yml
+++ b/gems/dragonfly/OSVDB-97854.yml
@@ -1,7 +1,7 @@
 ---
 gem: dragonfly
 osvdb: 97854
-url: https://github.com/markevans/dragonfly/blob/master/spec/dragonfly/shell_spec.rb#L26
+url: https://security.snyk.io/vuln/SNYK-RUBY-DRAGONFLY-20016
 title: Dragonfly Gem for Ruby on Windows Shell Escaping Weakness
 date: 2011-09-01
 description: |

--- a/gems/dragonfly/OSVDB-97854.yml
+++ b/gems/dragonfly/OSVDB-97854.yml
@@ -1,12 +1,20 @@
 ---
 gem: dragonfly
 osvdb: 97854
-url: http://osvdb.org/show/osvdb/97854
+url: https://github.com/markevans/dragonfly/blob/master/spec/dragonfly/shell_spec.rb#L26
 title: Dragonfly Gem for Ruby on Windows Shell Escaping Weakness
 date: 2011-09-01
 description: |
-  Dragonfly Gem for Ruby contains a flaw that is due to the program failing to
-  properly escape a shell that contains injected characters. This may allow a
-  context-dependent attacker to potentially execute arbitrary commands.
+  Dragonfly Gem for Ruby contains a flaw that is due to the program
+  failing to properly escape a shell that contains injected characters.
+  This may allow a context-dependent attacker to potentially execute
+  arbitrary commands.
 patched_versions:
-  - '>= 0.9.6'
+  - ">= 0.9.6"
+related:
+  url:
+    - https://github.com/markevans/dragonfly/blob/master/spec/dragonfly/shell_spec.rb#L26
+    - https://github.com/markevans/dragonfly/pull/506
+    - https://github.com/markevans/dragonfly/commit/f4f8e37a171a34f0ef3a6d80b52f44ed4d66d3bc
+    - https://security.snyk.io/vuln/SNYK-RUBY-DRAGONFLY-20016
+    - http://osvdb.org/show/osvdb/97854

--- a/gems/enum_column3/OSVDB-94679.yml
+++ b/gems/enum_column3/OSVDB-94679.yml
@@ -1,10 +1,15 @@
 ---
 gem: enum_column3
 osvdb: 94679
-url: http://osvdb.org/show/osvdb/94679
+url: https://security.snyk.io/vuln/SNYK-RUBY-ENUMCOLUMN3-20100
 title: enum_column3 Gem for Ruby Symbol Creation Remote DoS
 date: 2013-06-26
 description: |
   The enum_column3 Gem for Ruby contains a flaw that may allow a remote
-  denial of service. The issue is due to the program typecasting unexpected strings
-  to symbols. This may allow a remote attacker to crash the program.
+  denial of service. The issue is due to the program typecasting unexpected
+  strings to symbols. This may allow a remote attacker to crash the program.
+related:
+  url:
+    - https://security.snyk.io/vuln/SNYK-RUBY-ENUMCOLUMN3-20100
+    - http://osvdb.org/show/osvdb/94679
+notes: "Never patched"

--- a/gems/flavour_saver/OSVDB-110796.yml
+++ b/gems/flavour_saver/OSVDB-110796.yml
@@ -1,7 +1,7 @@
 ---
 gem: flavour_saver
 osvdb: 110796
-url: https://github.com/FlavourSaver/FlavourSaver/compare/v0.3.2...v0.3.3
+url: https://security.snyk.io/vuln/SNYK-RUBY-FLAVOURSAVER-5457859
 title: FlavourSaver handlebars helper remote code execution.
 date: 2014-09-04
 description: |

--- a/gems/flavour_saver/OSVDB-110796.yml
+++ b/gems/flavour_saver/OSVDB-110796.yml
@@ -1,7 +1,7 @@
 ---
 gem: flavour_saver
 osvdb: 110796
-url: http://osvdb.org/show/osvdb/110796
+url: https://github.com/FlavourSaver/FlavourSaver/compare/v0.3.2...v0.3.3
 title: FlavourSaver handlebars helper remote code execution.
 date: 2014-09-04
 description: |
@@ -10,4 +10,12 @@ description: |
   within the template context first.  This allows expressions such as
   {{system "ls"}} or {{eval "puts 1 + 1"}} to be executed.
 patched_versions:
-  - '>= 0.3.3'
+  - ">= 0.3.3"
+related:
+  url:
+    - https://github.com/FlavourSaver/FlavourSaver/compare/v0.3.2...v0.3.3
+    - https://github.com/FlavourSaver/FlavourSaver/commit/04a8ff444a9a9668a75b01b20b4974d398087a64
+    - https://raw.githubusercontent.com/codesake/codesake-dawn/master/Roadmap.md
+    - https://github.com/slowmistio/dawnscanner-analysis-security-scanner-for-ruby-/blob/master/Roadmap.md
+    - https://security.snyk.io/vuln/SNYK-RUBY-FLAVOURSAVER-5457859
+    - http://osvdb.org/show/osvdb/110796

--- a/gems/flukso4r/OSVDB-101577.yml
+++ b/gems/flukso4r/OSVDB-101577.yml
@@ -1,10 +1,16 @@
 ---
 gem: flukso4r
 osvdb: 101577
-url: http://osvdb.org/show/osvdb/101577
+url: https://vulners.com/seebug/SSV:61267
 title: flukso4r Gem for Ruby /lib/flukso/R.rb Arbitrary Command Execution
 date: 2013-12-31
 description: |
   flukso4r Gem for Ruby contains a flaw in /lib/flukso/R.rb that is due
   to the application failing to properly validate user-supplied input. This may allow
   a context-dependent attacker to execute arbitrary commands.
+notes: "No patched version"
+related:
+  url:
+    - https://security.snyk.io/vuln/SNYK-RUBY-FLUKSO4R-20136
+    - https://vulners.com/seebug/SSV:61267
+    - http://osvdb.org/show/osvdb/101577

--- a/gems/fog-dragonfly/OSVDB-110439.yml
+++ b/gems/fog-dragonfly/OSVDB-110439.yml
@@ -1,15 +1,21 @@
 ---
 gem: fog-dragonfly
 osvdb: 110439
-url: http://osvdb.org/show/osvdb/110439
+url: https://github.com/markevans/dragonfly/compare/v0.8.3...v0.8.4
 title: Dragonfly Gem for Ruby Image Uploading & Processing Remote Command Execution
-date: 2014-08-25
+date: 2010-04-27
 description: |
-  Dragonfly Gem for Ruby contains a flaw in Uploading & Processing that is due
-  to the gem failing to restrict arbitrary commands to imagemagicks convert.
-  This may allow a remote attacker to gain read/write access to the filesystem
-  and execute arbitrary commands.
+  Dragonfly Gem for Ruby contains a flaw in Uploading & Processing
+  that is due to the gem failing to restrict arbitrary commands to
+  imagemagicks convert. This may allow a remote attacker to gain
+  read/write access to the filesystem and execute arbitrary commands.
 
   This gem has been renamed. Please use "dragonfly" from now on.
 patched_versions:
-  - '>= 0.8.4'
+  - ">= 0.8.4"
+related:
+  url:
+    - https://github.com/markevans/dragonfly/compare/v0.8.3...v0.8.4
+    - https://security.snyk.io/vuln/SNYK-RUBY-DRAGONFLY-20193
+    - https://www.mend.io/vulnerability-database/WS-2014-0016
+    - http://osvdb.org/show/osvdb/110439

--- a/gems/fog-dragonfly/OSVDB-110439.yml
+++ b/gems/fog-dragonfly/OSVDB-110439.yml
@@ -1,7 +1,7 @@
 ---
 gem: fog-dragonfly
 osvdb: 110439
-url: https://github.com/markevans/dragonfly/compare/v0.8.3...v0.8.4
+url: https://security.snyk.io/vuln/SNYK-RUBY-DRAGONFLY-20193
 title: Dragonfly Gem for Ruby Image Uploading & Processing Remote Command Execution
 date: 2010-04-27
 description: |

--- a/gems/fog-dragonfly/OSVDB-97854.yml
+++ b/gems/fog-dragonfly/OSVDB-97854.yml
@@ -1,12 +1,22 @@
 ---
 gem: fog-dragonfly
 osvdb: 97854
-url: http://osvdb.org/show/osvdb/97854
+url: https://github.com/markevans/dragonfly/blob/master/spec/dragonfly/shell_spec.rb#L26
 title: Dragonfly Gem for Ruby on Windows Shell Escaping Weakness
 date: 2011-09-01
 description: |
-  Dragonfly Gem for Ruby contains a flaw that is due to the program failing to
-  properly escape a shell that contains injected characters. This may allow a
-  context-dependent attacker to potentially execute arbitrary commands.
+  Dragonfly Gem for Ruby contains a flaw that is due to the program
+  failing to properly escape a shell that contains injected characters.
+  This may allow a context-dependent attacker to potentially execute
+  arbitrary commands.
 
   This gem has been renamed. Please use "dragonfly" from now on.
+patched_versions:
+  - ">= 0.9.6"
+related:
+  url:
+    - https://github.com/markevans/dragonfly/blob/master/spec/dragonfly/shell_spec.rb#L26
+    - https://github.com/markevans/dragonfly/pull/506
+    - https://github.com/markevans/dragonfly/commit/f4f8e37a171a34f0ef3a6d80b52f44ed4d66d3bc
+    - https://security.snyk.io/vuln/SNYK-RUBY-DRAGONFLY-20016
+    - http://osvdb.org/show/osvdb/97854

--- a/gems/fog-dragonfly/OSVDB-97854.yml
+++ b/gems/fog-dragonfly/OSVDB-97854.yml
@@ -1,7 +1,7 @@
 ---
 gem: fog-dragonfly
 osvdb: 97854
-url: https://github.com/markevans/dragonfly/blob/master/spec/dragonfly/shell_spec.rb#L26
+url: https://security.snyk.io/vuln/SNYK-RUBY-DRAGONFLY-20016
 title: Dragonfly Gem for Ruby on Windows Shell Escaping Weakness
 date: 2011-09-01
 description: |

--- a/gems/gnms/OSVDB-108594.yml
+++ b/gems/gnms/OSVDB-108594.yml
@@ -1,11 +1,16 @@
 ---
 gem: gnms
 osvdb: 108594
-url: http://osvdb.org/show/osvdb/108594
-title: gnms Gem for Ruby /lib/cmd_parse.rb ip Variable Shell Metacharacter Handling
-  Remote Command Injection
+url: http://www.vapidlabs.com/advisories/gnms-2.1.1.html
+title: gnms Gem for Ruby /lib/cmd_parse.rb ip Variable
+  Shell Metacharacter Handling Remote Command Injection
 date: 2014-06-30
 description: |
   gnms Gem for Ruby contains a flaw in /lib/cmd_parse.rb that is triggered
-  when handling shell metacharacters passed via the 'ip' variable. This may allow
-  a remote attacker to inject arbitrary commands.
+  when handling shell metacharacters passed via the 'ip' variable.
+  This may allow a remote attacker to inject arbitrary commands.
+notes: "Never patched"
+related:
+  url:
+    - http://www.vapidlabs.com/advisories/gnms-2.1.1.html
+    - http://osvdb.org/show/osvdb/108594

--- a/gems/handlebars-source/OSVDB-131671.yml
+++ b/gems/handlebars-source/OSVDB-131671.yml
@@ -1,17 +1,25 @@
 ---
 gem: handlebars-source
 osvdb: 131671
-url: https://blog.srcclr.com/handlebars_vulnerability_research_findings/
+url: https://github.com/handlebars-lang/handlebars.js/compare/v3.0.8...v4.0.0
 title: handlebars.js - quoteless attributes in templates can lead to XSS
 date: 2015-08-24
 description: |
-  The upstream 'handlebars' node.js module was found to not properly escape
-  equals (=) signs, leading to possible content injection via attributes
-  in templates.
+  The upstream 'handlebars' node.js module was found to not properly
+  escape equals (=) signs, leading to possible content injection
+  via attributes in templates.
 
   Example:
   * Template: <a href={{foo}}/>
   * Input: { 'foo' : 'test.com onload=alert(1)'}
   * Rendered result: <a href=test.com onload=alert(1)/>
 patched_versions:
-  - '>= 4.0.0'
+  - ">= 4.0.0"
+related:
+  ghsa:
+    - 9prh-257w-9277
+  url:
+    - https://github.com/handlebars-lang/handlebars.js
+    - https://security.snyk.io/vuln/SNYK-RUBY-HANDLEBARSSOURCE-20238
+    - https://github.com/rubysec/bundler-audit/issues/185
+    - https://www.veracode.com/blog/research/handlebarsjs-vulnerability-impact-study

--- a/gems/handlebars-source/OSVDB-131671.yml
+++ b/gems/handlebars-source/OSVDB-131671.yml
@@ -1,7 +1,7 @@
 ---
 gem: handlebars-source
 osvdb: 131671
-url: https://github.com/handlebars-lang/handlebars.js/compare/v3.0.8...v4.0.0
+url: https://security.snyk.io/vuln/SNYK-RUBY-HANDLEBARSSOURCE-20238
 title: handlebars.js - quoteless attributes in templates can lead to XSS
 date: 2015-08-24
 description: |
@@ -20,6 +20,7 @@ related:
     - 9prh-257w-9277
   url:
     - https://github.com/handlebars-lang/handlebars.js
+    - https://github.com/handlebars-lang/handlebars.js/compare/v3.0.8...v4.0.0
     - https://security.snyk.io/vuln/SNYK-RUBY-HANDLEBARSSOURCE-20238
     - https://github.com/rubysec/bundler-audit/issues/185
     - https://www.veracode.com/blog/research/handlebarsjs-vulnerability-impact-study

--- a/gems/jruby-sandbox/OSVDB-106279.yml
+++ b/gems/jruby-sandbox/OSVDB-106279.yml
@@ -2,11 +2,15 @@
 gem: jruby-sandbox
 platform: jruby
 osvdb: 106279
-url: http://www.phenoelit.org/stuff/jruby-sandbox.txt
+url: https://www.exploit-db.com/exploits/33028
 title: jruby-sandbox Java Class Importation Sandbox Bypass
 date: 2014-04-24
 description: |
   jruby-sandbox contains a flaw that is triggered when importing Java Classes.
   This may allow a remote attacker to bypass the sandbox for code execution.
 patched_versions:
-  - '>= 0.2.3'
+  - ">= 0.2.3"
+related:
+  url:
+    - https://www.exploit-db.com/exploits/33028
+    - https://security.snyk.io/vuln/SNYK-RUBY-JRUBYSANDBOX-20156

--- a/gems/jruby-sandbox/OSVDB-106279.yml
+++ b/gems/jruby-sandbox/OSVDB-106279.yml
@@ -2,7 +2,7 @@
 gem: jruby-sandbox
 platform: jruby
 osvdb: 106279
-url: https://www.exploit-db.com/exploits/33028
+url: https://security.snyk.io/vuln/SNYK-RUBY-JRUBYSANDBOX-20156
 title: jruby-sandbox Java Class Importation Sandbox Bypass
 date: 2014-04-24
 description: |

--- a/gems/json/OSVDB-101157.yml
+++ b/gems/json/OSVDB-101157.yml
@@ -1,7 +1,7 @@
 ---
 gem: json
 osvdb: 101157
-url: http://osvdb.org/show/osvdb/101157
+url: https://security.snyk.io/vuln/SNYK-RUBY-JSON-20000
 title: json Gem for Ruby Data Handling Stack Buffer Overflow
 date: 2007-05-21
 description: |
@@ -11,4 +11,8 @@ description: |
   overflow, resulting in a denial of service or potentially allowing the
   execution of arbitrary code.
 patched_versions:
-  - '>= 1.1.0'
+  - ">= 1.1.0"
+related:
+  url:
+    - https://security.snyk.io/vuln/SNYK-RUBY-JSON-20000
+    - http://osvdb.org/show/osvdb/101157

--- a/gems/kajam/OSVDB-108530.yml
+++ b/gems/kajam/OSVDB-108530.yml
@@ -1,12 +1,18 @@
 ---
 gem: kajam
 osvdb: 108530
-url: http://osvdb.org/show/osvdb/108530
-title: kajam Gem for Ruby /dataset/lib/dataset/database/postgresql.rb Metacharacter
-  Handling Remote Command Execution
+url: https://security.snyk.io/vuln/SNYK-RUBY-KAJAM-20171
+title: kajam Gem for Ruby /dataset/lib/dataset/database/postgresql.rb
+  Metacharacter Handling Remote Command Execution
 date: 2014-06-30
 description: |
   kajam Gem for Ruby contains a flaw in
-  /dataset/lib/dataset/database/postgresql.rb that is triggered when handling
-  metacharacters. This may allow a remote attacker to execute arbitrary
-  commands.
+  /dataset/lib/dataset/database/postgresql.rb that is triggered
+  when handling metacharacters. This may allow a remote attacker
+  to execute arbitrary commands.
+notes: "Never patched"
+related:
+  url:
+    - https://security.snyk.io/vuln/SNYK-RUBY-KAJAM-20171
+    - https://my.diffend.io/gems/kajam/1.0.3.rc2
+    - http://osvdb.org/show/osvdb/108530

--- a/gems/kcapifony/OSVDB-108572.yml
+++ b/gems/kcapifony/OSVDB-108572.yml
@@ -1,11 +1,17 @@
 ---
 gem: kcapifony
 osvdb: 108572
-url: http://osvdb.org/show/osvdb/108572
-title: kcapifony Gem for Ruby /lib/ksymfony1.rb Metacharacter Handling Remote Command
-  Execution
+url: https://www.mend.io/vulnerability-database/WS-2014-0019
+title: kcapifony Gem for Ruby /lib/ksymfony1.rb Metacharacter
+  Handling Remote Command Execution
 date: 2014-06-30
 description: |
-  kcapifony Gem for Ruby contains a flaw in /lib/ksymfony1.rb that is triggered
-  when handling metacharacters. This may allow a remote attacker to execute arbitrary
-  commands.
+  kcapifony Gem for Ruby contains a flaw in /lib/ksymfony1.rb that
+  is triggered when handling metacharacters. This may allow a remote
+  attacker to execute arbitrary commands.
+notes: "Never patched"
+related:
+  url:
+    - https://www.mend.io/vulnerability-database/WS-2014-0019
+    - https://github.com/Kunstmaan/kCapifony/blob/master/lib/ksymfony1.rb
+    - http://osvdb.org/show/osvdb/108572

--- a/gems/kompanee-recipes/OSVDB-108593.yml
+++ b/gems/kompanee-recipes/OSVDB-108593.yml
@@ -1,9 +1,9 @@
 ---
 gem: kompanee-recipes
 osvdb: 108593
-url: http://osvdb.org/show/osvdb/108593
-title: kompanee-recipes Gem for Ruby /lib/kompanee-recipes/heroku.rb Multiple Variable
-  Handling Remote Command Execution Weakness
+url: https://www.openwall.com/lists/oss-security/2014/07/07/17
+title: kompanee-recipes Gem for Ruby /lib/kompanee-recipes/heroku.rb
+  Multiple Variable Handling Remote Command Execution Weakness
 date: 2014-06-30
 description: |
   kompanee-recipes Gem for Ruby contains a flaw in
@@ -11,3 +11,11 @@ description: |
   metacharacters passed via the 'password', 'user', 'deploy_name', and
   'application' variables. This may allow a remote attacker to execute
   arbitrary commands.
+notes: "Never patched"
+related:
+  url:
+    - https://www.openwall.com/lists/oss-security/2014/07/07/17
+    - https://seclists.org/oss-sec/2014/q3/162
+    - https://www.mend.io/vulnerability-database/WS-2014-0025
+    - https://security.snyk.io/vuln/SNYK-RUBY-KOMPANEERECIPES-20177
+    - http://osvdb.org/show/osvdb/108593

--- a/gems/lingq/OSVDB-108585.yml
+++ b/gems/lingq/OSVDB-108585.yml
@@ -1,9 +1,16 @@
 ---
 gem: lingq
 osvdb: 108585
-url: http://osvdb.org/show/osvdb/108585
-title: lingq Gem for Ruby client.rb Metacharacter Handling Remote Command Execution
+url: https://www.versioneye.com/Ruby/lingq/0.3.1
+title: lingq Gem for Ruby client.rb Metacharacter
+  Handling Remote Command Execution
 date: 2014-06-30
 description: |
-  lingq Gem for Ruby contains a flaw in client.rb that is triggered when
-  handling metacharacters. This may allow a remote attacker to execute arbitrary commands.
+  lingq Gem for Ruby contains a flaw in client.rb that is triggered
+  when handling metacharacters. This may allow a remote attacker
+  to execute arbitrary commands.
+notes: "Never patched"
+related:
+  url:
+    - https://www.versioneye.com/Ruby/lingq/0.3.1
+    - http://osvdb.org/show/osvdb/108585

--- a/gems/loofah/OSVDB-90945.yml
+++ b/gems/loofah/OSVDB-90945.yml
@@ -1,7 +1,7 @@
 ---
 gem: loofah
 osvdb: 90945
-url: https://github.com/flavorjones/loofah/compare/v0.4.5...v0.4.6
+url: https://security.snyk.io/vuln/SNYK-RUBY-LOOFAH-20039
 title: Loofah HTML and XSS injection vulnerability
 date: 2012-09-08
 description: |
@@ -19,7 +19,7 @@ patched_versions:
 related:
   url:
     - https://github.com/flavorjones/loofah/compare/v0.4.5...v0.4.6
+    - https://security.snyk.io/vuln/SNYK-RUBY-LOOFAH-20039
     - https://www.versioneye.com/Ruby/loofah/0.4.2
     - https://www.mend.io/vulnerability-database/WS-2012-0023
-    - https://security.snyk.io/vuln/SNYK-RUBY-LOOFAH-20039
     - http://www.osvdb.org/show/osvdb/90945

--- a/gems/loofah/OSVDB-90945.yml
+++ b/gems/loofah/OSVDB-90945.yml
@@ -1,7 +1,7 @@
 ---
 gem: loofah
 osvdb: 90945
-url: http://www.osvdb.org/show/osvdb/90945
+url: https://github.com/flavorjones/loofah/compare/v0.4.5...v0.4.6
 title: Loofah HTML and XSS injection vulnerability
 date: 2012-09-08
 description: |
@@ -15,4 +15,11 @@ description: |
   within the trust relationship between their browser and the server.
 cvss_v2: 5.0
 patched_versions:
-  - '>= 0.4.6'
+  - ">= 0.4.6"
+related:
+  url:
+    - https://github.com/flavorjones/loofah/compare/v0.4.5...v0.4.6
+    - https://www.versioneye.com/Ruby/loofah/0.4.2
+    - https://www.mend.io/vulnerability-database/WS-2012-0023
+    - https://security.snyk.io/vuln/SNYK-RUBY-LOOFAH-20039
+    - http://www.osvdb.org/show/osvdb/90945

--- a/gems/lynx/OSVDB-108579.yml
+++ b/gems/lynx/OSVDB-108579.yml
@@ -1,9 +1,16 @@
 ---
 gem: lynx
 osvdb: 108579
-url: http://osvdb.org/show/osvdb/108579
+url: https://www.openwall.com/lists/oss-security/2014/07/07/23
 title: lynx Gem for Ruby lib/lynx/pipe/run.rb Remote Command Execution
 date: 2014-06-30
 description: |
-  lynx Gem for Ruby contains a flaw in lib/lynx/pipe/run.rb that may allow
-  a remote attacker to execute arbitrary commands.
+  lynx Gem for Ruby contains a flaw in lib/lynx/pipe/run.rb that
+  may allow a remote attacker to execute arbitrary commands.
+notes: "Never patched"
+related:
+  url:
+    - https://www.openwall.com/lists/oss-security/2014/07/07/23
+    - https://security.snyk.io/vuln/SNYK-RUBY-LYNX-20160
+    - https://github.com/panthomakos/lynx/blob/master/lib/lynx/pipe/run.rb
+    - http://osvdb.org/show/osvdb/108579

--- a/gems/mustache-js-rails/OSVDB-131671.yml
+++ b/gems/mustache-js-rails/OSVDB-131671.yml
@@ -1,7 +1,7 @@
 ---
 gem: mustache-js-rails
 osvdb: 131671
-url: https://github.com/janl/mustache.js/pull/530
+url: https://security.snyk.io/vuln/SNYK-RUBY-MUSTACHEJSRAILS-20242
 title: mustache.js - quoteless attributes in templates can lead to XSS
 date: 2015-11-17
 description: |

--- a/gems/mustache-js-rails/OSVDB-131671.yml
+++ b/gems/mustache-js-rails/OSVDB-131671.yml
@@ -1,17 +1,24 @@
 ---
 gem: mustache-js-rails
 osvdb: 131671
-url: https://blog.srcclr.com/handlebars_vulnerability_research_findings/
+url: https://github.com/janl/mustache.js/pull/530
 title: mustache.js - quoteless attributes in templates can lead to XSS
 date: 2015-11-17
 description: |
-  The upstream 'mustache.js' node.js module was found to not properly escape
-  backtick (`) and equals (=) characters, leading to possible content injection
-  via attributes in templates.
+  The upstream 'mustache.js' node.js module was found to not properly
+  escape backtick (`) and equals (=) characters, leading to possible
+  content injection via attributes in templates.
 
   Example:
   * Template: <a href={{foo}}/>
   * Input: { 'foo' : 'test.com onload=alert(1)'}
   * Rendered result: <a href=test.com onload=alert(1)/>
 patched_versions:
-  - '>= 2.0.3'
+  - ">= 2.0.3"
+related:
+  ghsa:
+    - w3w8-37jv-2c58
+  url:
+    - https://github.com/janl/mustache.js/pull/530
+    - https://security.snyk.io/vuln/SNYK-RUBY-MUSTACHEJSRAILS-20242
+    - https://www.veracode.com/blog/research/handlebarsjs-vulnerability-impact-study

--- a/gems/nokogiri/OSVDB-118481.yml
+++ b/gems/nokogiri/OSVDB-118481.yml
@@ -4,12 +4,20 @@ platform: jruby
 osvdb: 118481
 url: https://github.com/sparklemotion/nokogiri/pull/1087
 title:
-  Nokogiri Gem for JRuby XML Document Root Element Handling Memory Consumption
-  Remote DoS
+  Nokogiri Gem for JRuby XML Document Root Element
+  Handling Memory Consumption Remote DoS
 date: 2014-04-30
 description: |
-  Nokogiri Gem for JRuby contains a flaw that is triggered when handling a root
-  element in an XML document. This may allow a remote attacker to cause a
-  consumption of memory resources.
+  Nokogiri Gem for JRuby contains a flaw that is triggered when
+  handling a root element in an XML document. This may allow a
+  remote attacker to cause a consumption of memory resources.
 patched_versions:
-  - '>= 1.6.3'
+  - "~> 1.6.2.2"
+  - ">= 1.6.3"
+related:
+  cve:
+    - 2013-6461
+  url:
+    - https://github.com/sparklemotion/nokogiri/pull/1087
+    - https://github.com/sparklemotion/nokogiri/pull/1087/commits/8293bf6fddecb68b688cf025859afde7609f7bff
+    - https://github.com/sparklemotion/nokogiri/commit/a098ddfc9990ea79dbc191407d3e83611e5ff1e6

--- a/gems/paperclip/OSVDB-103151.yml
+++ b/gems/paperclip/OSVDB-103151.yml
@@ -1,8 +1,8 @@
 ---
 gem: paperclip
 osvdb: 103151
-url: http://osvdb.org/show/osvdb/103151
-title: Paperclip Gem for Ruby contains a flaw
+url: https://security.snyk.io/vuln/SNYK-RUBY-PAPERCLIP-20144
+title: "Paperclip: Access Restriction Bypass"
 date: 2014-01-31
 description: |
   Paperclip Gem for Ruby contains a flaw that is due to the application
@@ -10,4 +10,10 @@ description: |
   header during file uploads. This may allow a remote attacker to bypass restrictions
   on file types for uploaded files by spoofing the content-type.
 patched_versions:
-  - '>= 4.0.0'
+  - ">= 4.0.0"
+related:
+  url:
+    - https://thoughtbot.com/blog/prevent-spoofing-with-paperclip
+    - https://www.theregister.com/2014/02/09/content_type_spoofing_bug_in_ror_paperclip
+    - https://security.snyk.io/vuln/SNYK-RUBY-PAPERCLIP-20144
+    - http://osvdb.org/show/osvdb/103151

--- a/gems/quick_magick/OSVDB-106954.yml
+++ b/gems/quick_magick/OSVDB-106954.yml
@@ -1,11 +1,16 @@
 ---
 gem: quick_magick
 osvdb: 106954
-url: http://osvdb.org/show/osvdb/106954
-title: quick_magick Gem for Ruby QuickMagick::Image.read Function Crafted String Handling
-  Remote Command Injection
+url: https://security.snyk.io/vuln/SNYK-RUBY-QUICKMAGICK-20012
+title: quick_magick Gem for Ruby QuickMagick::Image.read Function
+  Crafted String Handling Remote Command Injection
 date: 2011-01-12
 description: |
   quick_magick Gem for Ruby contains a flaw in the QuickMagick::Image.read
-  function. The issue is triggered when handling a specially crafted string. This
-  may allow a remote attacker to inject arbitrary commands.
+  function. The issue is triggered when handling a specially crafted string.
+  This may allow a remote attacker to inject arbitrary commands.
+notes: "Never patched"
+related:
+  url:
+    - https://security.snyk.io/vuln/SNYK-RUBY-QUICKMAGICK-20012
+    - http://osvdb.org/show/osvdb/106954

--- a/gems/rack-attack/OSVDB-132234.yml
+++ b/gems/rack-attack/OSVDB-132234.yml
@@ -23,4 +23,10 @@ description: |
   would not match a request to '/login/', though Rails would route
   '/login/' to the same '/login' action.
 patched_versions:
-  - '>= 4.3.1'
+  - ">= 4.3.1"
+related:
+  url:
+    - https://github.com/kickstarter/rack-attack/releases/tag/v4.3.1
+    - https://github.com/rack/rack-attack/commit/76c2e3143099d938883ae5654527b47e9e6a8977
+    - https://security.snyk.io/vuln/SNYK-RUBY-RACKATTACK-20246
+    - https://github.com/rack/rack-attack/blob/main/CHANGELOG.md

--- a/gems/redcarpet/OSVDB-120415.yml
+++ b/gems/redcarpet/OSVDB-120415.yml
@@ -12,4 +12,14 @@ description: |
   execute arbitrary script code in a user's browser session within the trust
   relationship between their browser and the server.
 patched_versions:
-  - '>= 3.2.3'
+  - ">= 3.2.3"
+related:
+  url:
+    - https://github.com/vmg/redcarpet/releases/tag/v3.2.3
+    - http://danlec.com/blog/bug-in-sundown-and-redcarpet
+    - https://hackerone.com/reports/46916
+    - https://github.com/vmg/redcarpet/blob/master/ext/redcarpet/markdown.c
+    - https://github.com/Homebrew/brew.sh/issues/75
+    - https://git.revreso.de/gigadoc2/diaspora/-/tags/v0.4.1.3
+    - https://www.rapid7.com/db/vulnerabilities/freebsd-vid-c368155a-fa83-11e4-bc58-001e67150279
+    - https://www.mend.io/vulnerability-database/WS-2015-0038

--- a/gems/redis-namespace/OSVDB-96425.yml
+++ b/gems/redis-namespace/OSVDB-96425.yml
@@ -9,7 +9,13 @@ description: |
   The issue is triggered when handling exec commands called via send(). This may allow a
   remote attacker to execute arbitrary commands.
 patched_versions:
-  - '>= 1.3.1'
-  - ~> 1.2.2
-  - ~> 1.1.1
-  - ~> 1.0.4
+  - "~> 1.0.4"
+  - "~> 1.1.1"
+  - "~> 1.2.2"
+  - ">= 1.3.1"
+related:
+  url:
+    - http://blog.steveklabnik.com/posts/2013-08-03-redis-namespace-1-3-1--security-release
+    - https://github.com/resque/redis-namespace/issues/65
+    - https://github.com/resque/redis-namespace/commit/6d839515e8a3fdc17b5fb391500fda3f919689d6
+    - https://security.snyk.io/vuln/SNYK-RUBY-REDISNAMESPACE-20105

--- a/gems/refile/OSVDB-120857.yml
+++ b/gems/refile/OSVDB-120857.yml
@@ -1,7 +1,7 @@
 ---
 gem: refile
 osvdb: 120857
-url: https://groups.google.com/forum/#!topic/ruby-security-ann/VIfMO2LvzNs
+url: https://groups.google.com/g/ruby-security-ann/c/VIfMO2LvzNs
 title: refile Gem for Ruby contains a remote code execution vulnerability
 date: 2015-04-15
 description: |
@@ -10,6 +10,9 @@ description: |
   'image' is the name of the attachment. This may allow a remote attacker
   to execute arbitrary shell commands.
 unaffected_versions:
-  - < 0.5.0
+  - "< 0.5.0"
 patched_versions:
-  - '>= 0.5.4'
+  - ">= 0.5.4"
+related:
+  url:
+    - https://groups.google.com/g/ruby-security-ann/c/VIfMO2LvzNs

--- a/gems/ruby-saml/OSVDB-117903.yml
+++ b/gems/ruby-saml/OSVDB-117903.yml
@@ -1,12 +1,21 @@
 ---
 gem: ruby-saml
 osvdb: 117903
-url: http://www.osvdb.org/show/osvdb/117903
+url: https://advisories.dxw.com/advisories/publicly-exploitable-command-injection-in-ruby-saml-0-7-2-library-can-root-the-host
 title: Ruby-Saml Gem is vulnerable to arbitrary code execution
 date: 2015-02-03
 description: |
-  ruby-saml contains a flaw that is triggered as the URI value of a SAML response is
-  not properly sanitized through a prepared statement. This may allow a remote
-  attacker to execute arbitrary shell commands on the host machine.
+  ruby-saml contains a flaw that is triggered as the URI value of a
+  SAML response is not properly sanitized through a prepared statement.
+  This may allow a remote attacker to execute arbitrary shell commands
+  on the host machine.
 patched_versions:
-  - '>= 0.8.2'
+  - ">= 0.8.2"
+related:
+  url:
+    - https://advisories.dxw.com/advisories/publicly-exploitable-command-injection-in-ruby-saml-0-7-2-library-can-root-the-host
+    - https://seclists.org/oss-sec/2015/q3/282
+    - https://github.com/SAML-Toolkits/ruby-saml/pull/225#issuecomment-120084288
+    - https://github.com/SAML-Toolkits/ruby-saml/commit/1b4e3dd6d2d44efa629144b2180842456bfb2a0f#diff-661b9d9743a3ff77661f224c6191165cL242
+    - https://www.mend.io/vulnerability-database/WS-2015-0040
+    - http://www.osvdb.org/show/osvdb/117903

--- a/gems/ruby-saml/OSVDB-124383.yml
+++ b/gems/ruby-saml/OSVDB-124383.yml
@@ -1,11 +1,17 @@
 ---
 gem: ruby-saml
 osvdb: 124383
-url: https://github.com/onelogin/ruby-saml/pull/247
+url: https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.0.0
 title: Ruby-Saml Gem is vulnerable to entity expansion attacks
 date: 2015-06-30
 description: |
   ruby-saml before 1.0.0 is vulnerable to entity expansion attacks.
 cvss_v2: 3.9
 patched_versions:
-  - '>= 1.0.0'
+  - ">= 1.0.0"
+related:
+  url:
+    - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.0.0
+    - https://github.com/SAML-Toolkits/ruby-saml/pull/247
+    - https://security.snyk.io/vuln/SNYK-RUBY-RUBYSAML-20232
+    - https://github.com/onelogin/ruby-saml/pull/247

--- a/gems/ruby-saml/OSVDB-124991.yml
+++ b/gems/ruby-saml/OSVDB-124991.yml
@@ -1,13 +1,19 @@
 ---
 gem: ruby-saml
 osvdb: 124991
-url: https://github.com/onelogin/ruby-saml/pull/225
+url: https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.0.0
 title: Ruby-Saml Gem is vulnerable to XPath Injection
 date: 2015-04-29
 description: |
-  ruby-saml before 1.0.0 is vulnerable to XPath injection on xml_security.rb. The
-  lack of prepared statements allows for possibly command injection, leading to
-  arbitrary code execution
+  ruby-saml before 1.0.0 is vulnerable to XPath injection on
+  xml_security.rb. The lack of prepared statements allows for
+  possibly command injection, leading to arbitrary code execution.
 cvss_v2: 6.7
 patched_versions:
-  - '>= 1.0.0'
+  - ">= 1.0.0"
+related:
+  url:
+    - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.0.0
+    - https://github.com/SAML-Toolkits/ruby-saml/pull/225
+    - https://security.snyk.io/vuln/SNYK-RUBY-RUBYSAML-20217
+    - https://www.mend.io/vulnerability-database/WS-2015-0036

--- a/gems/screen_capture/OSVDB-107783.yml
+++ b/gems/screen_capture/OSVDB-107783.yml
@@ -1,11 +1,16 @@
 ---
 gem: screen_capture
 osvdb: 107783
-url: http://osvdb.org/show/osvdb/107783
-title: Screen Capture Gem for Ruby screen_capture.rb URL Handling Arbitrary Command
-  Execution
+url: https://github.com/jamster/screen_capture/blob/master/lib/screen_capture.rb
+title: Screen Capture Gem for Ruby screen_capture.rb
+  URL Handling Arbitrary Command Execution
 date: 2014-06-07
 description: |
   Screen Capture Gem for Ruby contains a flaw in screen_capture.rb that
-  is triggered when handling input passed via the URL. This may allow a context-dependent
-  attacker to execute arbitrary commands.
+  is triggered when handling input passed via the URL. This may allow
+  a context-dependent attacker to execute arbitrary commands.
+notes: "Never patched"
+related:
+  url:
+    - https://github.com/jamster/screen_capture/blob/master/lib/screen_capture.rb
+    - http://osvdb.org/show/osvdb/107783

--- a/gems/sidekiq-pro/OSVDB-126329.yml
+++ b/gems/sidekiq-pro/OSVDB-126329.yml
@@ -1,12 +1,18 @@
 ---
 gem: sidekiq-pro
 osvdb: 126329
-url: https://github.com/mperham/sidekiq/commit/a695ff347ae50f641dfc35189131b232ea0aa1db
+url: https://github.com/sidekiq/sidekiq/blob/main/Pro-Changes.md#202
 title:
-  Sidekiq Pro Gem for Ruby web/views/batch.erb Class and ErrorMessage Elements
-  Reflected XSS
+  Sidekiq Pro Gem for Ruby web/views/batch.erb Class and
+  ErrorMessage Elements Reflected XSS
 date: 2015-05-11
 description: |
   XSS via batch failure error_class and error_message in Sidekiq::Web
 patched_versions:
-  - '>= 2.0.2'
+  - ">= 2.0.2"
+related:
+  url:
+    - https://github.com/sidekiq/sidekiq/blob/main/Pro-Changes.md#202
+    - https://github.com/mperham/sidekiq/commit/a695ff347ae50f641dfc35189131b232ea0aa1db
+    - https://github.com/sidekiq/sidekiq/issues/2467
+    - https://security.snyk.io/vuln/SNYK-RUBY-SIDEKIQPRO-20219

--- a/gems/sidekiq-pro/OSVDB-126330.yml
+++ b/gems/sidekiq-pro/OSVDB-126330.yml
@@ -1,7 +1,7 @@
 ---
 gem: sidekiq-pro
 osvdb: 126330
-url: https://github.com/mperham/sidekiq/commit/99b12fb50fe244c5a317f03f1bed9b333ec56ebe
+url: https://security.snyk.io/vuln/SNYK-RUBY-SIDEKIQPRO-20197
 title: Sidekiq Pro Gem for Ruby web/views/batch{,es}.erb Description Element XSS
 date: 2014-10-13
 description: |

--- a/gems/sidekiq-pro/OSVDB-126330.yml
+++ b/gems/sidekiq-pro/OSVDB-126330.yml
@@ -7,4 +7,8 @@ date: 2014-10-13
 description: |
   XSS via batch description in Sidekiq::Web
 patched_versions:
-  - '>= 1.9.1'
+  - ">= 1.9.1"
+related:
+  url:
+    - https://github.com/mperham/sidekiq/commit/99b12fb50fe244c5a317f03f1bed9b333ec56ebe
+    - https://security.snyk.io/vuln/SNYK-RUBY-SIDEKIQPRO-20197

--- a/gems/sidekiq-pro/OSVDB-126331.yml
+++ b/gems/sidekiq-pro/OSVDB-126331.yml
@@ -1,14 +1,21 @@
 ---
 gem: sidekiq-pro
 osvdb: 126331
-url: https://github.com/mperham/sidekiq/commit/651400ed8f237118346895c99dc28ca94f3169d3
+url: https://github.com/sidekiq/sidekiq/blob/main/Pro-Changes.md#206-193
 title: Sidekiq Pro Gem for Ruby CSRF in Job Filtering
 date: 2015-07-17
 description: |
-  Sidekiq::Web job filtering lacks CSRF protection. This issue
-  is related to OSVDB-125675.
+  Sidekiq::Web job filtering lacks CSRF protection.
+  This issue is related to OSVDB-125675.
 patched_versions:
-  - '>= 2.0.6'
+  - "~> 1.9.3"
+  - ">= 2.0.6"
 related:
   osvdb:
     - 125675
+  url:
+    - https://github.com/sidekiq/sidekiq/blob/main/Pro-Changes.md#206-193
+    - https://github.com/sidekiq/sidekiq/issues/2442
+    - https://github.com/sidekiq/sidekiq/issues/2467
+    - https://github.com/rubysec/ruby-advisory-db/pull/201
+    - https://security.snyk.io/vuln/SNYK-RUBY-SIDEKIQPRO-20234

--- a/gems/sidekiq/OSVDB-125675.yml
+++ b/gems/sidekiq/OSVDB-125675.yml
@@ -1,10 +1,16 @@
 ---
 gem: sidekiq
 osvdb: 125675
-url: https://github.com/mperham/sidekiq/pull/2422
+url: https://seclists.org/oss-sec/2015/q3/267
 title: Sidekiq Gem for Ruby Multiple Unspecified CSRF
 date: 2015-07-06
 description: |
   Sidekiq::Web lacks CSRF protection
 patched_versions:
-  - '>= 3.4.2'
+  - ">= 3.4.2"
+related:
+  url:
+    - https://seclists.org/oss-sec/2015/q3/267
+    - https://github.com/mperham/sidekiq/pull/2422
+    - https://github.com/sidekiq/sidekiq/commit/cf3c43b2410c4573e05ac119494e41115f4140ad
+    - https://security.snyk.io/vuln/SNYK-RUBY-SIDEKIQ-20233

--- a/gems/sidekiq/OSVDB-125676.yml
+++ b/gems/sidekiq/OSVDB-125676.yml
@@ -1,15 +1,21 @@
 ---
 gem: sidekiq
 osvdb: 125676
-url: https://github.com/mperham/sidekiq/issues/2330
+url: https://seclists.org/oss-sec/2015/q3/267
 title:
-  Sidekiq Gem for Ruby web/views/queue.erb CurrentMessagesInQueue Element
-  Reflected XSS
+  Sidekiq Gem for Ruby web/views/queue.erb Element Reflected XSS
 date: 2015-06-04
 description: |
-  XSS via queue name in Sidekiq::Web
+  Sidekiq Gem for Ruby web/views/queue.erb [CurrentMessagesInQueue,
+  AreYouSureDeleteQueue] Element Reflected XSS
 patched_versions:
-  - '>= 3.4.0'
+  - ">= 3.4.0"
 related:
   osvdb:
     - 125677
+  url:
+    - https://seclists.org/oss-sec/2015/q3/267
+    - https://github.com/mperham/sidekiq/issues/2330
+    - https://github.com/sidekiq/sidekiq/commit/2178d66b6686fbf4430223c34c184a64c9906828
+    - https://github.com/rubysec/ruby-advisory-db/pull/196
+    - https://github.com/rubysec/ruby-advisory-db/commit/19a8fc075a6cc0702f978219c88d97c666fecdbd

--- a/gems/sidekiq/OSVDB-125678.yml
+++ b/gems/sidekiq/OSVDB-125678.yml
@@ -7,4 +7,9 @@ date: 2015-04-21
 description: |
   XSS via job arguments display class in Sidekiq::Web
 patched_versions:
-  - '>= 3.4.0'
+  - ">= 3.4.0"
+related:
+  url:
+    - https://seclists.org/oss-sec/2015/q3/267
+    - https://github.com/mperham/sidekiq/pull/2309
+    - https://github.com/sidekiq/sidekiq/commit/54766f336620ca0ce3b0b87a7a56382496e64b61

--- a/gems/sidekiq/OSVDB-125678.yml
+++ b/gems/sidekiq/OSVDB-125678.yml
@@ -1,7 +1,7 @@
 ---
 gem: sidekiq
 osvdb: 125678
-url: https://github.com/mperham/sidekiq/pull/2309
+url: https://seclists.org/oss-sec/2015/q3/267
 title: Sidekiq Gem for Ruby web/views/queue.erb msg.display_class Element XSS
 date: 2015-04-21
 description: |

--- a/gems/spree/OSVDB-119205.yml
+++ b/gems/spree/OSVDB-119205.yml
@@ -1,18 +1,26 @@
 ---
 gem: spree
 osvdb: 119205
-url: https://spreecommerce.com/blog/security-updates-2015-3-3
+url: https://web.archive.org/web/20150920092934/https://spreecommerce.com/blog/security-updates-2015-3-3
 title: Spree API Information Disclosure CSRF
 date: 2015-03-05
 description: |
-  Spree contains a flaw in the API as HTTP requests do not require multiple
-  steps, explicit confirmation, or a unique token when performing certain
-  sensitive actions. By tricking a user into following a specially crafted
-  link, a context-dependent attacker can perform a Cross-Site Request Forgery
-  (CSRF / XSRF) attack causing the victim to disclose potentially sensitive
-  information to attackers.
+  Spree contains a flaw in the API as HTTP requests do not require
+  multiple steps, explicit confirmation, or a unique token when
+  performing certain sensitive actions. By tricking a user into
+  following a specially crafted link, a context-dependent attacker
+  can perform a Cross-Site Request Forgery (CSRF / XSRF) attack
+  causing the victim to disclose potentially sensitive information
+  to attackers.
 patched_versions:
-  - ~> 2.2.10
-  - ~> 2.3.8
-  - ~> 2.4.5
-  - '>= 3.0.0.rc4'
+  - "~> 2.2.10"
+  - "~> 2.3.8"
+  - "~> 2.4.5"
+  - ">= 3.0.0.rc4"
+related:
+  url:
+    - https://web.archive.org/web/20150920092934/https://spreecommerce.com/blog/security-updates-2015-3-3
+    - https://seclists.org/oss-sec/2015/q3/275
+    - https://github.com/spree/spree/commit/bfb5f907219d6f8f879ca940882befe89b58a1a4
+    - https://security.snyk.io/vuln/SNYK-RUBY-SPREE-20360
+    - https://github.com/rubysec/bundler-audit/issues/106

--- a/gems/spree/OSVDB-125699.yml
+++ b/gems/spree/OSVDB-125699.yml
@@ -1,18 +1,24 @@
 ---
 gem: spree
 osvdb: 125699
-url: https://spreecommerce.com/blog/security-updates-2015-7-28
+url: https://web.archive.org/web/20160331133641/spreecommerce.com/blog/security-updates-2015-7-28
 title:
-  Spree RABL templates rendering allows Arbitrary Code Execution and File
-  Disclosure
+  Spree RABL templates rendering allows Arbitrary Code Execution
+  and File Disclosure
 date: 2015-07-28
 description: |
-  Spree contains a flaw where the rendering of arbitrary RABL templates allows
-  for execution arbitrary files on the host system, as well as disclosing the
-  existence of files on the system. This is a different issue than
-  OSVDB-125701.
+  Spree contains a flaw where the rendering of arbitrary RABL templates
+  allows for execution arbitrary files on the host system, as well as
+  disclosing the existence of files on the system.
+  This is a different issue than OSVDB-125701.
 patched_versions:
-  - ~> 2.2.13
-  - ~> 2.3.12
-  - ~> 2.4.9
-  - '>= 3.0.3'
+  - "~> 2.2.13"
+  - "~> 2.3.12"
+  - "~> 2.4.9"
+  - ">= 3.0.3"
+related:
+  osvdb:
+    - 125701
+  url:
+    - https://github.com/rubysec/bundler-audit/issues/106
+    - https://security.snyk.io/vuln/SNYK-RUBY-SPREE-20237

--- a/gems/spree/OSVDB-125701.yml
+++ b/gems/spree/OSVDB-125701.yml
@@ -1,17 +1,21 @@
 ---
 gem: spree
 osvdb: 125701
-url: https://spreecommerce.com/blog/security-updates-2015-7-20
+url: https://web.archive.org/web/20160331140223/https://spreecommerce.com/blog/security-updates-2015-7-20
 title:
-  Spree RABL templates rendering allows Arbitrary Code Execution and File
-  Disclosure
+  Spree RABL templates rendering allows Arbitrary Code Execution
+  and File Disclosure
 date: 2015-07-20
 description: |
-  Spree contains a flaw where the rendering of arbitrary RABL templates allows
-  for execution arbitrary files on the host system, as well as disclosing the
-  existence of files on the system.
+  Spree contains a flaw where the rendering of arbitrary RABL templates
+  allows for execution arbitrary files on the host system, as well as
+  disclosing the existence of files on the system.
 patched_versions:
-  - ~> 2.2.12
-  - ~> 2.3.11
-  - ~> 2.4.8
-  - '>= 3.0.2'
+  - "~> 2.2.12"
+  - "~> 2.3.11"
+  - "~> 2.4.8"
+  - ">= 3.0.2"
+related:
+  url:
+    - https://web.archive.org/web/20160331140223/https://spreecommerce.com/blog/security-updates-2015-7-20
+    - https://github.com/rubysec/bundler-audit/issues/106

--- a/gems/spree/OSVDB-125712.yml
+++ b/gems/spree/OSVDB-125712.yml
@@ -1,7 +1,7 @@
 ---
 gem: spree
 osvdb: 125712
-url: https://spreecommerce.com/blog/security-issue-all-versions
+url: https://web.archive.org/web/20121126005814/https://spreecommerce.com/blog/security-issue-all-versions
 title: Product Scopes could allow for unauthenticated remote command execution
 date: 2012-07-02
 description: |
@@ -9,7 +9,11 @@ description: |
   This was corrected by removing conditions_any scope and use ARel query
   building instead.
 patched_versions:
-  - ~> 0.11.4
-  - ~> 0.70.6
-  - ~> 1.0.5
-  - '>= 1.1.2'
+  - "~> 0.11.4"
+  - "~> 0.70.6"
+  - "~> 1.0.5"
+  - ">= 1.1.2"
+related:
+  url:
+    - https://web.archive.org/web/20121126005814/https://spreecommerce.com/blog/security-issue-all-versions
+    - https://security.snyk.io/vuln/SNYK-RUBY-SPREE-20034

--- a/gems/spree/OSVDB-125713.yml
+++ b/gems/spree/OSVDB-125713.yml
@@ -1,14 +1,17 @@
 ---
 gem: spree
 osvdb: 125713
-url: https://spreecommerce.com/blog/security-issue-all-versions
+url: https://web.archive.org/web/20121126005814/https://spreecommerce.com/blog/security-issue-all-versions
 title: Potential XSS vulnerability related to the analytics dashboard
 date: 2012-07-02
 description: |
-  Spree has a flaw in its analytics dashboard where keywords are not escaped,
-  leading to potential XSS.
+  Spree has a flaw in its analytics dashboard where
+  keywords are not escaped, leading to potential XSS.
 patched_versions:
-  - ~> 0.11.4
-  - ~> 0.70.6
-  - ~> 1.0.5
-  - '>= 1.1.2'
+  - "~> 0.11.4"
+  - "~> 0.70.6"
+  - "~> 1.0.5"
+  - ">= 1.1.2"
+related:
+  url:
+    - https://web.archive.org/web/20121126005814/https://spreecommerce.com/blog/security-issue-all-versions

--- a/gems/spree/OSVDB-73751.yml
+++ b/gems/spree/OSVDB-73751.yml
@@ -1,11 +1,16 @@
 ---
 gem: spree
 osvdb: 73751
-url: https://spreecommerce.com/blog/security-fixes
+url: https://web.archive.org/web/20160331142302/https://spreecommerce.com/blog/security-fixes
 title: Spree Content Controller Unspecified Arbitrary File Disclosure
 date: 2011-04-19
 description: |
   Spree Gem for Ruby would allow a user to request a specially crafted URL and
   expose arbitrary files on the server
 patched_versions:
-  - '>= 0.50.1'
+  - ">= 0.50.1"
+related:
+  url:
+    - https://web.archive.org/web/20160331142302/https://spreecommerce.com/blog/security-fixes
+    - https://seclists.org/oss-sec/2015/q3/275
+    - https://github.com/spree/spree/commit/0a2ee5fc68b22b8257e8a6cf1811598293416d33

--- a/gems/spree/OSVDB-76011.yml
+++ b/gems/spree/OSVDB-76011.yml
@@ -1,7 +1,7 @@
 ---
 gem: spree
 osvdb: 76011
-url: https://spreecommerce.com/blog/remote-command-product-group
+url: https://web.archive.org/web/20121124215359/https://spreecommerce.com/blog/remote-command-product-group
 title:
   Spree Search ProductScope Class search[send][] Parameter Arbitrary Command
   Execution
@@ -12,4 +12,7 @@ description: |
   specially crafted request, a remote attacker can potentially cause arbitrary
   command execution.
 patched_versions:
-  - '>= 0.60.2'
+  - ">= 0.60.2"
+related:
+  url:
+    - https://web.archive.org/web/20121124215359/https://spreecommerce.com/blog/remote-command-product-group

--- a/gems/web-console/OSVDB-112346.yml
+++ b/gems/web-console/OSVDB-112346.yml
@@ -1,7 +1,7 @@
 ---
 gem: web-console
 osvdb: 112346
-url: https://github.com/rails/web-console/compare/v2.0.0.beta3...v2.0.0.beta4
+url: https://my.diffend.io/gems/web-console/versions/2.0.0.beta3
 title: Web Console Gem for Ruby contains an unspecified flaw
 date: 2014-09-29
 description: |

--- a/gems/web-console/OSVDB-112346.yml
+++ b/gems/web-console/OSVDB-112346.yml
@@ -1,12 +1,18 @@
 ---
 gem: web-console
 osvdb: 112346
-url: http://www.osvdb.org/show/osvdb/112346
+url: https://github.com/rails/web-console/compare/v2.0.0.beta3...v2.0.0.beta4
 title: Web Console Gem for Ruby contains an unspecified flaw
 date: 2014-09-29
 description: |
-  The Web Console Gem for Ruby on Rails contains an unspecified flaw that
-  may allow an attacker to have an unspecified impact. No further details have been
-  provided by the vendor.
+  The Web Console Gem for Ruby on Rails contains an unspecified
+  flaw that may allow an attacker to have an unspecified impact.
+  No further details have been provided by the vendor.
 patched_versions:
-  - '>= 2.0.0.beta4'
+  - ">= 2.0.0.beta4"
+related:
+  url:
+    - https://github.com/rails/web-console/compare/v2.0.0.beta3...v2.0.0.beta4
+    - https://my.diffend.io/gems/web-console/versions/2.0.0.beta3
+    - https://github.com/slowmistio/dawnscanner-analysis-security-scanner-for-ruby-/blob/master/Roadmap.md
+    - http://www.osvdb.org/show/osvdb/112346

--- a/rubies/jruby/OSVDB-94644.yml
+++ b/rubies/jruby/OSVDB-94644.yml
@@ -1,7 +1,7 @@
 ---
 engine: jruby
 osvdb: 94644
-url: http://www.osvdb.org/show/osvdb/94644
+url: https://www.jruby.org/2011/05/24/jruby-1-6-2.html
 title: JRuby Null Byte Request Arbitrary File Access
 date: 2010-05-26
 description: |
@@ -9,4 +9,8 @@ description: |
   for null byte requests in certain file operations. This may allow a remote
   attacker to gain access to arbitrary files. No further details are available.
 patched_versions:
-  - '>= 1.6.2'
+  - ">= 1.6.2"
+related:
+  url:
+    - https://www.jruby.org/2011/05/24/jruby-1-6-2.html
+    - http://www.osvdb.org/show/osvdb/94644

--- a/rubies/rbx/CVE-2012-5372.yml
+++ b/rubies/rbx/CVE-2012-5372.yml
@@ -2,7 +2,8 @@
 engine: rbx
 cve: 2012-5372
 osvdb: 87861
-url: http://www.osvdb.org/show/osvdb/87861
+ghsa: 9f35-5wj4-v27g
+url: http://www.ocert.org/advisories/ocert-2012-001.html
 title: Rubinius MurmurHash3 Implementation Hash Collision Remote DoS
 date: 2012-11-23
 description: |
@@ -14,4 +15,17 @@ description: |
   This will result in a loss of availability for the program.
 cvss_v2: 5.0
 patched_versions:
-  - '>= 1.3.1'
+  - ">= 1.3.1"
+related:
+  osvdb:
+    - 78119
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-5372
+    - https://github.com/rubinius/rubinius/commit/a9a40fc6a1256bcf6382631b710430105c5dd868
+    - https://github.com/advisories/GHSA-GHSA-9f35-5wj4-v27g
+    - http://2012.appsec-forum.ch/conferences/#c17
+    - http://www.ocert.org/advisories/ocert-2012-001.html
+    - https://web.archive.org/web/20200229110821/http://www.securityfocus.com/bid/56670
+    - https://web.archive.org/web/20121223202152/https://www.131002.net/data/talks/appsec12_slides.pdf
+    - http://www.osvdb.org/show/osvdb/87861
+    - http://www.osvdb.org/show/osvdb/78119

--- a/rubies/ruby/CVE-2008-2662.yml
+++ b/rubies/ruby/CVE-2008-2662.yml
@@ -2,21 +2,30 @@
 engine: ruby
 cve: 2008-2662
 osvdb: 46550
-url: http://www.osvdb.org/show/osvdb/46550
+ghsa: c4h6-p7gp-39x2
+url: https://rubyonrails.org/2008/6/21/multiple-ruby-security-vulnerabilities
 title: "CVE-2008-2662 ruby: Integer overflows in rb_str_buf_append()"
 date: 2008-06-20
 description: |
-  'Multiple integer overflows in the rb_str_buf_append function in Ruby
-  1.8.4 and earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230, 1.8.7 before
-  1.8.7-p22, and 1.9.0 before 1.9.0-2 allow context-dependent attackers to execute
-  arbitrary code or cause a denial of service via unknown vectors that trigger memory
-  corruption, a different issue than CVE-2008-2663, CVE-2008-2664, and CVE-2008-2725.  NOTE:
-  as of 20080624, there has been inconsistent usage of multiple CVE identifiers related
-  to Ruby. This CVE description should be regarded as authoritative, although it is
-  likely to change.'
+  Multiple integer overflows in the rb_str_buf_append function in Ruby
+  1.8.4 and earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230,
+  1.8.7 before 1.8.7-p22, and 1.9.0 before 1.9.0-2 allow context-dependent
+  attackers to execute arbitrary code or cause a denial of service via
+  unknown vectors that trigger memory corruption, a different issue
+  than CVE-2008-2663, CVE-2008-2664, and CVE-2008-2725.
+
+  NOTE: As of 20080624, there has been inconsistent usage of multiple
+  CVE identifiers related to Ruby. This CVE description should be
+  regarded as authoritative, although it is likely to change.
 cvss_v2: 10.0
 patched_versions:
-  - ~> 1.8.5.231
-  - ~> 1.8.6.230
-  - ~> 1.8.7.22
-  - '>= 1.9.0.2'
+  - "~> 1.8.5.231"
+  - "~> 1.8.6.230"
+  - "~> 1.8.7.22"
+  - ">= 1.9.0.2"
+related:
+  url:
+    - https://rubyonrails.org/2008/6/21/multiple-ruby-security-vulnerabilities
+    - https://nvd.nist.gov/vuln/detail/CVE-2008-2662
+    - https://github.com/advisories/GHSA-c4h6-p7gp-39x2
+    - http://www.osvdb.org/show/osvdb/46550

--- a/rubies/ruby/CVE-2008-2663.yml
+++ b/rubies/ruby/CVE-2008-2663.yml
@@ -2,20 +2,29 @@
 engine: ruby
 cve: 2008-2663
 osvdb: 46551
-url: http://www.osvdb.org/show/osvdb/46551
+ghsa: c4h6-p7gp-39x2
+url: https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
 title: "CVE-2008-2663 ruby: Integer overflows in rb_ary_store()"
 date: 2008-06-20
 description: |
-  'Multiple integer overflows in the rb_ary_store function in Ruby 1.8.4
-  and earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230, and 1.8.7 before
-  1.8.7-p22 allow context-dependent attackers to execute arbitrary code or cause a
-  denial of service via unknown vectors, a different issue than CVE-2008-2662, CVE-2008-2664,
-  and CVE-2008-2725. NOTE: as of 20080624, there has been inconsistent usage of multiple
-  CVE identifiers related to Ruby. The CVE description should be regarded as authoritative,
-  although it is likely to change.'
+  Multiple integer overflows in the rb_ary_store function in Ruby 1.8.4
+  and earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230, and
+  1.8.7 before 1.8.7-p22 allow context-dependent attackers to execute
+  arbitrary code or cause a denial of service via unknown vectors, a
+  different issue than CVE-2008-2662, CVE-2008-2664, and CVE-2008-2725.
+
+  NOTE: As of 20080624, there has been inconsistent usage of multiple
+  CVE identifiers related to Ruby. The CVE description should be
+  regarded as authoritative, although it is likely to change.'
 cvss_v2: 10.0
 patched_versions:
-  - ~> 1.8.5.231
-  - ~> 1.8.6.230
-  - ~> 1.8.7.22
-  - '>= 1.9.0.2'
+  - "~> 1.8.5.231"
+  - "~> 1.8.6.230"
+  - "~> 1.8.7.22"
+  - ">= 1.9.0.2"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
+    - https://nvd.nist.gov/vuln/detail/CVE-2008-2663
+    - https://github.com/advisories/GHSA-c4h6-p7gp-39x2
+    - http://www.osvdb.org/show/osvdb/46551

--- a/rubies/ruby/CVE-2008-2664.yml
+++ b/rubies/ruby/CVE-2008-2664.yml
@@ -1,21 +1,32 @@
 ---
 engine: ruby
 cve: 2008-2664
+ghsa: c4h6-p7gp-39x2
 osvdb: 46552
-url: http://www.osvdb.org/show/osvdb/46552
+url: https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
 title: "CVE-2008-2664 ruby: Unsafe use of alloca in rb_str_format()"
 date: 2008-06-20
 description: |
-  'The rb_str_format function in Ruby 1.8.4 and earlier, 1.8.5 before 1.8.5-p231,
-  1.8.6 before 1.8.6-p230, 1.8.7 before 1.8.7-p22, and 1.9.0 before 1.9.0-2 allows
-  context-dependent attackers to trigger memory corruption via unspecified vectors
-  related to alloca, a different issue than CVE-2008-2662, CVE-2008-2663, and CVE-2008-2725.  NOTE:
-  as of 20080624, there has been inconsistent usage of multiple CVE identifiers related
-  to Ruby. The CVE description should be regarded as authoritative, although it is
-  likely to change.'
+  The rb_str_format function in Ruby 1.8.4 and earlier,
+  1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230,
+  1.8.7 before 1.8.7-p22, and 1.9.0 before 1.9.0-2 allows
+  context-dependent attackers to trigger memory corruption via
+  unspecified vectors related to alloca, a different issue than
+  CVE-2008-2662, CVE-2008-2663, and CVE-2008-2725.
+
+  NOTE: As of 20080624, there has been inconsistent usage of
+  multiple CVE identifiers related to Ruby. The CVE description
+  should be regarded as authoritative, although it is likely to change.
 cvss_v2: 7.8
 patched_versions:
-  - ~> 1.8.5.231
-  - ~> 1.8.6.230
-  - ~> 1.8.7.22
-  - '>= 1.9.0.2'
+  - "~> 1.8.5.231"
+  - "~> 1.8.6.230"
+  - "~> 1.8.7.22"
+  - ">= 1.9.0.2"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
+    - https://rubyonrails.org/2008/6/21/multiple-ruby-security-vulnerabilities
+    - https://nvd.nist.gov/vuln/detail/CVE-2008-2664
+    - https://github.com/advisories/GHSA-c4h6-p7gp-39x2
+    - http://www.osvdb.org/show/osvdb/46552

--- a/rubies/ruby/CVE-2008-2725.yml
+++ b/rubies/ruby/CVE-2008-2725.yml
@@ -1,22 +1,31 @@
 ---
 engine: ruby
 cve: 2008-2725
+ghsa: c4h6-p7gp-39x2
 osvdb: 46553
-url: http://www.osvdb.org/show/osvdb/46553
+url: https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
 title: "CVE-2008-2725 ruby: integer overflow in rb_ary_splice/update/replace() - REALLOC_N"
 date: 2008-06-20
 description: |
-  'Integer overflow in the (1) rb_ary_splice function in Ruby 1.8.4 and
-  earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230, and 1.8.7 before 1.8.7-p22;
-  and (2) the rb_ary_replace function in 1.6.x allows context-dependent attackers
-  to trigger memory corruption via unspecified vectors, aka the "REALLOC_N" variant,
-  a different issue than CVE-2008-2662, CVE-2008-2663, and CVE-2008-2664.  NOTE: as
-  of 20080624, there has been inconsistent usage of multiple CVE identifiers related
-  to Ruby. The CVE description should be regarded as authoritative, although it is
-  likely to change.'
+  Integer overflow in the (1) rb_ary_splice function in Ruby 1.8.4
+  and earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230,
+  and 1.8.7 before 1.8.7-p22; and (2) the rb_ary_replace function
+  in 1.6.x allows context-dependent attackers to trigger memory
+  corruption via unspecified vectors, aka the "REALLOC_N" variant,
+  a different issue than CVE-2008-2662, CVE-2008-2663, and CVE-2008-2664.
+
+  NOTE: As  of 20080624, there has been inconsistent usage of multiple
+  CVE identifiers related to Ruby. The CVE description should be
+  regarded as authoritative, although it is likely to change.
 cvss_v2: 7.8
 patched_versions:
-  - ~> 1.8.5.231
-  - ~> 1.8.6.230
-  - ~> 1.8.7.22
-  - '>= 1.9.0.2'
+  - "~> 1.8.5.231"
+  - "~> 1.8.6.230"
+  - "~> 1.8.7.22"
+  - ">= 1.9.0.2"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
+    - https://rubyonrails.org/2008/6/21/multiple-ruby-security-vulnerabilities
+    - https://github.com/advisories/GHSA-c4h6-p7gp-39x2
+    - http://www.osvdb.org/show/osvdb/46553

--- a/rubies/ruby/CVE-2008-2726.yml
+++ b/rubies/ruby/CVE-2008-2726.yml
@@ -1,22 +1,31 @@
 ---
 engine: ruby
 cve: 2008-2726
+ghsa: v2mw-g73g-923h
 osvdb: 46554
-url: http://www.osvdb.org/show/osvdb/46554
-title: 'CVE-2008-2726 ruby: integer overflow in rb_ary_splice/update/replace() - beg
-  + rlen'
+url: https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
+title: "CVE-2008-2726 ruby: integer overflow in rb_ary_splice/update/replace() - beg + rlen"
 date: 2008-06-20
 description: |
-  'Integer overflow in the (1) rb_ary_splice function in Ruby 1.8.4 and
-  earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230, 1.8.7 before 1.8.7-p22,
-  and 1.9.0 before 1.9.0-2; and (2) the rb_ary_replace function in 1.6.x allows context-dependent
-  attackers to trigger memory corruption, aka the "beg + rlen" issue.  NOTE: as of
-  20080624, there has been inconsistent usage of multiple CVE identifiers related
-  to Ruby. The CVE description should be regarded as authoritative, although it is
-  likely to change.'
+  Integer overflow in the (1) rb_ary_splice function in Ruby 1.8.4
+  and earlier, 1.8.5 before 1.8.5-p231, 1.8.6 before 1.8.6-p230,
+  1.8.7 before 1.8.7-p22, and 1.9.0 before 1.9.0-2; and (2) the
+  rb_ary_replace function in 1.6.x allows context-dependent
+  attackers to trigger memory corruption, aka the "beg + rlen" issue.
+
+  NOTE: As of 20080624, there has been inconsistent usage of multiple
+  CVE identifiers related to Ruby. The CVE description should be
+  regarded as authoritative, although it is likely to change.
 cvss_v2: 7.8
 patched_versions:
-  - ~> 1.8.5.231
-  - ~> 1.8.6.230
-  - ~> 1.8.7.22
-  - '>= 1.9.0.2'
+  - "~> 1.8.5.231"
+  - "~> 1.8.6.230"
+  - "~> 1.8.7.22"
+  - ">= 1.9.0.2"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
+    - https://rubyonrails.org/2008/6/21/multiple-ruby-security-vulnerabilities
+    - https://nvd.nist.gov/vuln/detail/CVE-2008-2726
+    - https://github.com/advisories/GHSA-v2mw-g73g-923h
+    - http://www.osvdb.org/show/osvdb/46554

--- a/rubies/ruby/CVE-2008-3790.yml
+++ b/rubies/ruby/CVE-2008-3790.yml
@@ -1,15 +1,24 @@
 ---
 engine: ruby
 cve: 2008-3790
+ghsa: 96jc-f6m3-pf2w
 osvdb: 47753
-url: http://www.osvdb.org/show/osvdb/47753
+url: https://www.ruby-lang.org/en/news/2008/08/23/dos-vulnerability-in-rexml
 title: "CVE-2008-3790 ruby: DoS vulnerability in the REXML module"
 date: 2008-08-25
 description: |
-  The REXML module in Ruby 1.8.6 through 1.8.6-p287, 1.8.7 through 1.8.7-p72,
-  and 1.9 allows context-dependent attackers to cause a denial of service (CPU consumption)
-  via an XML document with recursively nested entities, aka an "XML entity explosion."
+  The REXML module in Ruby 1.8.6 through 1.8.6-p287, 1.8.7 through
+  1.8.7-p72, and 1.9 allows context-dependent attackers to cause
+  a denial of service (CPU consumption) via an XML document with
+  recursively nested entities, aka an "XML entity explosion.
 cvss_v2: 5.0
 patched_versions:
-  - ~> 1.8.7.160
-  - '>= 1.9.1'
+  - "~> 1.8.7.160"
+  - ">= 1.9.1"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2008/08/23/dos-vulnerability-in-rexml
+    - https://groups.google.com/g/comp.lang.ruby/c/GfaeiggfwNE
+    - https://nvd.nist.gov/vuln/detail/CVE-2008-3790
+    - https://github.com/advisories/GHSA-96jc-f6m3-pf2w
+    - http://www.osvdb.org/show/osvdb/47753

--- a/rubies/ruby/CVE-2009-1904.yml
+++ b/rubies/ruby/CVE-2009-1904.yml
@@ -1,16 +1,23 @@
 ---
 engine: ruby
 cve: 2009-1904
+ghsa: v74x-h8vc-p3j5
 osvdb: 55031
-url: http://www.osvdb.org/show/osvdb/55031
+url: https://www.ruby-lang.org/en/news/2009/06/09/dos-vulnerability-in-bigdecimal
 title: "CVE-2009-1904 ruby: DoS vulnerability in BigDecimal"
 date: 2009-06-10
 description: |
   The BigDecimal library in Ruby 1.8.6 before p369 and 1.8.7 before p173
-  allows context-dependent attackers to cause a denial of service (application crash)
-  via a string argument that represents a large number, as demonstrated by an attempted
-  conversion to the Float data type.
+  allows context-dependent attackers to cause a denial of service
+  (application crash) via a string argument that represents a large
+  number, as demonstrated by an attempted conversion to the Float data type.
 cvss_v2: 5.0
 patched_versions:
-  - ~> 1.8.6.369
-  - '>= 1.8.7.174'
+  - "~> 1.8.6.369"
+  - ">= 1.8.7.174"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2009/06/09/dos-vulnerability-in-bigdecimal
+    - https://nvd.nist.gov/vuln/detail/CVE-2009-1904
+    - https://github.com/advisories/GHSA-v74x-h8vc-p3j5
+    - http://www.osvdb.org/show/osvdb/55031

--- a/rubies/ruby/CVE-2009-4124.yml
+++ b/rubies/ruby/CVE-2009-4124.yml
@@ -1,16 +1,25 @@
 ---
 engine: ruby
 cve: 2009-4124
+ghsa: 9mvm-2xp2-9wmw
 osvdb: 60880
-url: http://www.osvdb.org/show/osvdb/60880
+url: https://www.ruby-lang.org/en/news/2009/12/07/heap-overflow-in-string
 title: "CVE-2009-4124 ruby: Heap-based buffer overflow in the rb_str_justify() function"
 date: 2009-12-07
 description: |
-  'Heap-based buffer overflow in the rb_str_justify function in string.c
-  in Ruby 1.9.1 before 1.9.1-p376 allows context-dependent attackers to execute arbitrary
-  code via unspecified vectors involving (1) String#ljust, (2) String#center, or (3)
-  String#rjust.  NOTE: some of these details are obtained from third party information.'
+  Heap-based buffer overflow in the rb_str_justify function in
+  string.c in Ruby 1.9.1 before 1.9.1-p376 allows context-dependent
+  attackers to execute arbitrary code via unspecified vectors involving
+  (1) String#ljust, (2) String#center, or (3) String#rjust.
+
+  NOTE: some of these details are obtained from third party information.
 cvss_v2: 10.0
 patched_versions:
-  - ~> 1.8.0
-  - '>= 1.9.1.376'
+  - "~> 1.8.0"
+  - ">= 1.9.1.376"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2009/12/07/heap-overflow-in-string
+    - https://nvd.nist.gov/vuln/detail/CVE-2009-4124
+    - https://github.com/advisories/GHSA-9mvm-2xp2-9wmw
+    - http://www.osvdb.org/show/osvdb/60880

--- a/rubies/ruby/CVE-2010-0541.yml
+++ b/rubies/ruby/CVE-2010-0541.yml
@@ -1,17 +1,24 @@
 ---
 engine: ruby
 cve: 2010-0541
+ghsa: h9r2-943c-qg8v
 osvdb: 65556
-url: http://www.osvdb.org/show/osvdb/65556
+url: https://support.apple.com/en-us/HT4188
 title: CVE-2010-0541 Ruby WEBrick javascript injection flaw
 date: 2010-06-15
 description: |
-  Cross-site scripting (XSS) vulnerability in the WEBrick HTTP server in
-  Ruby in Apple Mac OS X 10.5.8, and 10.6 before 10.6.4, allows remote attackers to
-  inject arbitrary web script or HTML via a crafted URI that triggers a UTF-7 error
-  page.
+  Cross-site scripting (XSS) vulnerability in the WEBrick HTTP server
+  in Ruby in Apple Mac OS X 10.5.8, and 10.6 before 10.6.4, allows
+  remote attackers to inject arbitrary web script or HTML via a
+  crafted URI that triggers a UTF-7 error page.
 cvss_v2: 4.3
 patched_versions:
-  - ~> 1.8.6.420
-  - ~> 1.8.7.302
-  - '>= 1.9.1.430'
+  - "~> 1.8.6.420"
+  - "~> 1.8.7.302"
+  - ">= 1.9.1.430"
+related:
+  url:
+    - https://support.apple.com/en-us/HT4188
+    - https://nvd.nist.gov/vuln/detail/CVE-2010-0541
+    - https://github.com/advisories/GHSA-h9r2-943c-qg8v
+    - http://www.osvdb.org/show/osvdb/65556

--- a/rubies/ruby/CVE-2010-2489.yml
+++ b/rubies/ruby/CVE-2010-2489.yml
@@ -1,17 +1,26 @@
 ---
 engine: ruby
 cve: 2010-2489
+ghsa: pj28-mx3m-9668
 osvdb: 66040
-url: http://www.osvdb.org/show/osvdb/66040
+url: https://www.ruby-lang.org/en/news/2010/07/02/ruby-1-9-1-p429-is-released
 title: Ruby on Windows ARGF.inplace_mode Variable Local Overflow
 date: 2010-07-02
 description: |
-  Buffer overflow in Ruby 1.9.x before 1.9.1-p429
-  on Windows might allow local users to gain privileges via a crafted ARGF.inplace_mode
-  value that is not properly handled when constructing the filenames of the backup
-  files.
+  Buffer overflow in Ruby 1.9.x before 1.9.1-p429 on Windows might
+  allow local users to gain privileges via a crafted ARGF.inplace_mode
+  value that is not properly handled when constructing the filenames
+  of the backup files.
 cvss_v2: 7.2
 patched_versions:
-  - ~> 1.8.7
-  - ~> 1.9.1.429
-  - '>= 1.9.2'
+  - "~> 1.8.7"
+  - "~> 1.9.1.429"
+  - ">= 1.9.2"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2010/07/02/ruby-1-9-1-p429-is-released
+    - https://www.openwall.com/lists/oss-security/2010/07/02/1
+    - https://www.openwall.com/lists/oss-security/2010/07/02/10
+    - https://github.com/advisories/GHSA-pj28-mx3m-9668
+    - https://nvd.nist.gov/vuln/detail/cve-2010-2489
+    - http://www.osvdb.org/show/osvdb/66040

--- a/rubies/ruby/CVE-2011-1004.yml
+++ b/rubies/ruby/CVE-2011-1004.yml
@@ -1,17 +1,25 @@
 ---
 engine: ruby
 cve: 2011-1004
+ghsa: 45wv-gc6w-fq7m
 osvdb: 70958
-url: http://www.osvdb.org/show/osvdb/70958
-title: 'CVE-2011-1004 Ruby: Symlink race condition by removing directory trees in
-  fileutils module'
+url: https://www.ruby-lang.org/en/news/2011/02/18/fileutils-is-vulnerable-to-symlink-race-attacks
+title: "CVE-2011-1004 Ruby: Symlink race condition by removing
+  directory trees in fileutils module"
 date: 2011-02-19
 description: |
   The FileUtils.remove_entry_secure method in Ruby 1.8.6 through 1.8.6-420,
-  1.8.7 through 1.8.7-330, 1.8.8dev, 1.9.1 through 1.9.1-430, 1.9.2 through 1.9.2-136,
-  and 1.9.3dev allows local users to delete arbitrary files via a symlink attack.
+  1.8.7 through 1.8.7-330, 1.8.8dev, 1.9.1 through 1.9.1-430,
+  1.9.2 through 1.9.2-136, and 1.9.3dev allows local users
+  to delete arbitrary files via a symlink attack.
 cvss_v2: 6.3
 patched_versions:
-  - ~> 1.8.7.334
-  - ~> 1.9.1.431
-  - '>= 1.9.2.180'
+  - "~> 1.8.7.334"
+  - "~> 1.9.1.431"
+  - ">= 1.9.2.180"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2011/02/18/fileutils-is-vulnerable-to-symlink-race-attacks
+    - https://nvd.nist.gov/vuln/detail/CVE-2011-1004
+    - https://github.com/advisories/GHSA-45wv-gc6w-fq7m
+    - http://www.osvdb.org/show/osvdb/70958

--- a/rubies/ruby/CVE-2011-1005.yml
+++ b/rubies/ruby/CVE-2011-1005.yml
@@ -1,14 +1,23 @@
 ---
 engine: ruby
 cve: 2011-1005
+ghsa: h2rc-3ppq-6pjg
 osvdb: 70957
-url: http://www.osvdb.org/show/osvdb/70957
+url: https://www.ruby-lang.org/en/news/2011/02/18/exception-methods-can-bypass-safe
 title: "CVE-2011-1005 Ruby: Untrusted codes able to modify arbitrary strings"
 date: 2011-02-18
 description: |
   The safe-level feature in Ruby 1.8.6 through 1.8.6-420, 1.8.7 through
-  1.8.7-330, and 1.8.8dev allows context-dependent attackers to modify strings via
-  the Exception#to_s method, as demonstrated by changing an intended pathname.
-cvss_v2: 4.3
+  1.8.7-330, and 1.8.8dev allows context-dependent attackers to modify
+  strings via the Exception#to_s method, as demonstrated by changing
+  an intended pathname.
+cvss_v2: 5.0
 patched_versions:
-  - '>= 1.8.7.334'
+  - ">= 1.8.7.334"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2011/02/18/exception-methods-can-bypass-safe
+    - https://nvd.nist.gov/vuln/detail/CVE-2011-1005
+    - https://github.com/advisories/GHSA-h2rc-3ppq-6pjg
+    - http://www.osvdb.org/show/osvdb/70957
+notes: "Changed cvss_v2 per NVD url"

--- a/rubies/ruby/CVE-2011-3389.yml
+++ b/rubies/ruby/CVE-2011-3389.yml
@@ -1,18 +1,29 @@
 ---
 engine: ruby
 cve: 2011-3389
+ghsa: rhch-pcq2-7gp3
 osvdb: 74829
-url: http://www.osvdb.org/show/osvdb/74829
+url: https://nvd.nist.gov/vuln/detail/CVE-2011-3389
 title: "CVE-2011-3389 HTTPS: block-wise chosen-plaintext attack against SSL/TLS (BEAST)"
 date: 2011-08-31
 description: |
-  The SSL protocol, as used in certain configurations in Microsoft Windows
-  and Microsoft Internet Explorer, Mozilla Firefox, Google Chrome, Opera, and other
-  products, encrypts data by using CBC mode with chained initialization vectors, which
-  allows man-in-the-middle attackers to obtain plaintext HTTP headers via a blockwise
-  chosen-boundary attack (BCBA) on an HTTPS session, in conjunction with JavaScript
-  code that uses (1) the HTML5 WebSocket API, (2) the Java URLConnection API, or (3)
-  the Silverlight WebClient API, aka a "BEAST" attack.
-cvss_v2: 10.0
+  The SSL protocol, as used in certain configurations in Microsoft
+  Windows and Microsoft Internet Explorer, Mozilla Firefox, Google
+  Chrome, Opera, and other products, encrypts data by using CBC mode
+  with chained initialization vectors, which allows man-in-the-middle
+  attackers to obtain plaintext HTTP headers via a blockwise
+  chosen-boundary attack (BCBA) on an HTTPS session, in conjunction
+  with JavaScript code that uses
+  (1) the HTML5 WebSocket API,
+  (2) the Java URLConnection API, or
+  (3) the Silverlight WebClient API, aka a "BEAST" attack.
+cvss_v2: 4.3
 patched_versions:
-  - '>= 1.8.7.358'
+  - ">= 1.8.7.358"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2011-3389
+    - https://github.com/rubysec/ruby-advisory-db/commit/c12e0023331f56cc187539ab323917c494139f0d
+    - https://github.com/advisories/GHSA-rhch-pcq2-7gp3
+    - http://www.osvdb.org/show/osvdb/74829
+notes: "Changed cvss_v2 per NVD URL; no 'ruby' URLs"

--- a/rubies/ruby/CVE-2011-4815.yml
+++ b/rubies/ruby/CVE-2011-4815.yml
@@ -1,15 +1,24 @@
 ---
 engine: ruby
 cve: 2011-4815
+ghsa: xpr8-vpc7-7vfc
 osvdb: 78118
-url: http://www.osvdb.org/show/osvdb/78118
+url: https://www.ruby-lang.org/en/news/2011/12/28/denial-of-service-attack-was-found-for-rubys-hash-algorithm-cve-2011-4815
 title: "CVE-2011-4815 ruby: hash table collisions CPU usage DoS (oCERT-2011-003)"
 date: 2011-12-28
 description: |
-  Ruby (aka CRuby) before 1.8.7-p357 computes hash values without restricting
-  the ability to trigger hash collisions predictably, which allows context-dependent
-  attackers to cause a denial of service (CPU consumption) via crafted input to an
-  application that maintains a hash table.
+  Ruby (aka CRuby) before 1.8.7-p357 computes hash values without
+  restricting the ability to trigger hash collisions predictably,
+  which allows context-dependent attackers to cause a denial of
+  service (CPU consumption) via crafted input to an application
+  that maintains a hash table.
 cvss_v2: 7.8
 patched_versions:
-  - '>= 1.8.7.357'
+  - ">= 1.8.7.357"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2011/12/28/denial-of-service-attack-was-found-for-rubys-hash-algorithm-cve-2011-4815
+    - https://ocert.org/advisories/ocert-2011-003.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2011-4815
+    - https://github.com/advisories/GHSA-xpr8-vpc7-7vfc
+    - http://www.osvdb.org/show/osvdb/78118

--- a/rubies/ruby/CVE-2012-4522.yml
+++ b/rubies/ruby/CVE-2012-4522.yml
@@ -1,16 +1,24 @@
 ---
 engine: ruby
 cve: 2012-4522
+ghsa: 6mch-f8jc-rpmr
 osvdb: 87917
-url: http://www.osvdb.org/show/osvdb/87917
-title: 'CVE-2012-4522 ruby: unintentional file creation caused by inserting an illegal
-  NUL character'
+url: https://www.ruby-lang.org/en/news/2012/10/12/poisoned-NUL-byte-vulnerability
+title: "CVE-2012-4522 ruby: unintentional file creation caused
+  by inserting an illegal NUL character"
 date: 2012-10-12
 description: |
-  The rb_get_path_check function in file.c in Ruby 1.9.3 before patchlevel
-  286 and Ruby 2.0.0 before r37163 allows context-dependent attackers to create files
-  in unexpected locations or with unexpected names via a NUL byte in a file path.
+  The rb_get_path_check function in file.c in Ruby 1.9.3 before
+  patchlevel 286 and Ruby 2.0.0 before r37163 allows context-dependent
+  attackers to create files in unexpected locations or with unexpected
+  names via a NUL byte in a file path.
 cvss_v2: 5.0
 patched_versions:
-  - ~> 1.9.3.286
-  - '>= 2.0.0'
+  - "~> 1.9.3.286"
+  - ">= 2.0.0"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2012/10/12/poisoned-NUL-byte-vulnerability
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-4522
+    - https://github.com/advisories/GHSA-6mch-f8jc-rpmr
+    - http://www.osvdb.org/show/osvdb/87917

--- a/rubies/ruby/CVE-2012-5371.yml
+++ b/rubies/ruby/CVE-2012-5371.yml
@@ -1,18 +1,28 @@
 ---
 engine: ruby
 cve: 2012-5371
+ghsa: phrv-cj28-9h57
 osvdb: 87863
-url: http://www.osvdb.org/show/osvdb/87863
+url: https://www.ruby-lang.org/en/news/2012/11/09/ruby19-hashdos-cve-2012-5371
 title: "CVE-2012-5371 ruby: Murmur hash-flooding DoS flaw in ruby 1.9 (oCERT-2012-001)"
 date: 2012-11-23
 description: |
   Ruby (aka CRuby) 1.9 before 1.9.3-p327 and 2.0 before r37575 computes
-  hash values without properly restricting the ability to trigger hash collisions
-  predictably, which allows context-dependent attackers to cause a denial of service
-  (CPU consumption) via crafted input to an application that maintains a hash table,
-  as demonstrated by a universal multicollision attack against a variant of the MurmurHash2
+  hash values without properly restricting the ability to trigger hash
+  collisions predictably, which allows context-dependent attackers to
+  cause a denial of service (CPU consumption) via crafted input to an
+  application that maintains a hash table, as demonstrated by a universal
+  multicollision attack against a variant of the MurmurHash2
   algorithm, a different vulnerability than CVE-2011-4815.
 cvss_v2: 5.0
 patched_versions:
-  - ~> 1.9.3.327
-  - '>= 2.0.0'
+  - "~> 1.9.3.327"
+  - ">= 2.0.0"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2012/11/09/ruby19-hashdos-cve-2012-5371
+    - https://nvd.nist.gov/vuln/detail/CVE-2012-5371
+    - http://ocert.org/advisories/ocert-2012-001.html
+    - https://seclists.org/oss-sec/2012/q4/352
+    - https://github.com/advisories/GHSA-phrv-cj28-9h57
+    - http://www.osvdb.org/show/osvdb/87863

--- a/rubies/ruby/CVE-2013-1821.yml
+++ b/rubies/ruby/CVE-2013-1821.yml
@@ -1,15 +1,23 @@
 ---
 engine: ruby
 cve: 2013-1821
+ghsa: hgg7-cghq-xhf4
 osvdb: 90587
-url: http://www.osvdb.org/show/osvdb/90587
+url: https://www.ruby-lang.org/en/news/2013/02/22/rexml-dos-2013-02-22
 title: "CVE-2013-1821 ruby: entity expansion DoS vulnerability in REXML"
 date: 2013-02-22
 description: |
-  lib/rexml/text.rb in the REXML parser in Ruby before 1.9.3-p392 allows
-  remote attackers to cause a denial of service (memory consumption and crash) via
-  crafted text nodes in an XML document, aka an XML Entity Expansion (XEE) attack.
+  lib/rexml/text.rb in the REXML parser in Ruby before 1.9.3-p392
+  allows remote attackers to cause a denial of service (memory
+  consumption and crash) via crafted text nodes in an XML document,
+  aka an XML Entity Expansion (XEE) attack.
 cvss_v2: 5.0
 patched_versions:
-  - ~> 1.9.3.392
-  - '>= 2.0.0.0'
+  - "~> 1.9.3.392"
+  - ">= 2.0.0.0"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2013/02/22/rexml-dos-2013-02-22
+    - https://nvd.nist.gov/vuln/detail/CVE-2013-1821
+    - https://github.com/advisories/GHSA-hgg7-cghq-xhf4
+    - http://www.osvdb.org/show/osvdb/90587

--- a/rubies/ruby/CVE-2013-2065.yml
+++ b/rubies/ruby/CVE-2013-2065.yml
@@ -1,17 +1,25 @@
 ---
 engine: ruby
 cve: 2013-2065
+ghsa: wh77-3w5g-7q6x
 osvdb: 93414
-url: http://www.osvdb.org/show/osvdb/93414
+url: https://www.ruby-lang.org/en/news/2013/05/14/taint-bypass-dl-fiddle-cve-2013-2065
 title: "CVE-2013-2065 Ruby: Object taint bypassing in DL and Fiddle"
 date: 2013-05-14
 description: |
-  (1) DL and (2) Fiddle in Ruby 1.9 before 1.9.3 patchlevel 426, and 2.0
-  before 2.0.0 patchlevel 195, do not perform taint checking for native functions,
-  which allows context-dependent attackers to bypass intended $SAFE level restrictions.
+  (1) DL and (2) Fiddle in Ruby 1.9 before 1.9.3 patchlevel 426, and
+  2.0 before 2.0.0 patchlevel 195, do not perform taint checking for
+  native functions, which allows context-dependent attackers to bypass
+  intended $SAFE level restrictions.
 cvss_v2: 6.4
 unaffected_versions:
-  - ~> 1.8.0
+  - "~> 1.8.0"
 patched_versions:
-  - ~> 1.9.3.426
-  - '>= 2.0.0.195'
+  - "~> 1.9.3.426"
+  - ">= 2.0.0.195"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2013/05/14/taint-bypass-dl-fiddle-cve-2013-2065
+    - https://nvd.nist.gov/vuln/detail/CVE-2013-2065
+    - https://github.com/advisories/GHSA-wh77-3w5g-7q6x
+    - http://www.osvdb.org/show/osvdb/93414

--- a/rubies/ruby/CVE-2013-4073.yml
+++ b/rubies/ruby/CVE-2013-4073.yml
@@ -1,19 +1,29 @@
 ---
 engine: ruby
 cve: 2013-4073
+ghsa: 3gpq-xx45-4rr9
 osvdb: 94628
-url: http://www.osvdb.org/show/osvdb/94628
+url: https://www.ruby-lang.org/en/news/2013/06/27/hostname-check-bypassing-vulnerability-in-openssl-client-cve-2013-4073
 title: "CVE-2013-4073 ruby: hostname check bypassing vulnerability in SSL client"
 date: 2013-06-27
 description: |
-  The OpenSSL::SSL.verify_certificate_identity function in lib/openssl/ssl.rb
-  in Ruby 1.8 before 1.8.7-p374, 1.9 before 1.9.3-p448, and 2.0 before 2.0.0-p247
-  does not properly handle a '\0' character in a domain name in the Subject Alternative
-  Name field of an X.509 certificate, which allows man-in-the-middle attackers to
-  spoof arbitrary SSL servers via a crafted certificate issued by a legitimate Certification
+  The OpenSSL::SSL.verify_certificate_identity function in
+  lib/openssl/ssl.rb in Ruby 1.8 before 1.8.7-p374,
+  1.9 before 1.9.3-p448, and 2.0 before 2.0.0-p247
+  does not properly handle a '\0' character in a domain name in
+  the Subject Alternative Name field of an X.509 certificate, which
+  allows man-in-the-middle attackers to spoof arbitrary SSL servers
+  via a crafted certificate issued by a legitimate Certification
   Authority, a related issue to CVE-2009-2408.
 cvss_v2: 6.8
 patched_versions:
-  - ~> 1.8.7.373
-  - ~> 1.9.3.447
-  - '>= 2.0.0.246'
+  - "~> 1.8.7.374"
+  - "~> 1.9.3.448"
+  - ">= 2.0.0.247"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2013/06/27/hostname-check-bypassing-vulnerability-in-openssl-client-cve-2013-4073
+    - https://nvd.nist.gov/vuln/detail/CVE-2013-4073
+    - https://github.com/advisories/GHSA-3gpq-xx45-4rr9
+    - http://www.osvdb.org/show/osvdb/94628
+notes: "Changed patched_versions per ruby-lang URL"

--- a/rubies/ruby/CVE-2013-4164.yml
+++ b/rubies/ruby/CVE-2013-4164.yml
@@ -1,18 +1,27 @@
 ---
 engine: ruby
 cve: 2013-4164
+ghsa: j98q-m2w8-57rc
 osvdb: 100113
-url: http://www.osvdb.org/show/osvdb/100113
+url: https://www.ruby-lang.org/en/news/2013/11/22/heap-overflow-in-floating-point-parsing-cve-2013-4164
 title: "CVE-2013-4164 ruby: heap overflow in floating point parsing"
 date: 2013-11-22
 description: |
-  Heap-based buffer overflow in Ruby 1.8, 1.9 before 1.9.3-p484, 2.0 before
-  2.0.0-p353, 2.1 before 2.1.0 preview2, and trunk before revision 43780 allows context-dependent
-  attackers to cause a denial of service (segmentation fault) and possibly execute
-  arbitrary code via a string that is converted to a floating point value, as demonstrated
-  using (1) the to_f method or (2) JSON.parse.
+  Heap-based buffer overflow in Ruby 1.8, 1.9 before 1.9.3-p484,
+  2.0 before 2.0.0-p353, 2.1 before 2.1.0 preview2, and trunk before
+  revision 43780 allows context-dependent attackers to cause a denial
+  of service (segmentation fault) and possibly execute arbitrary code
+  via a string that is converted to a floating point value, as
+  demonstrated using (1) the to_f method or (2) JSON.parse.
 cvss_v2: 6.8
 patched_versions:
-  - ~> 1.9.3.484
-  - ~> 2.0.0.353
-  - '>= 2.1.0.preview.2'
+  - "~> 1.9.3.484"
+  - "~> 2.0.0.353"
+  - "~> 2.1.0.preview.2"
+  - ">= 2.1.0"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2013/11/22/heap-overflow-in-floating-point-parsing-cve-2013-4164
+    - https://nvd.nist.gov/vuln/detail/CVE-2013-4164
+    - https://github.com/advisories/GHSA-j98q-m2w8-57rc
+    - http://www.osvdb.org/show/osvdb/100113

--- a/rubies/ruby/CVE-2014-2525.yml
+++ b/rubies/ruby/CVE-2014-2525.yml
@@ -1,15 +1,24 @@
 ---
 engine: ruby
 cve: 2014-2525
+ghsa: rffm-7xqq-h2v6
 osvdb: 105027
-url: http://www.osvdb.org/show/osvdb/105027
+url: https://www.ruby-lang.org/en/news/2014/03/29/heap-overflow-in-yaml-uri-escape-parsing-cve-2014-2525
 title: "CVE-2014-2525 libyaml: heap-based buffer overflow when parsing URLs"
 date: 2014-03-26
 description: |
-  Heap-based buffer overflow in the yaml_parser_scan_uri_escapes function
-  in LibYAML before 0.1.6 allows context-dependent attackers to execute arbitrary
-  code via a long sequence of percent-encoded characters in a URI in a YAML file.
+  Heap-based buffer overflow in the yaml_parser_scan_uri_escapes
+  function in LibYAML before 0.1.6 allows context-dependent attackers
+  to execute arbitrary code via a long sequence of percent-encoded
+  characters in a URI in a YAML file.
 cvss_v2: 6.8
 patched_versions:
-  - ~> 2.0.0.481
-  - '>= 2.1.2'
+  - "~> 2.0.0.481"
+  - ">= 2.1.2"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2014/03/29/heap-overflow-in-yaml-uri-escape-parsing-cve-2014-2525
+    - http://ocert.org/advisories/ocert-2014-003.html
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-2525
+    - https://github.com/advisories/GHSA-rffm-7xqq-h2v6
+    - http://www.osvdb.org/show/osvdb/105027

--- a/rubies/ruby/CVE-2014-3916.yml
+++ b/rubies/ruby/CVE-2014-3916.yml
@@ -1,16 +1,25 @@
 ---
 engine: ruby
 cve: 2014-3916
+ghsa: 252h-69rw-g2rp
 osvdb: 107478
-url: http://www.osvdb.org/show/osvdb/107478
+url: https://vulners.com/rubygems/RUBY:RUBY-2014-3916-107478
 title: "CVE-2014-3916 ruby: DoS via long string in str_buf_cat()"
 date: 2014-04-07
 description: |
-  The str_buf_cat function in string.c in Ruby 1.9.3, 2.0.0, and 2.1 allows
-  context-dependent attackers to cause a denial of service (segmentation fault and
-  crash) via a long string.
+  The str_buf_cat function in string.c in Ruby 1.9.3, 2.0.0, and
+  2.1 allows context-dependent attackers to cause a denial of
+  service (segmentation fault and crash) via a long string.
 cvss_v2: 5.0
 patched_versions:
-  - ~> 2.0.0.576
-  - ~> 2.1.3
-  - '>= 2.2.0.preview.1'
+  - "~> 2.0.0.576"
+  - "~> 2.1.3"
+  - "~> 2.2.0.preview.1"
+  - ">= 2.2.0"
+related:
+  url:
+    - https://vulners.com/rubygems/RUBY:RUBY-2014-3916-107478
+    - https://bugs.ruby-lang.org/issues/9709
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-3916
+    - https://github.com/advisories/GHSA-252h-69rw-g2rp
+    - http://www.osvdb.org/show/osvdb/107478

--- a/rubies/ruby/CVE-2014-4975.yml
+++ b/rubies/ruby/CVE-2014-4975.yml
@@ -1,17 +1,27 @@
 ---
 engine: ruby
 cve: 2014-4975
+ghsa: gxj7-mcpg-jpr6
 osvdb: 108971
-url: http://www.osvdb.org/show/osvdb/108971
-title: 'CVE-2014-4975 ruby: off-by-one stack-based buffer overflow in the encodes()
-  function'
+url: https://bugs.ruby-lang.org/issues/10019
+title: "CVE-2014-4975 ruby: off-by-one stack-based buffer overflow
+  in the encodes() function"
 date: 2014-07-09
 description: |
   Off-by-one error in the encodes function in pack.c in Ruby 1.9.3 and
-  earlier, and 2.x through 2.1.2, when using certain format string specifiers, allows
-  context-dependent attackers to cause a denial of service (segmentation fault) via
-  vectors that trigger a stack-based buffer overflow.
+  earlier, and 2.x through 2.1.2, when using certain format string
+  specifiers, allows context-dependent attackers to cause a denial of
+  service (segmentation fault) via vectors that trigger a stack-based
+  buffer overflow.
 cvss_v2: 5.0
 patched_versions:
-  - ~> 2.1.3
-  - '>= 2.2.0.preview.1'
+  - "~> 2.1.3"
+  - "~> 2.2.0.preview.1"
+  - ">= 2.2.0"
+related:
+  url:
+    - https://bugs.ruby-lang.org/issues/10019
+    - https://www.vulnerabilitycenter.com/#!vul=47400
+    - https://github.com/advisories/GHSA-gxj7-mcpg-jpr6
+    - http://www.osvdb.org/show/osvdb/108971
+notes: "Did not find announcement URL"

--- a/rubies/ruby/CVE-2014-8080.yml
+++ b/rubies/ruby/CVE-2014-8080.yml
@@ -1,16 +1,25 @@
 ---
 engine: ruby
 cve: 2014-8080
+ghsa: ggvr-v7qh-jwjh
 osvdb: 113747
-url: http://www.osvdb.org/show/osvdb/113747
+url: https://www.ruby-lang.org/en/news/2014/10/27/rexml-dos-cve-2014-8080
 title: "CVE-2014-8080 ruby: REXML billion laughs attack via parameter entity expansion"
 date: 2014-10-27
 description: |
   The REXML parser in Ruby 1.9.x before 1.9.3-p550, 2.0.x before 2.0.0-p594,
-  and 2.1.x before 2.1.4 allows remote attackers to cause a denial of service (memory
-  consumption) via a crafted XML document, aka an XML Entity Expansion (XEE) attack.
+  and 2.1.x before 2.1.4 allows remote attackers to cause a denial of
+  service (memory consumption) via a crafted XML document, aka an
+  XML Entity Expansion (XEE) attack.
 cvss_v2: 5.0
 patched_versions:
-  - ~> 1.9.3.550
-  - ~> 2.0.0.594
-  - '>= 2.1.4'
+  - "~> 1.9.3.550"
+  - "~> 2.0.0.594"
+  - ">= 2.1.4"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2014/10/27/rexml-dos-cve-2014-8080
+    - https://nvd.nist.gov/vuln/detail/CVE-2014-8080
+    - https://github.com/advisories/GHSA-ggvr-v7qh-jwjh
+    - https://github.com/thesp0nge/dawnscanner/issues/116
+    - http://www.osvdb.org/show/osvdb/113747

--- a/rubies/ruby/CVE-2014-8090.yml
+++ b/rubies/ruby/CVE-2014-8090.yml
@@ -1,19 +1,29 @@
 ---
 engine: ruby
 cve: 2014-8090
+ghsa: 2x97-vvh4-m4q4
 osvdb: 114641
-url: http://www.osvdb.org/show/osvdb/114641
+url: https://www.ruby-lang.org/en/news/2014/11/13/rexml-dos-cve-2014-8090
 title: "CVE-2014-8090 ruby: REXML incomplete fix for CVE-2014-8080"
 date: 2014-11-13
 description: |
-  'The REXML parser in Ruby 1.9.x before 1.9.3 patchlevel 551, 2.0.x before
-  2.0.0 patchlevel 598, and 2.1.x before 2.1.5 allows remote attackers to cause a
-  denial of service (CPU and memory consumption) a crafted XML document containing
-  an empty string in an entity that is used in a large number of nested entity references,
-  aka an XML Entity Expansion (XEE) attack.  NOTE: this vulnerability exists because
-  of an incomplete fix for CVE-2013-1821 and CVE-2014-8080.'
+  The REXML parser in Ruby 1.9.x before 1.9.3 patchlevel 551,
+  2.0.x before 2.0.0 patchlevel 598, and 2.1.x before 2.1.5 allows
+  remote attackers to cause a denial of service (CPU and memory
+  consumption) a crafted XML document containing an empty string
+  in an entity that is used in a large number of nested entity
+  references, aka an XML Entity Expansion (XEE) attack.
+
+  NOTE: this vulnerability exists because of an incomplete
+  fix for CVE-2013-1821 and CVE-2014-8080.
 cvss_v2: 5.0
 patched_versions:
-  - ~> 1.9.3.551
-  - ~> 2.0.0.598
-  - '>= 2.1.5'
+  - "~> 1.9.3.551"
+  - "~> 2.0.0.598"
+  - ">= 2.1.5"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2014/11/13/rexml-dos-cve-2014-8090
+    - https://nvd.nist.gov/vuln/detail/cve-2014-8090
+    - https://github.com/advisories/GHSA-2x97-vvh4-m4q4
+    - http://www.osvdb.org/show/osvdb/114641


### PR DESCRIPTION
## Updating advisories with osvdb.org in "url:" field

  * Updated "url:" field with non-osvdb reference since     osvdb.org is no longer available.
  * Added "ghsa:" field value for advisories with "cve:" values.
  * Added "related:" references as evidence for further work (for advisories with "cve": values, usually only 4 refs; check NVD reference for full list).
  * Changed quotes to or adding double-quotes as needed.
  * Added "notes:" as needed to be more explicit.
  * Line wrapped text fields as needed.
  * Merged one duplicate OSVDB-78119 advisory into CVE-2012-5372 advisory.

## Special Notes
 * No new files/advisories in this PR.
 * Will delete rubies/rbx/OSVDB-78119.yml file in separate PR.

## Checks
 * internal "morechks" script (all clean)
 * yamlint (green)
 * rake (green)
