### PR TITLE
Attempt to automatically generate `unaffected_versions:`

### DIFF
--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -351,7 +351,7 @@ module GitHub
         case operator
         when '>'
           ["<= #{version}"]
-        when '>='
+        when '>=', '='
           ["< #{version}"]
         end
       end

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -337,8 +337,14 @@ module GitHub
       package.filename
     end
 
+    def first_vulnerability_for(package)
+      vulnerabilities.find do |v|
+        v['package']['name'] == package.name
+      end
+    end
+
     def unaffected_versions_for(package)
-      if (vulnerability = vulnerabilities.first)
+      if (vulnerability = first_vulnerability_for(package))
         vulnerable_version_range = vulnerabilities['vulnerableVersionRange']
         operator, version        = vulnerable_version_range.split(' ',2)
 

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -337,6 +337,20 @@ module GitHub
       package.filename
     end
 
+    def unaffected_versions_for(package)
+      if (vulnerability = vulnerabilities.first)
+        vulnerable_version_range = vulnerabilities['vulnerableVersionRange']
+        operator, version        = vulnerable_version_range.split(' ',2)
+
+        case operator
+        when '>'
+          ["<= #{version}"]
+        when '>='
+          ["< #{version}"]
+        end
+      end
+    end
+
     def first_patched_versions_for(package)
       first_patched_versions = []
 
@@ -371,9 +385,12 @@ module GitHub
 
       new_data = package.merge_data(
         "cvss_v3"             => ("<FILL IN IF AVAILABLE>" unless cvss),
-        "cvss_v4"             => "<FILL IN IF AVAILABLE>",
-        "unaffected_versions" => ["<OPTIONAL: FILL IN SEE BELOW>"]
+        "cvss_v4"             => "<FILL IN IF AVAILABLE>"
       )
+
+      if (unaffected_versions = unaffected_versions_for(package))
+        new_data['unaffected_versions'] = unaffected_versions
+      end
 
       patched_versions = patched_versions_for(package)
 

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -345,7 +345,7 @@ module GitHub
 
     def unaffected_versions_for(package)
       if (vulnerability = first_vulnerability_for(package))
-        vulnerable_version_range = vulnerabilities['vulnerableVersionRange']
+        vulnerable_version_range = vulnerability['vulnerableVersionRange']
         operator, version        = vulnerable_version_range.split(' ',2)
 
         case operator

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -346,7 +346,8 @@ module GitHub
     def unaffected_versions_for(package)
       if (vulnerability = first_vulnerability_for(package))
         vulnerable_version_range = vulnerability['vulnerableVersionRange']
-        operator, version        = vulnerable_version_range.split(' ',2)
+        lower_version_range      = vulnerable_version_range.split(', ',2).first
+        operator, version        = lower_version_range.split(' ',2)
 
         case operator
         when '>'


### PR DESCRIPTION
Generate `unaffected_versions` based on the inverse of the first `vulnerableVersionRange`, iff `vulnerableVersionRange` starts with `> ` or `>= `.