### PR TITLE
Added CVE-2024-25062 for nokogiri

### DIFF
--- a/gems/nokogiri/CVE-2024-25062.yml
+++ b/gems/nokogiri/CVE-2024-25062.yml
@@ -1,0 +1,48 @@
+---
+gem: nokogiri
+cve: 2024-25062
+ghsa: xc9x-jj77-9p9j
+url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j
+title: Improper Handling of Unexpected Data Type in Nokogiri
+date: 2024-02-04
+description: |
+  ### Summary
+
+  Nokogiri v1.16.2 upgrades the version of its dependency libxml2 to v2.12.5.
+
+  libxml2 v2.12.5 addresses the following vulnerability:
+
+  CVE-2024-25062 / https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25062
+  described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/604
+  patched by https://gitlab.gnome.org/GNOME/libxml2/-/commit/92721970
+
+  Please note that this advisory only applies to the CRuby implementation of
+  Nokogiri < 1.16.2, and only if the packaged libraries are being used. If
+  you've overridden defaults at installation time to use system libraries
+  instead of packaged libraries, you should instead pay attention to your
+  distro's libxml2 release announcements.
+
+  ### Severity
+
+  The Nokogiri maintainers have evaluated this as **Moderate**.
+
+  ### Mitigation
+
+  Upgrade to Nokogiri >= 1.16.2.
+
+  Users who are unable to upgrade Nokogiri may also choose a more complicated
+  mitigation: compile and link Nokogiri against external libraries libxml2 >=
+  2.12.5 which will also address these same issues.
+
+  JRuby users are not affected.
+
+  ### Workarounds
+
+cvss_v3: 5.0
+patched_versions:
+  - ">= 1.16.2"
+related:
+  url:
+    - https://github.com/sparklemotion/nokogiri/commit/1b768b797fd42d94de12b9cff4ed0221f5cb92ec
+    - https://github.com/sparklemotion/nokogiri/releases/tag/v1.16.2
+    - https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j


### PR DESCRIPTION
Information taken from GitHub Advisory: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j

The only thing I couldn't find is the cvss_v3 Number as it is not mentioned anywhere. I've used 5 for moderate.