### PR TITLE
2nd GHSA rwiki advisories from 2006

### DIFF
--- a/gems/rwiki/CVE-2006-2582.yml
+++ b/gems/rwiki/CVE-2006-2582.yml
@@ -1,0 +1,38 @@
+---
+gem: rwiki
+cve: 2006-2582
+ghsa: wwmf-6p58-6vj2
+url: https://web.archive.org/web/20090501134922/http://www2a.biglobe.ne.jp/~seki/ruby/rwiki.html
+title: High severity vulnerability that affects rwiki
+date: 2006-05-14
+description: |
+  The editing form in RWiki 2.1.0pre1 through 2.1.0 allows remote
+  attackers to execute arbitrary Ruby code via unknown attack vectors.
+cvss_v2: 7.5
+unaffected_versions:
+  - "< 2.1.0pre1"
+patched_versions:
+  - ">= 2.1.1"
+related:
+  cve:
+    - 2006-2581
+  ghsa:
+    - gvhx-gj42-m28v
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2006-2582
+    - https://exchange.xforce.ibmcloud.com/vulnerabilities/26664
+    - https://github.com/advisories/GHSA-wwmf-6p58-6vj2
+    - https://github.com/advisories/GHSA-gvhx-gj42-m28v
+    - https://rubygems.org/gems/rwiki
+    - https://web.archive.org/web/20090501134922/http://www2a.biglobe.ne.jp/~seki/ruby/rwiki.html
+    - https://web.archive.org/web/20090504061152/http://pub.cozmixng.org/~the-rwiki/rw-cgi.rb?cmd=view;name=top
+    - https://web.archive.org/web/20081201080215/http://secunia.com/advisories/20264
+    - https://web.archive.org/web/20090524010623/http://www.vupen.com/english/advisories/2006/1949
+notes: |
+  - Best references are in Japanese.
+  - Source code link on rubygems.org goes to
+    lucassus/rwiki (last version 0.2.5, not 2.1.1).
+  - Found two other repos:
+    - https://github.com/rwiki/rwiki
+    - https://github.com/ytakhs/rwiki
+  - CWE: [NVD-CWE-Other] MODERATE


### PR DESCRIPTION
2nd GHSA rwiki advisories from 2006
 * CVE-2006-2582.yml
 
 Previous one was CVE-2006-2581.
