### PR TITLE
Correct affected versions for CVE-2024-34341

### DIFF
--- a/gems/actiontext/CVE-2024-34341.yml
+++ b/gems/actiontext/CVE-2024-34341.yml
@@ -6,7 +6,7 @@ url: https://github.com/advisories/GHSA-qjqp-xr96-cj99
 title: Arbitrary Code Execution Vulnerability in Trix Editor included in ActionText
 date: 2024-05-07
 description: |
-  The ActionText gem includes a copy of the Trix rich text editor.
+  From version 7.0 onwards the ActionText gem includes a copy of the Trix rich text editor.
   Prior to versions 7.0.8.3 and 7.1.3.3, ActionText included a version of Trix that
   is vulnerable to arbitrary code execution when
   copying and pasting content from the web or other documents with markup into the editor.
@@ -16,7 +16,6 @@ description: |
   # Vulnerable Versions:
     * 7.1 series older than 7.1.3.3
     * 7.0 series older than 7.0.8.3
-    * All versions of ActionText older than 7.0
 
   # Fixed Versions:
     * 7.1.3.3
@@ -55,6 +54,8 @@ description: |
   can significantly mitigate the risk of such vulnerabilities.
   Set CSP policies such as script-src 'self' to ensure that only scripts hosted on the same origin
   are executed, and explicitly prohibit inline scripts using script-src-elem.
+unaffected_versions:
+  - "< 7.0.0"
 patched_versions:
   - "~> 7.0.8.3"
   - ">= 7.1.3.3"


### PR DESCRIPTION
Amends #784 (earlier fix to #783) to match affected versions with that officially documented at https://discuss.rubyonrails.org/t/xss-vulnerabilities-in-trix-editor/85803

I can't find any source for the assertion that < 7.0 is vulnerable in contradiction to the Rails teams' assertions, so suggest removing it.