### PR TITLE
GHSA Sync: Changed single quotes to double quotes and add "ghsa:" value for one advisory

### DIFF
--- a/gems/activesupport/CVE-2023-38037.yml
+++ b/gems/activesupport/CVE-2023-38037.yml
@@ -2,6 +2,7 @@
 gem: activesupport
 framework: rails
 cve: 2023-38037
+ghsa: cr5q-6q9f-rq6q
 url: https://github.com/rails/rails/releases/tag/v7.0.7.1
 title: Possible File Disclosure of Locally Encrypted Files
 date: 2023-08-23
@@ -27,10 +28,10 @@ description: |
   $ umask 0077
   ```
 unaffected_versions:
-  - '< 5.2.0'
+  - "< 5.2.0"
 patched_versions:
-  - '~> 6.1.7, >= 6.1.7.5'
-  - '>= 7.0.7.1'
+  - "~> 6.1.7, >= 6.1.7.5"
+  - ">= 7.0.7.1"
 related:
   url:
     - https://github.com/rails/rails/commit/a21d6edf35a60383dfa6c4da49e4b1aef5f00731


### PR DESCRIPTION
GHSA Sync: Changed single quotes to double quotes and add "ghsa:" value for one advisory.