### PR TITLE
Add CVE-2019-8331 for `twitter-bootstrap-rails`

### DIFF
--- a/gems/twitter-bootstrap-rails/CVE-2019-8331.yml
+++ b/gems/twitter-bootstrap-rails/CVE-2019-8331.yml
@@ -11,7 +11,7 @@ description: |
 
   In Bootstrap before 3.4.1 and 4.3.x before 4.3.1, XSS is possible
   in the tooltip or popover data-template attribute.
-  
+
   The most recent version of this gem, 5.0.0, includes Bootstrap v 3.3.6.
   All versions of Bootstrap before v 3.4.1 are affected by this vulnerability.
   All versions of this gem are affected.

--- a/gems/twitter-bootstrap-rails/CVE-2019-8331.yml
+++ b/gems/twitter-bootstrap-rails/CVE-2019-8331.yml
@@ -1,0 +1,28 @@
+---
+gem: twitter-bootstrap-rails
+cve: 2019-8331
+ghsa: 9v3m-8fp8-mj99
+url: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/
+title: twitter-bootstrap-rails vulnerable to Cross-Site Scripting (XSS)
+date: 2019-02-15
+description: |
+  The seyhunak/twitter-bootstrap-rails gem includes a vendored version of
+  the Bootstrap JavaScript library.
+
+  In Bootstrap before 3.4.1 and 4.3.x before 4.3.1, XSS is possible
+  in the tooltip or popover data-template attribute.
+  
+  The most recent version of this gem, 5.0.0, includes Bootstrap v 3.3.6.
+  All versions of Bootstrap before v 3.4.1 are affected by this vulnerability.
+  All versions of this gem are affected.
+
+  # Workarounds
+  Until this gem is updated to use Bootstrap v3.4.1, users can replace it
+  with the official Twitter-maintained gems, `bootstrap-sass` (version 3.4.1)
+  or `bootstrap` (bootstrap 4 and 5).
+
+cvss_v2: 4.3
+cvss_v3: 6.1
+related:
+  url:
+    - https://github.com/twbs/bootstrap-sass/releases/tag/v3.4.1


### PR DESCRIPTION
CVE-2019-8331 has already been reported for the `bootstrap` and `bootstrap-sass` gems, but the `twitter-bootstrap-rails` gem is still affected, since it includes the vulnerable 3.3.6 version.

I'm not sure if it's appropriate for me to tell users that "hey, there's this other version of the bootstrap gem that's actually maintained by the original developer, and until this gem is fixed you should use it instead". I have done it anyway; please let me know if that needs to be changed.