### PR TITLE
add CVE-2021-23369 and CVE-2021-23383 for `handlebars-source`

### DIFF
--- a/gems/handlebars-source/CVE-2021-23369.yml
+++ b/gems/handlebars-source/CVE-2021-23369.yml
@@ -12,4 +12,4 @@ description: |
 
 cvss_v3: 9.8
 patched_versions:
-  - "~> 4.7.7, >= 4.7.7"
+  - ">= 4.7.7"

--- a/gems/handlebars-source/CVE-2021-23369.yml
+++ b/gems/handlebars-source/CVE-2021-23369.yml
@@ -1,0 +1,15 @@
+---
+gem: handlebars-source
+cve: 2021-23369
+ghsa: f2jv-r9rf-7988
+url: https://github.com/advisories/GHSA-f2jv-r9rf-7988
+title: Remote code execution in handlebars when compiling templates
+date: 2021-04-12
+description: |
+  The package handlebars before 4.7.7 are vulnerable to Remote Code Execution (RCE) when
+  selecting certain compiling options to compile templates coming from an untrusted source.
+  This vulnerability has been assigned the CVE identifier CVE-2021-23369.
+
+cvss_v3: 9.8
+patched_versions:
+  - "~> 4.7.7, >= 4.7.7"

--- a/gems/handlebars-source/CVE-2021-23383.yml
+++ b/gems/handlebars-source/CVE-2021-23383.yml
@@ -1,0 +1,15 @@
+---
+gem: handlebars-source
+cve: 2021-23383
+ghsa: 765h-qjxv-5f44
+url: https://github.com/advisories/GHSA-765h-qjxv-5f44
+title: Prototype Pollution in handlebars
+date: 2021-05-04
+description: |
+  The package handlebars before 4.7.7 are vulnerable to Prototype Pollution when
+  selecting certain compiling options to compile templates coming from an untrusted source.
+  This vulnerability has been assigned the CVE identifier CVE-2021-23383.
+
+cvss_v3: 9.8
+patched_versions:
+  - "~> 4.7.7, >= 4.7.7"

--- a/gems/handlebars-source/CVE-2021-23383.yml
+++ b/gems/handlebars-source/CVE-2021-23383.yml
@@ -12,4 +12,4 @@ description: |
 
 cvss_v3: 9.8
 patched_versions:
-  - "~> 4.7.7, >= 4.7.7"
+  - ">= 4.7.7"


### PR DESCRIPTION
The `handlebars-source` gem (wraps the JS library [handlebars](https://github.com/handlebars-lang/handlebars.js)) has had about a dozen vulnerabilities over the years (see: https://github.com/advisories?query=handlebars and https://security.snyk.io/package/npm/handlebars). I've chosen to only add advisories for the most recent two of these, since handlebars v 4.7.7 will also fix the rest. I hope that's OK.