### PR TITLE
Update CVE-2024-26143.yml

### DIFF
--- a/gems/actionpack/CVE-2024-26143.yml
+++ b/gems/actionpack/CVE-2024-26143.yml
@@ -10,7 +10,9 @@ description: |
   (`translate`, `t`, etc) in Action Controller. This vulnerability has been
   assigned the CVE identifier CVE-2024-26143.
 
-  Versions Affected: All. Not affected: None Fixed Versions: 7.1.3.1, 7.0.8.1
+  Versions Affected: >= 7.0.0
+  Not affected: < 7.0.0
+  Fixed Versions: 7.1.3.1, 7.0.8.1
 
   # Impact
 
@@ -48,6 +50,8 @@ description: |
   # Workarounds
 
   There are no feasible workarounds for this issue.
+unaffected_versions:
+  - "< 7.0.0"
 patched_versions:
   - "~> 7.0.8, >= 7.0.8.1"
   - ">= 7.1.3.1"


### PR DESCRIPTION
Only Rails >= 7.0.0 is vulnerable to this issue.

See https://discuss.rubyonrails.org/t/possible-xss-vulnerability-in-action-controller/84947/3?u=rafaelfranca