### PR TITLE
GHSA sync + modifies + few manual edits

### DIFF
--- a/gems/actionpack/CVE-2014-0081.yml
+++ b/gems/actionpack/CVE-2014-0081.yml
@@ -3,9 +3,10 @@ gem: actionpack
 framework: rails
 cve: 2014-0081
 osvdb: 103439
+ghsa: m46p-ggm5-5j83
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-0081
-title: 'CVE-2014-0081 rubygem-actionpack: number_to_currency, number_to_percentage
-  and number_to_human XSS vulnerability'
+title: "CVE-2014-0081 rubygem-actionpack: number_to_currency,
+  number_to_percentage and number_to_human XSS vulnerability"
 date: 2014-02-18
 description: |
   Multiple cross-site scripting (XSS) vulnerabilities in actionview/lib/action_view/helpers/number_helper.rb
@@ -15,6 +16,6 @@ description: |
   or (c) number_to_human helper.
 cvss_v2: 4.3
 patched_versions:
-  - ~> 3.2.17
-  - ~> 4.0.3
-  - '>= 4.1.0.beta2'
+  - "~> 3.2.17"
+  - "~> 4.0.3"
+  - ">= 4.1.0.beta2"

--- a/gems/actionpack/CVE-2016-0752.yml
+++ b/gems/actionpack/CVE-2016-0752.yml
@@ -2,9 +2,10 @@
 gem: actionpack
 framework: rails
 cve: 2016-0752
-date: 2016-01-25
+ghsa: xrr4-p6fq-hjg7
 url: https://groups.google.com/forum/#!topic/rubyonrails-security/335P1DcLG00
 title: Possible Information Leak Vulnerability in Action View
+date: 2016-01-25
 description: |
   There is a possible directory traversal and information leak vulnerability in
   Action View. This vulnerability has been assigned the CVE identifier
@@ -83,11 +84,12 @@ description: |
   Credits
   -------
   Thanks John Poulin for reporting this!
+cvss_v3: 7.5
 unaffected_versions:
-  - '>= 4.1.0'
+  - ">= 4.1.0"
 patched_versions:
-  - '>= 5.0.0.beta1.1'
-  - ~> 4.2.5, >= 4.2.5.1
-  - ~> 4.1.14, >= 4.1.14.1
-  - ~> 3.2.22.1
-notes: Newer versions are affected, but tracked in the actionview gem.
+  - ">= 5.0.0.beta1.1"
+  - "~> 4.2.5, >= 4.2.5.1"
+  - "~> 4.1.14, >= 4.1.14.1"
+  - "~> 3.2.22.1"
+notes: "Newer versions are affected, but tracked in the actionview gem."

--- a/gems/actionpack/CVE-2016-2097.yml
+++ b/gems/actionpack/CVE-2016-2097.yml
@@ -2,9 +2,10 @@
 gem: actionpack
 framework: rails
 cve: 2016-2097
-date: 2016-02-29
+ghsa: vx9j-46rh-fqr8
 url: https://groups.google.com/forum/#!topic/rubyonrails-security/ddY6HgqB2z4
 title: Possible Information Leak Vulnerability in Action View
+date: 2016-02-29
 description: |
 
   There is a possible directory traversal and information leak vulnerability
@@ -78,10 +79,11 @@ description: |
   -------
   Thanks to both Jyoti Singh and Tobias Kraze from makandra for reporting this
   and working with us in the patch!
+cvss_v3: 5.3
 unaffected_versions:
-  - '>= 4.1.0'
+  - ">= 4.1.0"
 patched_versions:
-  - ~> 3.2.22.2
-  - ~> 4.1.14
-  - '>= 4.1.14.2'
-notes: Newer versions are affected, but tracked in the actionview gem.
+  - "~> 3.2.22.2"
+  - "~> 4.1.14"
+  - ">= 4.1.14.2"
+notes: "Newer versions are affected, but tracked in the actionview gem."

--- a/gems/actionpack/CVE-2016-6316.yml
+++ b/gems/actionpack/CVE-2016-6316.yml
@@ -2,9 +2,10 @@
 gem: actionpack
 framework: rails
 cve: 2016-6316
