### PR TITLE
GHSA SYNC adds ghsa: and cvss_v3 fields to yesterday's advisory

### DIFF
--- a/gems/rexml/CVE-2024-39908.yml
+++ b/gems/rexml/CVE-2024-39908.yml
@@ -1,6 +1,7 @@
 ---
 gem: rexml
 cve: 2024-39908
+ghsa: 4xqq-m2hx-25v8
 url: https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8
 title: DoS in REXML
 date: 2024-07-16
@@ -27,6 +28,7 @@ description: |
   ## History
 
   Originally published at 2024-07-16 03:00:00 (UTC)
+cvss_v3: 4.3
 patched_versions:
   - ">= 3.3.2"
 related:


### PR DESCRIPTION
GHSA SYNC adds ghsa: and cvss_v3 fields to yesterday's advisory: gems/rexml/CVE-2024-39908.yml
