### PR TITLE
Update CVE-2024-22191.yml

### DIFF
--- a/gems/avo/CVE-2024-22191.yml
+++ b/gems/avo/CVE-2024-22191.yml
@@ -55,8 +55,10 @@ description: |
 cvss_v3: 7.3
 patched_versions:
   - ">= 3.2.4"
+  - "~> 2.47, >= 2.47"
 related:
   url:
     - https://github.com/avo-hq/avo/security/advisories/GHSA-ghjv-mh6x-7q6h
     - https://github.com/avo-hq/avo/commit/51bb80b181cd8e31744bdc4e7f9b501c81172347
+    - https://github.com/avo-hq/avo/commit/fc92a05a8556b1787c8694643286a1afa6a71258
     - https://github.com/advisories/GHSA-ghjv-mh6x-7q6h


### PR DESCRIPTION
- Fix was backported to 2.x in https://github.com/avo-hq/avo/pull/2382
- The github security-advisory was updated to reflect this: https://github.com/advisories/GHSA-ghjv-mh6x-7q6h

I hope the formatting is okay. If you would get those updates automatically feel free to close this PR.