### PR TITLE
Add "Prefer GHSA over OSVDB filename" lint rule

### DIFF
--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -44,6 +44,8 @@ shared_examples_for 'Advisory' do |path|
     it "should CVE-XXX if cve field has a value" do
       if advisory['cve']
         expect(filename).to start_with('CVE-')
+      elsif advisory['ghsa']
+        expect(filename).to start_with('GHSA-')
       end
     end
 


### PR DESCRIPTION
Added lint rule to check that OSVDB-* advisories with "ghsa:" values have filenames starting with GSHA.

To test this, add a "ghsa:" field/value to an existing OSVDB advisory and run "rake".
