### PR TITLE
Add patched version for CVE-2013-1656

### DIFF
--- a/gems/spree/CVE-2013-1656.yml
+++ b/gems/spree/CVE-2013-1656.yml
@@ -6,7 +6,7 @@ url: https://blog.convisoappsec.com/en/spree-commerce-multiple-unsafe-reflection
 title: Spree controller Parameter Arbitrary Ruby Object Instantiation Command Execution
 date: 2013-02-21
 description: |
-  Spree Commerce 1.0.x through 1.3.2 allows remote authenticated
+  Spree Commerce 1.0.x before 2.0.0.rc1 allows remote authenticated
   administrators to instantiate arbitrary Ruby objects and executd
   arbitrary commands via the
   (1) payment_method parameter to core/app/controllers/spree/admin/
@@ -18,7 +18,7 @@ description: |
       of the constantize function.
 cvss_v2: 4.3
 patched_versions:
-  - ">= 2.0.0"
+  - ">= 2.0.0.rc1"
 related:
   url:
     - https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed


### PR DESCRIPTION
Based on the following [commit](https://github.com/spree/spree/commit/70092eb55b8be8fe5d21a7658b62da658612fba7), which was found [here](http://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed), the patched version is `2.0.0.rc1`. 
Aslo versions after `1.3.2` and before `2.0.0.rc1` (aka `1.3.3`, `1.3.4` and `1.3.5`) do not contain updates for the files concerned (See for example [payment_methods_controller.rb](https://github.com/spree/spree/commits/v1.3.5/core/app/controllers/spree/admin/payment_methods_controller.rb) where the last update dates back to 2012, i.e. before the vulnerability was patched). Thus, we can say that the patched version is `2.0.0.rc1` with a certain confidence.
