### PR TITLE
GHSA SYNC: One brand new advisory

### DIFF
--- a/gems/rack/CVE-2024-39316.yml
+++ b/gems/rack/CVE-2024-39316.yml
@@ -2,7 +2,7 @@
 gem: rack
 cve: 2024-39316
 ghsa: cj83-2ww7-mvq7
-url: https://github.com/rack/rack/security/advisories/GHSA-54rr-7fvw-6x8f
+url: https://github.com/rack/rack/security/advisories/GHSA-cj83-2ww7-mvq7
 title: Rack ReDoS Vulnerability in HTTP Accept Headers Parsing
 date: 2024-07-03
 description: |
@@ -29,7 +29,6 @@ patched_versions:
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-39316
-    - https://github.com/rack/rack/security/advisories/GHSA-54rr-7fvw-6x8f
     - https://github.com/rack/rack/security/advisories/GHSA-cj83-2ww7-mvq7
     - https://github.com/rack/rack/commit/412c980450ca729ee37f90a2661f166a9665e058
     - https://github.com/advisories/GHSA-cj83-2ww7-mvq7

--- a/gems/rack/CVE-2024-39316.yml
+++ b/gems/rack/CVE-2024-39316.yml
@@ -1,0 +1,35 @@
+---
+gem: rack
+cve: 2024-39316
+ghsa: cj83-2ww7-mvq7
+url: https://github.com/rack/rack/security/advisories/GHSA-54rr-7fvw-6x8f
+title: Rack ReDoS Vulnerability in HTTP Accept Headers Parsing
+date: 2024-07-03
+description: |
+  ### Summary
+
+  A Regular Expression Denial of Service (ReDoS) vulnerability exists
+  in the `Rack::Request::Helpers` module when parsing HTTP Accept headers.
+  This vulnerability can be exploited by an attacker sending specially
+  crafted `Accept-Encoding` or `Accept-Language` headers, causing the
+  server to spend excessive time processing the request and leading
+  to a Denial of Service (DoS).
+
+  ### Details
+
+  The fix for https://github.com/rack/rack/security/advisories/GHSA-54rr-7fvw-6x8f
+  was not applied to the main branch and thus while the issue was fixed
+  for the Rack v3.0 release series, it was not fixed in the v3.1
+  release series until v3.1.5.
+cvss_v3: 6.5
+unaffected_versions:
+  - "< 3.1.0"
+patched_versions:
+  - ">= 3.1.5"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-39316
+    - https://github.com/rack/rack/security/advisories/GHSA-54rr-7fvw-6x8f
+    - https://github.com/rack/rack/security/advisories/GHSA-cj83-2ww7-mvq7
+    - https://github.com/rack/rack/commit/412c980450ca729ee37f90a2661f166a9665e058
+    - https://github.com/advisories/GHSA-cj83-2ww7-mvq7


### PR DESCRIPTION
GHSA SYNC: One brand new advisory: gems/rack/CVE-2024-39316.yml
