### PR TITLE
Add "jquery-rails" as a candidate to add "framework: rails" during sync script run

### DIFF
--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -204,8 +204,8 @@ module GitHub
         when
           "actioncable",  "actionmailbox", "actionmailer",  "actionpack",
           "actiontext",   "actionview",    "activejob",     "activemodel",
-          "activerecord", "activestorage", "activesupport", "railties"
-          "rails"
+          "activerecord", "activestorage", "activesupport", "railties",
+          "rails", "jquery-rails"
         end
       end
 


### PR DESCRIPTION
Add "jquery-rails" as a candidate to add "framework: rails" during sync script run.