### PR TITLE
2 more advisories resulting from reclassifying 'rails' gems to sub-rails gems

### DIFF
--- a/gems/actionpack/CVE-2011-0446.yml
+++ b/gems/actionpack/CVE-2011-0446.yml
@@ -1,0 +1,33 @@
+---
+gem: actionpack
+framework: rails
+cve: 2011-0446
+ghsa: 75w6-p6mg-vh8j
+url: https://groups.google.com/g/rubyonrails-security/c/8CpI7egxX4E/m/SmtqtyOKWzYJ
+title: XSS vulnerabilities in the mail_to helper in rails/actionpack
+date: 2017-10-24
+description: |
+  Multiple cross-site scripting (XSS) vulnerabilities in the mail_to
+  helper in Ruby on Rails before 2.3.11, and 3.x before 3.0.4, when
+  javascript encoding is used, allow remote attackers to inject
+  arbitrary web script or HTML via a crafted (1) name or (2) email value.
+cvss_v2: 4.3
+patched_versions:
+  - "~> 2.3.11"
+  - ">= 3.0.4"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2011-0446
+    - https://groups.google.com/g/rubyonrails-security/c/8CpI7egxX4E/m/SmtqtyOKWzYJ
+    - https://github.com/advisories/GHSA-75w6-p6mg-vh8j
+    - http://lists.fedoraproject.org/pipermail/package-announce/2011-April/057650.html
+    - http://lists.fedoraproject.org/pipermail/package-announce/2011-March/055074.html
+    - http://lists.fedoraproject.org/pipermail/package-announce/2011-March/055088.html
+    - http://www.debian.org/security/2011/dsa-2247
+    - https://web.archive.org/web/20111225083933/http://secunia.com/advisories/43274
+    - https://web.archive.org/web/20111225083933/http://secunia.com/advisories/43666
+    - https://web.archive.org/web/20201208053819/http://www.securitytracker.com/id?1025064
+    - https://web.archive.org/web/20210121211512/http://www.securityfocus.com/bid/46291
+    - https://github.com/rails/rails/commit/abe97736b8316f1b714cac56c115c0779aa73217
+    - https://github.com/rails/rails/commit/e3dd2107c57a8efaaea5d61cf8da65f7444760b2
+    - https://github.com/advisories/GHSA-75w6-p6mg-vh8j

--- a/gems/activesupport/CVE-2009-3086.yml
+++ b/gems/activesupport/CVE-2009-3086.yml
@@ -1,0 +1,34 @@
+---
+gem: activesupport
+framework: rails
+cve: 2009-3086
+ghsa: fg9w-g6m4-557j
+url: http://weblog.rubyonrails.org/2009/9/4/timing-weakness-in-ruby-on-rails
+title: actionpack and activesupport vulnerable to information leaks
+date: 2017-10-24
+description: |
+  A certain algorithm in Ruby on Rails 2.1.0 through 2.2.2, and 2.3.x
+  before 2.3.4, leaks information about the complexity of message-digest
+  signature verification in the cookie store, which might allow remote
+  attackers to forge a digest via multiple attempts.
+cvss_v2: 5.0
+unaffected_versions:
+  - "< 2.1.0"
+patched_versions:
+  - "~> 2.2.3"
+  - ">= 2.3.4"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2009-3086
+    - http://weblog.rubyonrails.org/2009/9/4/timing-weakness-in-ruby-on-rails
+    - https://github.com/advisories/GHSA-fg9w-g6m4-557j
+    - http://lists.opensuse.org/opensuse-security-announce/2009-10/msg00004.html
+    - http://www.debian.org/security/2011/dsa-2260
+    - https://github.com/rubysec/ruby-advisory-db/blob/master/gems/actionpack/CVE-2009-3086.yml
+    - https://github.com/rails/rails/commit/1f07a89c5946910fc28ea5ccd1da6af8a0f972a0
+    - https://github.com/rails/rails/commit/674f780d59a5a7ec0301755d43a7b277a3ad2978
+    - https://github.com/rails/rails/commit/d460c9a25560f43e7c3789abadf7b455053eb686
+    - https://web.archive.org/web/20090906010200/http://www.vupen.com/english/advisories/2009/2544
+    - https://web.archive.org/web/20090907001716/http://secunia.com/advisories/36600
+    - https://web.archive.org/web/20200229150042/http://www.securityfocus.com/bid/37427
+    - https://github.com/advisories/GHSA-fg9w-g6m4-557j


### PR DESCRIPTION
2 more advisories resulting from reclassifying 'rails' gems to sub-rails gems.
 * gems/actionpack/CVE-2011-0446.yml
 * gems/activesupport/CVE-2009-3086.yml
