### PR TITLE
Added vapid-related URLs to older advisories

### DIFF
--- a/gems/Arabic-Prawn/CVE-2014-2322.yml
+++ b/gems/Arabic-Prawn/CVE-2014-2322.yml
@@ -24,5 +24,6 @@ related:
     - http://www.openwall.com/lists/oss-security/2014/03/12/6
     - https://web.archive.org/web/20160306235714/http://www.vapid.dhs.org/advisories/arabic-ruby-gem.html
     - http://www.vapid.dhs.org/advisories/arabic-ruby-gem.html
+    - http://www.vapidlabs.com/advisory.php?v=16
     - https://github.com/advisories/GHSA-hgmw-x865-hf9x
     - https://rubygems.org/gems/Arabic-Prawn

--- a/gems/as/OSVDB-112683.yml
+++ b/gems/as/OSVDB-112683.yml
@@ -12,5 +12,7 @@ notes: "Never patched"
 related:
   url:
     - https://security.snyk.io/vuln/SNYK-RUBY-AS-20195
+    - http://www.vapid.dhs.org/advisories/as-v1.0.html
+    - http://www.vapidlabs.com/advisory.php?v=17
     - http://osvdb.org/show/osvdb/112683
 # FYI: rubygem.org Homepage is 404"

--- a/gems/brbackup/CVE-2014-5004.yml
+++ b/gems/brbackup/CVE-2014-5004.yml
@@ -17,6 +17,7 @@ related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2014-5004
     - http://www.vapid.dhs.org/advisories/brbackup-0.1.1.html
+    - http://www.vapidlabs.com/advisory.php?v=25
     - http://www.openwall.com/lists/oss-security/2014/07/10/6
     - http://www.openwall.com/lists/oss-security/2014/07/17/5
     - http://www.securityfocus.com/bid/68506

--- a/gems/brbackup/OSVDB-108899.yml
+++ b/gems/brbackup/OSVDB-108899.yml
@@ -16,4 +16,6 @@ related:
     - https://www.openwall.com/lists/oss-security/2014/07/10/6
     - https://raw.githubusercontent.com/codesake/codesake-dawn/master/Roadmap.md
     - https://github.com/tongueroo/brbackup/blob/master/lib/brbackup.rb
+    - http://www.vapid.dhs.org/advisories/brbackup-0.1.1.html
+    - http://www.vapidlabs.com/advisory.php?v=25
     - http://osvdb.org/show/osvdb/108899

--- a/gems/brbackup/OSVDB-108900.yml
+++ b/gems/brbackup/OSVDB-108900.yml
@@ -15,4 +15,6 @@ related:
   url:
     - https://www.openwall.com/lists/oss-security/2014/07/10/6
     - https://raw.githubusercontent.com/codesake/codesake-dawn/master/Roadmap.md
+    - http://www.vapid.dhs.org/advisories/brbackup-0.1.1.html
+    - http://www.vapidlabs.com/advisory.php?v=25
     - http://osvdb.org/show/osvdb/108900

--- a/gems/cap-strap/OSVDB-108575.yml
+++ b/gems/cap-strap/OSVDB-108575.yml
@@ -13,4 +13,6 @@ related:
   url:
     - https://www.openwall.com/lists/oss-security/2014/07/07/9
     - https://github.com/substantial/cap-strap
+    - http://www.vapid.dhs.org/advisories/cap-strap-0.1.5.html
+    - http://www.vapidlabs.com/advisory.php?v=27
     - http://osvdb.org/show/osvdb/108575

--- a/gems/gnms/OSVDB-108594.yml
+++ b/gems/gnms/OSVDB-108594.yml
@@ -13,4 +13,5 @@ notes: "Never patched"
 related:
   url:
     - http://www.vapidlabs.com/advisories/gnms-2.1.1.html
+    - http://www.vapidlabs.com/advisory.php?v=55
     - http://osvdb.org/show/osvdb/108594

--- a/gems/kcapifony/CVE-2014-5001.yml
+++ b/gems/kcapifony/CVE-2014-5001.yml
@@ -11,4 +11,10 @@ description: |
   kcapifony Gem for Ruby contains a flaw in /lib/ksymfony1.rb that is triggered
   as the program displays password information in plaintext in the process list. This
   may allow a local attacker to gain access to password information.
+cvss_v2: 2.1
 cvss_v3: 7.8
+notes: "Never patched"
+related:
+  url:
+    - http://www.vapid.dhs.org/advisories/kcapifony-2.1.6.html
+    - http://www.vapidlabs.com/advisory.php?v=65

--- a/gems/kcapifony/OSVDB-108572.yml
+++ b/gems/kcapifony/OSVDB-108572.yml
@@ -14,4 +14,6 @@ related:
   url:
     - https://www.mend.io/vulnerability-database/WS-2014-0019
     - https://github.com/Kunstmaan/kCapifony/blob/master/lib/ksymfony1.rb
+    - http://www.vapid.dhs.org/advisories/kcapifony-2.1.6.html
+    - http://www.vapidlabs.com/advisory.php?v=65
     - http://osvdb.org/show/osvdb/108572

--- a/gems/kompanee-recipes/OSVDB-108593.yml
+++ b/gems/kompanee-recipes/OSVDB-108593.yml
@@ -18,4 +18,6 @@ related:
     - https://seclists.org/oss-sec/2014/q3/162
     - https://www.mend.io/vulnerability-database/WS-2014-0025
     - https://security.snyk.io/vuln/SNYK-RUBY-KOMPANEERECIPES-20177
+    - http://www.vapid.dhs.org/advisories/kompanee-recipes-0.1.4.html
+    - http://www.vapidlabs.com/advisory.php?v=67
     - http://osvdb.org/show/osvdb/108593

--- a/gems/lingq/OSVDB-108585.yml
+++ b/gems/lingq/OSVDB-108585.yml
@@ -13,4 +13,6 @@ notes: "Never patched"
 related:
   url:
     - https://www.versioneye.com/Ruby/lingq/0.3.1
+    - http://www.vapid.dhs.org/advisories/lingq-0.3.1.html
+    - http://www.vapidlabs.com/advisory.php?v=71
     - http://osvdb.org/show/osvdb/108585


### PR DESCRIPTION
Added vapid and vapidlabs related URLs to older advisories.

Had to be extra careful for brbackup and kcapifony gems.
Verified that osvdb: number in new URLs was the same as existing osvdb: number.
Ran yamllint and rake (both green).