### PR TITLE
Added Rspec lint check to prevent PoC sections inside description field

### DIFF
--- a/gems/avo/CVE-2023-34102.yml
+++ b/gems/avo/CVE-2023-34102.yml
@@ -27,41 +27,6 @@ description: |
   and attempts to work with it, which may result in dangerous behavior
   and code execution.
 
-  ### PoC
-
-  ![image](https://user-images.githubusercontent.com/26464774/243437854-933d94c8-4ae0-43fe-b2da-35b103e28796.png)
-
-  In the test scenario we choose the demo app and the review
-  resource which has a polymorphic reviewable field.
-
-  ![image](https://user-images.githubusercontent.com/26464774/243437954-2d947c6d-4e97-4e91-a442-405e553dd047.png)
-
-  Intercepting the request and switching the review[reviewable_type]
-  from “Fish” to “File” which is a real class inside Rails
-
-  ![image](https://user-images.githubusercontent.com/26464774/243438031-109de6d0-9370-4318-b18e-c5bcea61cf54.png)
-
-  Corrupting the database with unusable classes will cause a crash
-  at the application while viewing the new record or the index
-  view (partial DoS)
-
-  ![image](https://user-images.githubusercontent.com/26464774/243438104-80df5aae-86de-40fc-870d-689a03cae389.png)
-
-  Manual delete the corrupted resource in order to recover the
-  applications functionality
-
-  ![image](https://user-images.githubusercontent.com/26464774/243438182-1e7eef54-73ba-47d0-b5df-4bad14859af3.png)
-
-  Of course it is possible to use other class names or namespaces. The
-  local development environment displays the backend error message
-  when visiting a corrupted record. Avo is trying to apply a scope to
-  this class that does not exist.
-
-  ![image](https://user-images.githubusercontent.com/26464774/243438257-dbb59153-58a8-4421-b796-f2a0f2c20083.png)
-
-  Specifying an invalid class name in the parameter will cause the
-  application to crash again while trying constanize the provided string
-
   ### Impact
 
   The final exploitation of this vulnerability requires more time than

--- a/gems/avo/CVE-2023-34103.yml
+++ b/gems/avo/CVE-2023-34103.yml
@@ -22,13 +22,6 @@ description: |
   the request and modifying the post data, as the trix editor does not
   allow adding custom html or js tags on the frontend.
 
-  ### PoC
-
-  ![image](https://user-images.githubusercontent.com/26464774/243434868-47857054-9b20-437f-842f-0750d53c9b0e.png)
-  _Adding javascript in the post request which is used when editing a "post" resource (body is declared as a trix field)_
-  ![image](https://user-images.githubusercontent.com/26464774/243435009-948593a0-5179-4368-977c-ec36d2373925.png)
-  _Successful execution of JS code on live demo environment_
-
   ### Impact
 
   Unlike non-persistent XSS, persistent XSS does not require a social

--- a/gems/avo/CVE-2024-22191.yml
+++ b/gems/avo/CVE-2024-22191.yml
@@ -27,26 +27,6 @@ description: |
   the value is taken in lines **38** and **49** and seems to be
   interpreted directly as html in lines **44** and **55**.
 
-  ### PoC
-
-  ![POC](https://user-images.githubusercontent.com/26570201/295596307-5d4f563e-99c0-4981-a82e-fc42cfd902c5.gif)
-
-  To reproduce the vulnerability, follow these steps:
-
-  1. Edit an entry with a key_value field.
-
-  2. Enter the following payload into the value field:
-     ```POC\\\"> <script>alert('XSS in key_value' );</script> <strong>Outside-tag</strong```
-
-  3. Save the entry.
-
-  4. Go to the index page and click on the eye icon next to the entry.
-
-  The malicious JavaScript code will be executed and an alert box will be displayed.
-
-  _On the show and edit page the alert seems not to pop up, but the
-  strong tag breaks out of the expected html tag_
-
   ### Impact
 
   This vulnerability could be used to steal sensitive information from

--- a/gems/yard/CVE-2024-27285.yml
+++ b/gems/yard/CVE-2024-27285.yml
@@ -45,15 +45,6 @@ description: |
   </script>
   ```
 
-  ### PoC (Proof of Concept)
-
-  To exploit this vulnerability:
-  1. Gain access to the generated Yard Doc.
-  2. Locate and access the "frames.html" file.
-  3. Construct a URL containing the malicious payload in the hash
-     segment, for instance: `#!javascript:xss` for v0.9.34, and
-     `#:javascript:xss` for v0.9.35
-
   ### Impact
 
   This XSS vulnerability presents a substantial threat by enabling

--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -140,6 +140,10 @@ shared_examples_for 'Advisory' do |path|
         expect(subject).to_not include("\\n\\n")
       end
 
+      it "must not have PoC sections" do
+        expect(subject).to_not include("### PoC")
+      end
+
       it { expect(subject).to be_kind_of(String) }
       it { expect(subject).not_to be_empty }
     end


### PR DESCRIPTION
Added Rspec lint check to prevent PoC sections inside description field.
Also removed existing description/PoC subsections.from 4 advisories.