### PR TITLE
Added no-pull-or-commit url: lint rule plus date-based phased introduction approach

### DIFF
--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -106,6 +106,18 @@ shared_examples_for 'Advisory' do |path|
       it { expect(subject).to be_kind_of(String) }
       it { expect(subject).to_not match(%r{\Ahttp(s)?://osvdb\.org}) }
       it { expect(subject).not_to be_empty }
+
+      it "must not include '/pull' url" do
+        if advisory['date'] > (Date.today - 182)
+          expect(subject).not_to include("/pull")
+        end
+      end
+
+      it "must not include '/commit' url" do
+        if advisory['date'] > (Date.today - 88)
+          expect(subject).not_to include("/commit")
+        end
+      end
     end
 
     describe "title" do


### PR DESCRIPTION
Added no-pull-or-commit url: lint rule plus date-based phased introduction approach.

Expect to start fixing the 94 current advisories using the date-based 
phased introduction approach after this PR is merged.

The "date-based phased introduction approach" code 
will be removed after the 94 advisories are fixed.