### PR TITLE
GHSA Sync: 1 brand new advisory

### DIFF
--- a/gems/pubnub/CVE-2023-26154.yml
+++ b/gems/pubnub/CVE-2023-26154.yml
@@ -1,0 +1,53 @@
+---
+gem: pubnub
+cve: 2023-26154
+ghsa: 5844-q3fc-56rh
+url: https://github.com/advisories/GHSA-5844-q3fc-56rh
+title: pubnub Insufficient Entropy vulnerability
+date: 2023-12-06
+description: |
+  Versions of the package pubnub before 7.4.0; all versions of the
+  package com.pubnub:pubnub; versions of the package pubnub before
+  6.19.0; all versions of the package github.com/pubnub/go; versions
+  of the package github.com/pubnub/go/v7 before 7.2.0; versions of
+  the package pubnub before 7.3.0; versions of the package pubnub/pubnub
+  before 6.1.0; versions of the package pubnub before 5.3.0; versions
+  of the package pubnub before 0.4.0; versions of the package pubnub/c-core
+  before 4.5.0; versions of the package com.pubnub:pubnub-kotlin before
+  7.7.0; versions of the package pubnub/swift before 6.2.0; versions
+  of the package pubnub before 5.2.0; versions of the package pubnub
+  before 4.3.0 are vulnerable to Insufficient Entropy via the getKey
+  function, due to inefficient implementation of the AES-256-CBC
+  cryptographic algorithm. The provided encrypt function is less secure
+  when hex encoding and trimming are applied, leaving half of the bits
+  in the key always the same for every encoded message or file.
+
+  **Note:**
+
+  In order to exploit this vulnerability, the attacker needs to invest
+  resources in preparing the attack and brute-force the encryption.
+cvss_v3: 5.9
+patched_versions:
+  - ">= 5.3.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-26154
+    - https://github.com/pubnub/ruby/releases/tag/v5.3.0
+    - https://github.com/pubnub/javascript/commit/fb6cd0417cbb4ba87ea2d5d86a9c94774447e119
+    - https://gist.github.com/vargad/20237094fce7a0a28f0723d7ce395bb0
+    - https://github.com/pubnub/javascript/blob/master/src/crypto/modules/web.js#L70
+    - https://security.snyk.io/vuln/SNYK-COCOAPODS-PUBNUB-6098384
+    - https://security.snyk.io/vuln/SNYK-DOTNET-PUBNUB-6098372
+    - https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMPUBNUBGO-6098373
+    - https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMPUBNUBGOV7-6098374
+    - https://security.snyk.io/vuln/SNYK-JAVA-COMPUBNUB-6098371
+    - https://security.snyk.io/vuln/SNYK-JAVA-COMPUBNUB-6098380
+    - https://security.snyk.io/vuln/SNYK-JS-PUBNUB-5840690
+    - https://security.snyk.io/vuln/SNYK-PHP-PUBNUBPUBNUB-6098376
+    - https://security.snyk.io/vuln/SNYK-PUB-PUBNUB-6098385
+    - https://security.snyk.io/vuln/SNYK-PYTHON-PUBNUB-6098375
+    - https://security.snyk.io/vuln/SNYK-RUBY-PUBNUB-6098377
+    - https://security.snyk.io/vuln/SNYK-RUST-PUBNUB-6098378
+    - https://security.snyk.io/vuln/SNYK-SWIFT-PUBNUBSWIFT-6098381
+    - https://security.snyk.io/vuln/SNYK-UNMANAGED-PUBNUBCCORE-6098379
+    - https://github.com/advisories/GHSA-5844-q3fc-56rh


### PR DESCRIPTION
GHSA Sync: 1 brand new advisory: gems/pubnub/CVE-2023-26154.yml 

Added tag URL for corrected version.