### PR TITLE
GSHA-sync: 1 new advisory; 1 modified

### DIFF
--- a/gems/doorkeeper/CVE-2023-34246.yml
+++ b/gems/doorkeeper/CVE-2023-34246.yml
@@ -1,0 +1,35 @@
+---
+gem: doorkeeper
+cve: 2023-34246
+ghsa: 7w2c-w47h-789w
+url: https://github.com/advisories/GHSA-7w2c-w47h-789w
+title: Doorkeeper Improper Authentication vulnerability
+date: 2023-06-12
+description: |
+  OAuth RFC 8252 says  https://www.rfc-editor.org/rfc/rfc8252#section-8.6
+
+  > the authorization server SHOULD NOT process authorization requests
+  > automatically without user consent or interaction, except when the
+  > identity of the client can be assured. **This includes the case
+  > where the user has previously approved an authorization request
+  > for a given client id**
+
+  But Doorkeeper automatically processes authorization requests without
+  user consent for public clients that have been previous approved.
+  Public clients are inherently  vulnerable to impersonation, their
+  identity cannot be assured.
+
+  Issue https://github.com/doorkeeper-gem/doorkeeper/issues/1589
+
+  Fix https://github.com/doorkeeper-gem/doorkeeper/pull/1646
+cvss_v3: 4.2
+patched_versions:
+  - ">= 5.6.6"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-34246
+    - https://github.com/doorkeeper-gem/doorkeeper/releases/tag/v5.6.6
+    - https://github.com/doorkeeper-gem/doorkeeper/pull/1646
+    - https://github.com/doorkeeper-gem/doorkeeper/issues/1589
+    - https://www.rfc-editor.org/rfc/rfc8252#section-8.6
+    - https://github.com/advisories/GHSA-7w2c-w47h-789w

--- a/gems/gitlab-grit/CVE-2013-4489.yml
+++ b/gems/gitlab-grit/CVE-2013-4489.yml
@@ -2,6 +2,7 @@
 gem: gitlab-grit
 cve: 2013-4489
 osvdb: 99370
+ghsa: 95xq-v4m2-fq3r
 url: https://nvd.nist.gov/vuln/detail/CVE-2013-4489
 title: GitLab Grit Gem for Ruby contains a flaw
 date: 2013-11-04


### PR DESCRIPTION
**GSHA-sync: 1 new advisory; 1 modified**

Ran GHSA sync script plus post-processing and got:
* Added ghsa: field to 1 advisory file.
* Added brand new advisory: gems/doorkeeper/CVE-2023-34246.yml