### PR TITLE
Updated 3 and added 3 SRC:CLR advisories with CVE values from issue #238

### DIFF
--- a/gems/facter/CVE-2015-1426.yml
+++ b/gems/facter/CVE-2015-1426.yml
@@ -1,0 +1,26 @@
+---
+gem: facter
+cve: 2015-1426
+ghsa: j436-h7hm-rx46
+url: https://www.puppet.com/security/cve/cve-2015-1426-potential-sensitive-information-leakage-facters-amazon-ec2-metadata
+title: Puppet Labs Facter allows local users to obtains sensitive Amazon
+  EC2 IAM instance metadata by reading a fact for an Amazon EC2 node.
+date: 2015-02-10
+description: |
+  Puppet Labs Facter 1.6.0 through 2.4.0 allows local users to
+  obtains sensitive Amazon EC2 IAM instance metadata by reading
+  a fact for an Amazon EC2 node.
+cvss_v2: 2.1
+cvss_v3: 1.3
+unaffected_versions:
+  - "< 1.6.0"
+patched_versions:
+  - ">= 2.4.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-1426
+    - https://www.puppet.com/security/cve/cve-2015-1426-potential-sensitive-information-leakage-facters-amazon-ec2-metadata
+    - https://sca.analysiscenter.veracode.com/vulnerability-database/security/disclosure-amazon-ec2-iam-instance/ruby/sid-1508/summary
+    - https://srcclr.com/security/disclosure-amazon-ec2-iam-instance/ruby/s-1508
+    - https://github.com/rubysec/ruby-advisory-db/issues/238
+    - https://github.com/advisories/GHSA-j436-h7hm-rx46

--- a/gems/kafo/CVE-2014-0135.yml
+++ b/gems/kafo/CVE-2014-0135.yml
@@ -15,3 +15,7 @@ cvss_v2: 1.9
 patched_versions:
   - "~> 0.3.17"
   - ">= 0.5.2"
+related:
+  url:
+    - https://github.com/rubysec/ruby-advisory-db/issues/238
+    - https://sca.analysiscenter.veracode.com/vulnerability-database/security/world-readable-permissions-as-default/ruby/sid-740/summary

--- a/gems/logstash-core/CVE-2015-5378.yml
+++ b/gems/logstash-core/CVE-2015-5378.yml
@@ -1,0 +1,25 @@
+---
+gem: logstash-core
+cve: 2015-5378
+ghsa: g6rc-3fpq-w2gr
+url: https://packetstormsecurity.com/files/132800/Logstash-1.5.2-SSL-TLS-FREAK.html
+title: "Logstash: SSL/TLS FREAK Attack"
+date: 2015-07-21
+description: |
+  Logstash: SSL/TLS FREAK Attack: Logstash 1.5.x before 1.5.3 and
+  1.4.x before 1.4.4 allows remote attackers to read communications
+  between Logstash Forwarder agent and Logstash server.
+cvss_v2: 5.0
+cvss_v3: 7.5
+patched_versions:
+  - "~> 1.4.4"
+  - ">= 1.5.3"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-5378
+    - https://packetstormsecurity.com/files/132800/Logstash-1.5.2-SSL-TLS-FREAK.html
+    - https://sca.analysiscenter.veracode.com/vulnerability-database/security/factoring-attack-rsa-export-keys-freak/ruby/sid-1745/summary
+    - https://github.com/rubysec/ruby-advisory-db/issues/238
+    - https://www.elastic.co/community/security
+    - https://github.com/advisories/GHSA-g6rc-3fpq-w2gr
+    - https://web.archive.org/web/20181211080524/http://www.securityfocus.com/bid/76015

--- a/gems/logstash-core/CVE-2015-5619.yml
+++ b/gems/logstash-core/CVE-2015-5619.yml
@@ -1,0 +1,25 @@
+---
+gem: logstash-core
+cve: 2015-5619
+ghsa: 68pf-743m-hv2w
+url: https://www.elastic.co/blog/logstash-1-5-4-and-1-4-5-released
+title: "Logstash: Man-In-The Middle attack"
+date: 2015-08-20
+description: |
+  Logstash 1.4.x before 1.4.5 and 1.5.x before 1.5.4 with Lumberjack
+  output or the Logstash forwarder does not validate SSL/TLS certificates
+  from the Logstash server, which might allow attackers to obtain
+  sensitive information via a man-in-the-middle attack.
+cvss_v2: 4.3
+cvss_v3: 5.9
+patched_versions:
+  - "~> 1.4.5"
+  - ">= 1.5.4"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-5619
+    - https://www.elastic.co/blog/logstash-1-5-4-and-1-4-5-released
+    - https://www.elastic.co/community/security
+    - https://packetstormsecurity.com/files/133269/Logstash-1.5.3-Man-In-The-Middle.html
+    - https://sca.analysiscenter.veracode.com/vulnerability-database/security/man-middle-mitm-attacks/ruby/sid-1798/summary
+    - https://github.com/advisories/GHSA-68pf-743m-hv2w

--- a/gems/puppet/CVE-2014-3248.yml
+++ b/gems/puppet/CVE-2014-3248.yml
@@ -26,3 +26,5 @@ related:
     - http://secunia.com/advisories/59197
     - http://secunia.com/advisories/59200
     - http://www.securityfocus.com/bid/68035
+    - https://github.com/rubysec/ruby-advisory-db/issues/238
+    - https://sca.analysiscenter.veracode.com/vulnerability-database/security/elevation-privileges-untrusted-search/ruby/sid-1586/summary

--- a/gems/spina/CVE-2015-4619.yml
+++ b/gems/spina/CVE-2015-4619.yml
@@ -12,3 +12,7 @@ description: |
 cvss_v3: 8.8
 patched_versions:
   - ">= 0.6.29"
+related:
+  url:
+    - https://sca.analysiscenter.veracode.com/vulnerability-database/security/cross-site-request-forgery-csrf/ruby/sid-1686/summary
+    - https://github.com/rubysec/ruby-advisory-db/issues/238


### PR DESCRIPTION
Updated 3 and added 3 SRC:CLR advisories with CVE values from issue #238.
 * For the existing advisories, I added the updated SRC:CLR URL since SourceClear was purchased by Veracode.
 * For the brand new advisories, I added new files along with the updated SRC:CLR URL.
  * The other 10 URL in #238 do not have a CVE number so they need a CVE before adding them.