### PR TITLE
Omit `patched_versions:` if the GHSA has no patched version identifiers.

### DIFF
--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -371,15 +371,23 @@ module GitHub
         "unaffected_versions" => ["<OPTIONAL: FILL IN SEE BELOW>"]
       )
 
+      patched_versions = patched_versions_for(package)
+
+      if !patched_versions.empty?
+        new_data['patched_versions'] = patched_versions
+      else
+        new_data['notes'] = "Never patched"
+      end
+
+      # populate the related information
+      new_data["related"] = {
+        "url" => advisory["references"]
+      }
+
       FileUtils.mkdir_p(File.dirname(filename_to_write))
       File.open(filename_to_write, "w") do |file|
         # create an automatically generated advisory yaml file
-        file.write new_data.merge(
-          "patched_versions" => patched_versions_for(package),
-          "related" => {
-            "url"  => advisory["references"]
-          }
-        ).to_yaml
+        file.write new_data.to_yaml
 
         # The data we just wrote is incomplete,
         # and therefore should not be committed as is

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -341,7 +341,9 @@ module GitHub
       first_patched_versions = []
 
       vulnerabilities.each do |v|
-        if v['package']['name'] == package.name && v['firstPatchedVersion']
+        if v['package']['name'] == package.name &&
+           v['firstPatchedVersion'] &&
+           v['firstPatchedVersion']['identifier']
           first_patched_versions << v['firstPatchedVersion']['identifier']
         end
       end

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -355,11 +355,13 @@ module GitHub
       first_patched_versions = first_patched_versions_for(package)
       patched_versions       = []
 
-      first_patched_versions[0..-2].each do |version|
-        patched_versions << "~> #{version}"
-      end
+      if !first_patched_versions.empty?
+        first_patched_versions[0..-2].each do |version|
+          patched_versions << "~> #{version}"
+        end
 
-      patched_versions << ">= #{first_patched_versions.last}"
+        patched_versions << ">= #{first_patched_versions.last}"
+      end
 
       return patched_versions
     end


### PR DESCRIPTION
Implements a fix for #656.