### PR TITLE
Corrected "ghsa:" values (they were duplicates) for 3 rubies/ruby advisories

### DIFF
--- a/rubies/ruby/CVE-2008-2662.yml
+++ b/rubies/ruby/CVE-2008-2662.yml
@@ -2,7 +2,7 @@
 engine: ruby
 cve: 2008-2662
 osvdb: 46550
-ghsa: c4h6-p7gp-39x2
+ghsa: 6wwf-x53r-5qqq
 url: https://rubyonrails.org/2008/6/21/multiple-ruby-security-vulnerabilities
 title: "CVE-2008-2662 ruby: Integer overflows in rb_str_buf_append()"
 date: 2008-06-20
@@ -27,5 +27,6 @@ related:
   url:
     - https://rubyonrails.org/2008/6/21/multiple-ruby-security-vulnerabilities
     - https://nvd.nist.gov/vuln/detail/CVE-2008-2662
+    - https://github.com/advisories/GHSA-6wwf-x53r-5qqq
     - https://github.com/advisories/GHSA-c4h6-p7gp-39x2
     - http://www.osvdb.org/show/osvdb/46550

--- a/rubies/ruby/CVE-2008-2663.yml
+++ b/rubies/ruby/CVE-2008-2663.yml
@@ -2,7 +2,7 @@
 engine: ruby
 cve: 2008-2663
 osvdb: 46551
-ghsa: c4h6-p7gp-39x2
+ghsa: 8rh4-h2wx-5jpx
 url: https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
 title: "CVE-2008-2663 ruby: Integer overflows in rb_ary_store()"
 date: 2008-06-20
@@ -26,5 +26,6 @@ related:
   url:
     - https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
     - https://nvd.nist.gov/vuln/detail/CVE-2008-2663
+    - https://github.com/advisories/GHSA-8rh4-h2wx-5jpx
     - https://github.com/advisories/GHSA-c4h6-p7gp-39x2
     - http://www.osvdb.org/show/osvdb/46551

--- a/rubies/ruby/CVE-2008-2725.yml
+++ b/rubies/ruby/CVE-2008-2725.yml
@@ -1,7 +1,7 @@
 ---
 engine: ruby
 cve: 2008-2725
-ghsa: c4h6-p7gp-39x2
+ghsa: 924x-9756-qq8p
 osvdb: 46553
 url: https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
 title: "CVE-2008-2725 ruby: integer overflow in rb_ary_splice/update/replace() - REALLOC_N"
@@ -27,5 +27,6 @@ related:
   url:
     - https://www.ruby-lang.org/en/news/2008/06/20/arbitrary-code-execution-vulnerabilities
     - https://rubyonrails.org/2008/6/21/multiple-ruby-security-vulnerabilities
+    - https://github.com/advisories/GHSA-924x-9756-qq8p
     - https://github.com/advisories/GHSA-c4h6-p7gp-39x2
     - http://www.osvdb.org/show/osvdb/46553


### PR DESCRIPTION
Corrected "ghsa:" values (they were duplicates) for 3 rubies/ruby advisories.