### PR TITLE
Add cve file for activesupport

### DIFF
--- a/gems/activesupport/CVE-2023-38037.yml
+++ b/gems/activesupport/CVE-2023-38037.yml
@@ -1,0 +1,36 @@
+---
+gem: activesupport
+framework: rails
+cve: 2023-38037
+url: https://github.com/rails/rails/releases/tag/v7.0.7.1
+title: Possible File Disclosure of Locally Encrypted Files
+date: 2023-08-23
+description: |
+  There is a possible file disclosure of locally encrypted files in Active Support. This vulnerability has been assigned the CVE identifier CVE-2023-38037.
+
+  Versions Affected: >= 5.2.0 Not affected: < 5.2.0 Fixed Versions: 7.0.7.1, 6.1.7.5
+
+  # Impact
+  ActiveSupport::EncryptedFile writes contents that will be encrypted to a temporary file. The temporary file’s permissions are defaulted to the user’s current umask settings, meaning that it’s possible for other users on the same system to read the contents of the temporary file.
+
+  Attackers that have access to the file system could possibly read the contents of this temporary file while a user is editing it.
+
+  All users running an affected release should either upgrade or use one of the workarounds immediately.
+
+  # Releases
+  The fixed releases are available at the normal locations.
+
+  # Workarounds
+  To work around this issue, you can set your umask to be more restrictive like this:
+
+  ```ruby
+  $ umask 0077
+  ```
+unaffected_versions:
+  - '< 5.2.0'
+patched_versions:
+  - '~> 6.1.7, >= 6.1.7.5'
+  - '>= 7.0.7.1'
+related:
+  url:
+    - https://github.com/rails/rails/commit/a21d6edf35a60383dfa6c4da49e4b1aef5f00731


### PR DESCRIPTION
Add a file for the activesupport CVE.
Link: https://discuss.rubyonrails.org/t/cve-2023-38037-possible-file-disclosure-of-locally-encrypted-files/83544/1


