### PR TITLE
Removed extra patched_versions yaml line

### DIFF
--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -367,7 +367,6 @@ module GitHub
 
       new_data = package.merge_data(
         "cvss_v3"             => ("<FILL IN IF AVAILABLE>" unless cvss),
-        "patched_versions"    => ["<FILL IN SEE BELOW>"],
         "unaffected_versions" => ["<OPTIONAL: FILL IN SEE BELOW>"]
       )
 


### PR DESCRIPTION
Since we added code for patched_version field, we can removed extra patched_versions yaml line.
```
   "patched_versions"    => ["<FILL IN SEE BELOW>"],
```