### PR TITLE
Update CVE-2021-41182, CVE-2021-41183, CVE-2021-41184

### DIFF
--- a/gems/jquery-ui-rails/CVE-2021-41182.yml
+++ b/gems/jquery-ui-rails/CVE-2021-41182.yml
@@ -35,7 +35,7 @@ description: |
 cvss_v2: 4.3
 cvss_v3: 6.5
 patched_versions:
-  - ">= 1.13.0"
+  - ">= 7.0.0"
 related:
   url:
     - https://github.com/jquery/jquery-ui/security/advisories/GHSA-9gj3-hwp5-pmwc
@@ -61,3 +61,4 @@ related:
     - https://lists.fedoraproject.org/archives/list/package-announce
     - https://lists.debian.org/debian-lts-announce/2023/08/msg00040.html
     - https://github.com/advisories/GHSA-9gj3-hwp5-pmwc
+    - https://github.com/jquery-ui-rails/jquery-ui-rails/commit/413265e81f790f795239e07e7e25e01429b2f18d

--- a/gems/jquery-ui-rails/CVE-2021-41183.yml
+++ b/gems/jquery-ui-rails/CVE-2021-41183.yml
@@ -42,7 +42,7 @@ description: |
 cvss_v2: 4.3
 cvss_v3: 6.5
 patched_versions:
-  - ">= 1.13.0"
+  - ">= 7.0.0"
 related:
   url:
     - https://github.com/jquery/jquery-ui/security/advisories/GHSA-j7qv-pgf6-hvh4
@@ -70,3 +70,4 @@ related:
     - https://lists.fedoraproject.org/archives/list/package-announce
     - https://lists.debian.org/debian-lts-announce/2023/08/msg00040.html
     - https://github.com/advisories/GHSA-j7qv-pgf6-hvh4
+    - https://github.com/jquery-ui-rails/jquery-ui-rails/commit/413265e81f790f795239e07e7e25e01429b2f18d

--- a/gems/jquery-ui-rails/CVE-2021-41184.yml
+++ b/gems/jquery-ui-rails/CVE-2021-41184.yml
@@ -37,7 +37,7 @@ description: |
 cvss_v2: 4.3
 cvss_v3: 6.5
 patched_versions:
-  - ">= 1.13.0"
+  - ">= 7.0.0"
 related:
   url:
     - https://github.com/jquery/jquery-ui/security/advisories/GHSA-gpqq-952q-5327
@@ -61,3 +61,4 @@ related:
     - https://lists.fedoraproject.org/archives/list/package-announce
     - https://lists.debian.org/debian-lts-announce/2023/08/msg00040.html
     - https://github.com/advisories/GHSA-gpqq-952q-5327
+    - https://github.com/jquery-ui-rails/jquery-ui-rails/commit/413265e81f790f795239e07e7e25e01429b2f18d


### PR DESCRIPTION
The Ruby gem `jquery-ui-rails` relies on the NPM package `jquery-ui` according [to this table](https://github.com/jquery-ui-rails/jquery-ui-rails/blob/master/VERSIONS.md).
It appears that the patched versions in `CVE-2021-41182`, `CVE-2021-41183`, and `CVE-2021-41184` are based on the NPM package `jquery-ui`. Therefore, this PR addresses the issue by adjusting them to reflect the versioning of `jquery-ui-rails`.