### PR TITLE
Update CVE-2024-22411 to align with updated github advisory

### DIFF
--- a/gems/avo/CVE-2024-22411.yml
+++ b/gems/avo/CVE-2024-22411.yml
@@ -18,7 +18,8 @@ description: |
   are advised to upgrade.
 cvss_v3: 6.5
 patched_versions:
-  - ">= 3.0.2"
+  - ">= 3.3.0"
+  - "~> 2.47, >= 2.47"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-22411


### PR DESCRIPTION
github advisory (https://github.com/advisories/GHSA-g8vp-2v5p-9qfh) was updated to include more vulnerable releases in the 3.x branch and a fixed 2.x version.

This PR aligns ruby-advisory-db with github advisory