### PR TITLE
Add patched version to CVE-2023-51774

### DIFF
--- a/gems/json-jwt/CVE-2023-51774.yml
+++ b/gems/json-jwt/CVE-2023-51774.yml
@@ -10,6 +10,8 @@ description: |
   bypass of identity checks via a sign/encryption confusion attack.
   For example, JWE can sometimes be used to bypass JSON::JWT.decode.
 notes: Not patched yet
+patched_versions:
+  - ">= 1.16.6"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-51774


### PR DESCRIPTION
Adds `>= 1.16.6` as patched version. Version 1.16.6 was released on March 3rd, 2024. The Changelog is not clear on whether the vulnerability is mitigated though (https://github.com/nov/json-jwt/blob/main/CHANGELOG.md).