### PR TITLE
Added 2016 gems/bundler/CVE-2016-7954.yml advisory

### DIFF
--- a/gems/bundler/CVE-2016-7954.yml
+++ b/gems/bundler/CVE-2016-7954.yml
@@ -11,12 +11,12 @@ description: |
   code into an application by leveraging a Gem name collision on a
   secondary source.
 
-  '*****************************************************************
-  Please note that this vulnerability only applies for Ruby projects
-  using Bundler < 2.0 with Gemfiles having 2 or more "source" lines.
-  *****************************************************************'
+  Please note that this vulnerability only applies for Ruby
+  projects using Bundler < 2.0 with Gemfiles having 2 or more
+  "source" lines.
 
-  NOTE: This might overlap CVE-2013-0334.
+  In other words, if the user's Gemfile does not use multiple
+  sources, this vulnerability can be ignored.
 cvss_v2: 7.5
 cvss_v3: 9.8
 patched_versions:
@@ -37,4 +37,4 @@ related:
     - https://github.com/rubygems/bundler/issues/5274
     - https://github.com/rubygems/bundler/issues/5051
     - https://github.com/rubygems/bundler/issues/5062
-notes: "GHSA is unreviewed"
+notes: "NOTE: This might overlap CVE-2013-0334.; GHSA is unreviewed"

--- a/gems/bundler/CVE-2016-7954.yml
+++ b/gems/bundler/CVE-2016-7954.yml
@@ -1,0 +1,35 @@
+---
+gem: bundler
+cve: 2016-7954
+ghsa: jvgm-pfqv-887x
+url: https://collectiveidea.com/blog/archives/2016/10/06/bundlers-multiple-source-security-vulnerability
+title: Allows an attacker to inject arbitrary code into your application
+  via any secondary Gem source declared in your Gemfile
+date: 2016-10-06
+description: |
+  Bundler 1.x might allow remote attackers to inject arbitrary Ruby
+  code into an application by leveraging a Gem name collision on a
+  secondary source.
+
+  NOTE: This might overlap CVE-2013-0334.
+cvss_v2: 7.5
+cvss_v3: 9.8
+patched_versions:
+  - ">= 2.0.0"
+related:
+  cve:
+    - 2013-0334
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2016-7954
+    - https://collectiveidea.com/blog/archives/2016/10/06/bundlers-multiple-source-security-vulnerability
+    - https://bundler.io/blog/2014/08/14/bundler-may-install-gems-from-a-different-source-than-expected-cve-2013-0334.html
+    - https://github.com/advisories/GHSA-jvgm-pfqv-887x
+    - https://seclists.org/oss-sec/2016/q4/25
+    - https://seclists.org/oss-sec/2016/q4/18
+    - https://seclists.org/oss-sec/2016/q4/20
+    - https://github.com/rubygems/bundler/pull/3696
+    - https://github.com/rubygems/bundler/issues/3671
+    - https://github.com/rubygems/bundler/issues/5274
+    - https://github.com/rubygems/bundler/issues/5051
+    - https://github.com/rubygems/bundler/issues/5062
+notes: "GHSA is unreviewed"

--- a/gems/bundler/CVE-2016-7954.yml
+++ b/gems/bundler/CVE-2016-7954.yml
@@ -11,6 +11,11 @@ description: |
   code into an application by leveraging a Gem name collision on a
   secondary source.
 
+  '*****************************************************************
+  Please note that this vulnerability only applies for Ruby projects
+  using Bundler < 2.0 with Gemfiles having 2 or more "source" lines.
+  *****************************************************************'
+
   NOTE: This might overlap CVE-2013-0334.
 cvss_v2: 7.5
 cvss_v3: 9.8


### PR DESCRIPTION
Added 2016 gems/bundler/CVE-2016-7954.yml advisory.

NOTE: This will flag all 1.x versions of bundler.