### PR TITLE
GHSA SYNC: Added cvss_v3 and ghsa fields to 1 advisory

### DIFF
--- a/gems/nokogiri/CVE-2017-15412.yml
+++ b/gems/nokogiri/CVE-2017-15412.yml
@@ -1,6 +1,7 @@
 ---
 gem: nokogiri
 cve: 2017-15412
+ghsa: r58r-74gx-6wx3
 url: https://github.com/sparklemotion/nokogiri/issues/1714
 title: Nokogiri gem, via libxml, is affected by DoS vulnerabilities
 date: 2018-01-29
@@ -12,6 +13,7 @@ description: |
   It was discovered that libxml2 incorrecty handled certain files. An attacker
   could use this issue with specially constructed XML data to cause libxml2 to
   consume resources, leading to a denial of service.
+cvss_v3: 8.8
 patched_versions:
   - ">= 1.8.2"
 related:


### PR DESCRIPTION
GHSA SYNC: Added cvss_v3 and ghsa fields to 1 advisory: gems/nokogiri/CVE-2017-15412.yml .