-date: 2016-08-11
+ghsa: pc3m-v286-2jwj
 url: https://groups.google.com/forum/#!topic/rubyonrails-security/I-VWr034ouk
 title: Possible XSS Vulnerability in Action View
+date: 2016-08-11
 description: |
   There is a possible XSS vulnerability in Action View.  Text declared as "HTML
   safe" will not have quotes escaped when used as attribute values in tag
@@ -43,11 +44,12 @@ description: |
 
   content_tag(:div, "hi", title: escape_quotes(sanitize(user_input)))
   ```
+cvss_v3: 6.1
 unaffected_versions:
-  - < 3.0.0
-  - '>= 4.1.0'
+  - "< 3.0.0"
+  - ">= 4.1.0"
 patched_versions:
-  - ~> 3.2.22.3
-  - ~> 4.2.7.1
-  - '>= 5.0.0.1'
-notes: Newer versions are affected, but tracked in the actionview gem.
+  - "~> 3.2.22.3"
+  - "~> 4.2.7.1"
+  - ">= 5.0.0.1"
+notes: "Newer versions are affected, but tracked in the actionview gem."

--- a/gems/actionview/CVE-2023-23913.yml
+++ b/gems/actionview/CVE-2023-23913.yml
@@ -2,9 +2,9 @@
 gem: actionview
 framework: rails
 cve: 2023-23913
+ghsa: xp5h-f8jf-rc8q
 url: https://discuss.rubyonrails.org/t/cve-2023-23913-dom-based-cross-site-scripting-in-rails-ujs-for-contenteditable-html-elements/82468
-title: DOM Based Cross-site Scripting in rails-ujs for
-  contenteditable HTML Elements
+title: DOM Based Cross-site Scripting in rails-ujs for contenteditable HTML Elements
 date: 2023-03-13
 description: |
   NOTE: rails-ujs is part of Rails/actionview since 5.1.0.
@@ -56,7 +56,6 @@ description: |
   * rails-ujs-data-method-contenteditable-6-1.patch (8.5 KB)
   * rails-ujs-data-method-contenteditable-7-0.patch (8.5 KB)
   * rails-ujs-data-method-contenteditable-main.patch (8.9 KB)
-
 cvss_v3: 7.5
 unaffected_versions:
   - "< 5.1.0"

--- a/gems/echor/CVE-2014-1834.yml
+++ b/gems/echor/CVE-2014-1834.yml
@@ -2,6 +2,7 @@
 gem: echor
 cve: 2014-1834
 osvdb: 102129
+ghsa: 8936-cgj4-phr2
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-1834
 title: echor Gem for Ruby backplane.rb perform_request Function Arbitrary Command
   Execution
@@ -11,3 +12,4 @@ description: |
   function that is triggered when a semi-colon (;) is injected into a username
   or password. This may allow a context-dependent attacker to inject arbitrary
   commands if the gem is used in a rails application.
+cvss_v3: 7.8

--- a/gems/echor/CVE-2014-1835.yml
+++ b/gems/echor/CVE-2014-1835.yml
@@ -2,6 +2,7 @@
 gem: echor
 cve: 2014-1835
 osvdb: 102130
+ghsa: j4gx-p3x5-m987
 url: https://nvd.nist.gov/vuln/detail/CVE-2014-1835
 title: echor Gem for Ruby Process Listing Local Plaintext Credential Disclosure
 date: 2014-01-14
@@ -9,3 +10,4 @@ description: |
   echor Gem for Ruby contains a flaw that is due to the program exposing
   credential information in the system process listing. This may allow a local
   attacker to gain access to plaintext credential information.
+cvss_v3: 7.8

--- a/gems/kredis/CVE-2023-27531.yml
+++ b/gems/kredis/CVE-2023-27531.yml
@@ -2,6 +2,7 @@
 gem: kredis
 framework: rails
 cve: 2023-27531
+ghsa: h2wm-p2vg-6pw4
 url: https://discuss.rubyonrails.org/t/cve-2023-27531-possible-deserialization-of-untrusted-data-vulnerability-in-kredis-json/82467#post_1
 title: Possible Deserialization of Untrusted Data Vulnerability in Kredis JSON
 date: 2023-03-13
@@ -36,7 +37,6 @@ description: |
 
   Credits
     Thank you ooooooo_k 7 for reporting this!
-
 patched_versions:
   - ">= 1.3.0.1"
 related:

--- a/gems/nokogiri/CVE-2013-6460.yml
+++ b/gems/nokogiri/CVE-2013-6460.yml
@@ -3,6 +3,7 @@ gem: nokogiri
 platform: jruby
 cve: 2013-6460
 osvdb: 101179
+ghsa: 62qp-3fxm-9wxf
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-6460
 title: "CVE-2013-6460 rubygem-nokogiri: DoS while parsing XML documents"
 date: 2013-12-14
@@ -10,6 +11,7 @@ description: |
   Nokogiri gem 1.5.x has Denial of Service via infinite loop when parsing
   XML documents
 cvss_v2: 4.3
+cvss_v3: 6.5
 patched_versions:
-  - ~> 1.5.11
-  - '>= 1.6.1'
+  - "~> 1.5.11"
+  - ">= 1.6.1"

--- a/gems/nokogiri/CVE-2013-6461.yml
+++ b/gems/nokogiri/CVE-2013-6461.yml
@@ -2,12 +2,14 @@
 gem: nokogiri
 cve: 2013-6461
 osvdb: 101458
+ghsa: jmhh-w7xp-wg39
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-6461
 title: "CVE-2013-6461 rubygem-nokogiri: DoS while parsing XML entities"
 date: 2013-12-14
 description: |
   Nokogiri gem 1.5.x and 1.6.x has DoS while parsing XML entities by failing
   to apply limits
+cvss_v3: 6.5
 patched_versions:
-  - ~> 1.5.11
-  - '>= 1.6.1'
+  - "~> 1.5.11"
+  - ">= 1.6.1"

--- a/gems/nokogiri/CVE-2017-16932.yml
+++ b/gems/nokogiri/CVE-2017-16932.yml
@@ -1,6 +1,7 @@
 ---
 gem: nokogiri
 cve: 2017-16932
+ghsa: x2fm-93ww-ggvx
 url: https://github.com/sparklemotion/nokogiri/issues/1714
 title: Nokogiri gem, via libxml, is affected by DoS vulnerabilities
 date: 2018-01-29
@@ -12,8 +13,9 @@ description: |
   Wei Lei discovered that libxml2 incorrecty handled certain parameter
   entities. An attacker could use this issue with specially constructed XML
   data to cause libxml2 to consume resources, leading to a denial of service.
+cvss_v3: 7.5
 patched_versions:
-  - '>= 1.8.1'
+  - ">= 1.8.1"
 related:
   url:
     - https://usn.ubuntu.com/usn/usn-3504-1/

--- a/gems/nokogiri/CVE-2018-8048.yml
+++ b/gems/nokogiri/CVE-2018-8048.yml
@@ -1,9 +1,10 @@
 ---
 gem: nokogiri
 cve: 2018-8048
-date: 2018-03-29
+ghsa: x7rv-cr6v-4vm4
 url: https://github.com/sparklemotion/nokogiri/pull/1746
 title: Revert libxml2 behavior in Nokogiri gem that could cause XSS
+date: 2018-03-29
 description: |
   [MRI] Behavior in libxml2 has been reverted which caused
   CVE-2018-8048 (loofah gem), CVE-2018-3740 (sanitize gem), and
@@ -24,8 +25,9 @@ description: |
   comment on the upstream bug report here:
 
   https://bugzilla.gnome.org/show_bug.cgi?id=769760
+cvss_v3: 6.1
 patched_versions:
-  - '>= 1.8.3'
+  - ">= 1.8.3"
 related:
   cve:
     - 2018-3740

--- a/gems/nokogiri/CVE-2019-13117.yml
+++ b/gems/nokogiri/CVE-2019-13117.yml
@@ -1,9 +1,10 @@
 ---
 gem: nokogiri
 cve: 2019-13117
-date: 2019-10-31
+ghsa: 4hm9-844j-jmxp
 url: https://github.com/sparklemotion/nokogiri/issues/1943
 title: Nokogiri gem, via libxslt, is affected by multiple vulnerabilities
+date: 2019-10-31
 description: |
   Nokogiri v1.10.5 has been released.
 
@@ -65,15 +66,14 @@ description: |
 
   Patched with commit https://gitlab.gnome.org/GNOME/libxslt/commit/2232473733b7313d67de8836ea3b29eec6e8e285
 patched_versions:
-  - '>= 1.10.5'
-
+  - ">= 1.10.5"
 related:
+  cve:
+    - 2019-13118
+    - 2019-18197
   url:
     - https://groups.google.com/d/msg/ruby-security-ann/-Wq4aouIA3Q/yc76ZHemBgAJ
     - https://usn.ubuntu.com/4164-1/
     - https://gitlab.gnome.org/GNOME/libxslt/commit/c5eb6cf3aba0af048596106ed839b4ae17ecbcb1
     - https://gitlab.gnome.org/GNOME/libxslt/commit/6ce8de69330783977dd14f6569419489875fb71b
     - https://gitlab.gnome.org/GNOME/libxslt/commit/2232473733b7313d67de8836ea3b29eec6e8e285
-  cve:
-    - 2019-13118
-    - 2019-18197

--- a/gems/open-uri-cached/CVE-2015-3649.yml
+++ b/gems/open-uri-cached/CVE-2015-3649.yml
@@ -2,6 +2,7 @@
 gem: open-uri-cached
 cve: 2015-3649
 osvdb: 121701
+ghsa: 7m2w-9gw7-c3xp
 url: http://seclists.org/oss-sec/2015/q2/373
 title: open-uri-cached Gem for Ruby Unsafe Temporary File Creation Local Privilege
   Escalation
@@ -10,3 +11,4 @@ description: |
   open-uri-cached Gem for Ruby contains a flaw that is due to the
   program creating temporary files in a predictable, unsafe manner when using
   YAML. This may allow a local attacker to gain elevated privileges.
+cvss_v3: 7.8

--- a/gems/passenger/CVE-2018-12026.yml
+++ b/gems/passenger/CVE-2018-12026.yml
@@ -1,6 +1,7 @@
 ---
 gem: passenger
 cve: 2018-12026
+ghsa: 7cv3-gvmc-8mq5
 url: https://blog.phusion.nl/2018/06/12/passenger-5-3-2-various-security-fixes/
 title: SpawningKit exploits
 date: 2018-06-12
@@ -12,12 +13,10 @@ description: |
   can result in information disclosure and privilege escalation.
 cvss_v2: 7.5
 cvss_v3: 9.8
-patched_versions:
-  - '>= 5.3.2'
-
 unaffected_versions:
-  - < 5.3.0
-
+  - "< 5.3.0"
+patched_versions:
+  - ">= 5.3.2"
 related:
   cve:
     - 2018-12027

--- a/gems/passenger/CVE-2018-12029.yml
+++ b/gems/passenger/CVE-2018-12029.yml
@@ -1,6 +1,7 @@
 ---
 gem: passenger
 cve: 2018-12029
+ghsa: jjcj-fgfm-9g9r
 url: https://blog.phusion.nl/2018/06/12/passenger-5-3-2-various-security-fixes/
 title: CHMOD race vulnerability
 date: 2018-06-12
@@ -18,8 +19,7 @@ description: |
   root's crontab file, then privilege escalation was possible.
 cvss_v2: 4.4
 cvss_v3: 7.0
-patched_versions:
-  - '>= 5.3.2'
-
 unaffected_versions:
-  - < 3.0.0
+  - "< 3.0.0"
+patched_versions:
+  - ">= 5.3.2"


### PR DESCRIPTION
GHSA sync + modifies + few manual edits

After running the sync script and removing dups/etc and post-processor script and a few manual edits, the modify summary is:
  * ghsa: field was added
  * Single quotes changed to double quotes per local convention
   * Added double quotes back if removed.
    * Reorder date: field in file.