### PR TITLE
Removed 3 lines in lib/github_advisory_sync.rb script to get rid of unneeded debug text

### DIFF
--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -373,9 +373,6 @@ module GitHub
         # The second block of yaml in a .yaml file is ignored (after the second "---" line)
         # This effectively makes this data a large comment
         # Still it should be removed before the data goes into rubysec
-        file.write "\n\n# GitHub advisory data below - **Remove this data before committing**\n"
-        file.write "# Use this data to write patched_versions (and potentially unaffected_versions) above\n"
-        file.write advisory.merge("vulnerabilities" => vulnerabilities).to_yaml
       end
       puts "Wrote: #{filename_to_write}"
       filename_to_write


### PR DESCRIPTION
Removed 3 lines in lib/github_advisory_sync.rb script to get rid of unneeded debug text.
This change is needed as part of #537.

The 3 lines are:
```
file.write "\n\n# GitHub advisory data below - **Remove this data before committing**\n"
file.write "# Use this data to write patched_versions (and potentially unaffected_versions) above\n"
file.write advisory.merge("vulnerabilities" => vulnerabilities).to_yaml
```
Here is a sample of the above script lines:
```
(a blank lines)

# GitHub advisory data below - **Remove this data before committing**
# Use this data to write patched_versions (and potentially unaffected_versions) above
---
identifiers:
- type: GHSA
  value: GHSA-8qrh-h9m2-5fvf
- type: CVE
  value: CVE-2009-3009
summary: Moderate severity vulnerability that affects rails
description: Cross-site scripting (XSS) vulnerability in Ruby on Rails 2.x before
  2.2.3, and 2.3.x before 2.3.4, allows remote attackers to inject arbitrary web script
  or HTML by placing malformed Unicode strings into a form helper.
severity: MODERATE
cvss:
  score: 0.0
  vectorString: 
references:
- url: https://nvd.nist.gov/vuln/detail/CVE-2009-3009
- url: https://exchange.xforce.ibmcloud.com/vulnerabilities/53036
- url: https://github.com/advisories/GHSA-8qrh-h9m2-5fvf
- url: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=545063
- url: http://groups.google.com/group/rubyonrails-security/msg/7f57cd7794e1d1b4?dmode=source
- url: http://lists.apple.com/archives/security-announce/2010//Mar/msg00001.html
- url: http://lists.opensuse.org/opensuse-security-announce/2009-10/msg00004.html
- url: http://secunia.com/advisories/36600
- url: http://secunia.com/advisories/36717
- url: http://securitytracker.com/id?1022824
- url: http://support.apple.com/kb/HT4077
- url: http://weblog.rubyonrails.org/2009/9/4/xss-vulnerability-in-ruby-on-rails
- url: http://www.debian.org/security/2009/dsa-1887
- url: http://www.osvdb.org/57666
- url: http://www.securityfocus.com/bid/36278
- url: http://www.vupen.com/english/advisories/2009/2544
- url: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/activesupport/CVE-2009-3009.yml
publishedAt: '2017-10-24T18:33:38Z'
withdrawnAt: 
vulnerabilities:
- package:
    name: rails
    ecosystem: RUBYGEMS
  vulnerableVersionRange: ">= 2.3.0, < 2.3.4"
  firstPatchedVersion:
    identifier: 2.3.4
- package:
    name: rails
    ecosystem: RUBYGEMS
  vulnerableVersionRange: ">= 2.0.0, < 2.2.3"
  firstPatchedVersion:
    identifier: 2.2.3
```
@reedloden 
