### PR TITLE
update GHSA-xc9x-jj77-9p9J

### DIFF
--- a/gems/nokogiri/GHSA-xc9x-jj77-9p9j.yml
+++ b/gems/nokogiri/GHSA-xc9x-jj77-9p9j.yml
@@ -28,7 +28,7 @@ description: |
 
   The Nokogiri maintainers have evaluated this as **Moderate**.
 
-  ## Impact
+  ### Impact
 
   From the CVE description, this issue applies to the `xmlTextReader` module (which underlies
   `Nokogiri::XML::Reader`):

--- a/gems/nokogiri/GHSA-xc9x-jj77-9p9j.yml
+++ b/gems/nokogiri/GHSA-xc9x-jj77-9p9j.yml
@@ -2,47 +2,56 @@
 gem: nokogiri
 ghsa: xc9x-jj77-9p9j
 url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j
-title: Improper Handling of Unexpected Data Type in Nokogiri
+title: Use-after-free in libxml2 via Nokogiri::XML::Reader
 date: 2024-02-04
 description: |
   ### Summary
 
-  Nokogiri v1.16.2 upgrades the version of its dependency libxml2 to v2.12.5.
+  Nokogiri upgrades its dependency libxml2 as follows:
+  - v1.15.6 upgrades libxml2 to 2.11.7 from 2.11.6
+  - v1.16.2 upgrades libxml2 to 2.12.5 from 2.12.4
 
-  libxml2 v2.12.5 addresses the following vulnerability:
+  libxml2 v2.11.7 and v2.12.5 address the following vulnerability:
 
   CVE-2024-25062 / https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25062
-  described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/604
-  patched by https://gitlab.gnome.org/GNOME/libxml2/-/commit/92721970
+  - described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/604
+  - patched by https://gitlab.gnome.org/GNOME/libxml2/-/commit/92721970
 
-  Please note that this advisory only applies to the CRuby implementation of
-  Nokogiri < 1.16.2, and only if the packaged libraries are being used. If
-  you've overridden defaults at installation time to use system libraries
-  instead of packaged libraries, you should instead pay attention to your
-  distro's libxml2 release announcements.
+  Please note that this advisory only applies to the CRuby implementation of Nokogiri, and only if
+  the packaged libraries are being used. If you've overridden defaults at installation time to use
+  system libraries instead of packaged libraries, you should instead pay attention to your distro's
+  libxml2 release announcements.
+
+  JRuby users are not affected.
 
   ### Severity
 
   The Nokogiri maintainers have evaluated this as **Moderate**.
 
+  ## Impact
+
+  From the CVE description, this issue applies to the `xmlTextReader` module (which underlies
+  `Nokogiri::XML::Reader`):
+
+  > When using the XML Reader interface with DTD validation and XInclude expansion enabled,
+  > processing crafted XML documents can lead to an xmlValidatePopElement use-after-free.
+
   ### Mitigation
 
-  Upgrade to Nokogiri >= 1.16.2.
+  Upgrade to Nokogiri `~> 1.15.6` or `>= 1.16.2`.
 
-  Users who are unable to upgrade Nokogiri may also choose a more complicated
-  mitigation: compile and link Nokogiri against external libraries libxml2 >=
-  2.12.5 which will also address these same issues.
-
-  JRuby users are not affected.
-
-  ### Workarounds
+  Users who are unable to upgrade Nokogiri may also choose a more complicated mitigation: compile
+  and link Nokogiri against patched external libxml2 libraries which will also address these same
+  issues.
 
 patched_versions:
+  - "~> 1.15.6"
   - ">= 1.16.2"
 related:
   cve:
     - 2024-25062
   url:
     - https://github.com/sparklemotion/nokogiri/commit/1b768b797fd42d94de12b9cff4ed0221f5cb92ec
+    - https://github.com/sparklemotion/nokogiri/releases/tag/v1.15.6
     - https://github.com/sparklemotion/nokogiri/releases/tag/v1.16.2
     - https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j


### PR DESCRIPTION
- update to include nokogiri v1.15.6 information (https://github.com/sparklemotion/nokogiri/releases/tag/v1.15.6)
- add Impact section
- update title to be more accurate and descriptive

See https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j to verify against updated information.