### PR TITLE
GHSA Add unaffected_versions to CVE-2024-27456

### DIFF
--- a/gems/rack-cors/CVE-2024-27456.yml
+++ b/gems/rack-cors/CVE-2024-27456.yml
@@ -10,7 +10,7 @@ description: |
   for the .rb files.
 notes: Never patched
 unaffected_versions:
-  - "< 2.0.0"
+  - "< 2.0.1"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-27456

--- a/gems/rack-cors/CVE-2024-27456.yml
+++ b/gems/rack-cors/CVE-2024-27456.yml
@@ -9,6 +9,8 @@ description: |
   rack-cors (aka Rack CORS Middleware) 2.0.1 has 0666 permissions
   for the .rb files.
 notes: Never patched
+unaffected_versions:
+  - "< 2.0.0"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-27456


### PR DESCRIPTION
Updated the advisory for CVE-2024-27456 to include the unaffected versions.