### PR TITLE
Mark rack-cors 2.0.2 as resolving CVE-2024-27456

### DIFF
--- a/gems/rack-cors/CVE-2024-27456.yml
+++ b/gems/rack-cors/CVE-2024-27456.yml
@@ -10,7 +10,7 @@ description: |
   for the .rb files.
 unaffected_versions:
   - "< 2.0.1"
-patched_version:
+patched_versions:
   - ">= 2.0.2"
 related:
   url:

--- a/gems/rack-cors/CVE-2024-27456.yml
+++ b/gems/rack-cors/CVE-2024-27456.yml
@@ -8,9 +8,10 @@ date: 2024-02-26
 description: |
   rack-cors (aka Rack CORS Middleware) 2.0.1 has 0666 permissions
   for the .rb files.
-notes: Not yet patched
 unaffected_versions:
   - "< 2.0.1"
+patched_version:
+  - ">= 2.0.2"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-27456


### PR DESCRIPTION
The CVE was fixed in 2.0.2, see https://github.com/cyu/rack-cors/issues/274