### PR TITLE
Remove credit for CVE-2023-27531

### DIFF
--- a/gems/kredis/CVE-2023-27531.yml
+++ b/gems/kredis/CVE-2023-27531.yml
@@ -35,8 +35,6 @@ description: |
 
     * 1-3-0-1-kredis.patch - Patch for 1.3.0 series
 
-  Credits
-    Thank you ooooooo_k 7 for reporting this!
 patched_versions:
   - ">= 1.3.0.1"
 related:


### PR DESCRIPTION
`ooooooo_k` is a typo.

I contacted the typo of [rails](https://discuss.rubyonrails.org/t/cve-2023-27531-possible-deserialization-of-untrusted-data-vulnerability-in-kredis-json/82467#post_1) and had it corrected, but it seems that it was not reflected here.

It was said that credit is not usually included, so I deleted it.