### PR TITLE
GHSA SYNC: 3 modified and 8 brand new advisories

### DIFF
--- a/gems/bootstrap-sass/CVE-2016-10735.yml
+++ b/gems/bootstrap-sass/CVE-2016-10735.yml
@@ -1,6 +1,7 @@
 ---
 gem: bootstrap-sass
 cve: 2016-10735
+ghsa: 4p24-vmcr-4gqj
 url: https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/
 title: XSS vulnerability via data-target in bootstrap-sass
 date: 2016-07-27
@@ -11,7 +12,6 @@ cvss_v2: 4.3
 cvss_v3: 6.1
 patched_versions:
   - ">= 3.4.0"
-
 related:
   url:
     - https://github.com/twbs/bootstrap/issues/20184

--- a/gems/bootstrap-sass/CVE-2018-14042.yml
+++ b/gems/bootstrap-sass/CVE-2018-14042.yml
@@ -1,0 +1,45 @@
+---
+gem: bootstrap-sass
+cve: 2018-14042
+ghsa: 7mvr-5x2g-wfc8
+url: https://github.com/advisories/GHSA-7mvr-5x2g-wfc8
+title: Bootstrap Cross-site Scripting vulnerability
+date: 2018-09-13
+description: |
+  In Bootstrap starting in version 2.3.0 and prior to versions
+  3.4.0 and 4.1.2, XSS is possible in the data-container
+  property of tooltip.  This is similar to CVE-2018-14041.
+cvss_v2: 4.3
+cvss_v3: 6.1
+unaffected_versions:
+  - "< 2.3.0"
+patched_versions:
+  - "~> 3.4.0"
+  - ">= 4.1.2"
+related:
+  cve:
+    - CVE-2018-14041
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-14042
+    - https://github.com/twbs/bootstrap/issues/26423
+    - https://github.com/twbs/bootstrap/issues/26628
+    - https://github.com/twbs/bootstrap/pull/26630
+    - https://lists.apache.org/thread.html/519eb0fd45642dcecd9ff74cb3e71c20a4753f7d82e2f07864b5108f@
+    - https://lists.apache.org/thread.html/52e0e6b5df827ee7f1e68f7cc3babe61af3b2160f5d74a85469b7b0e@
+    - https://lists.apache.org/thread.html/b0656d359c7d40ec9f39c8cc61bca66802ef9a2a12ee199f5b0c1442@
+    - https://lists.apache.org/thread.html/f9bc3e55f4e28d1dcd1a69aae6d53e609a758e34d2869b4d798e13cc@
+    - https://lists.apache.org/thread.html/r3dc0cac8d856bca02bd6997355d7ff83027dcfc82f8646a29b89b714@
+    - https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@
+    - https://seclists.org/bugtraq/2019/May/18
+    - https://www.oracle.com/security-alerts/cpuApr2021.html
+    - http://packetstormsecurity.com/files/156743/OctoberCMS-Insecure-Dependencies.html
+    - http://seclists.org/fulldisclosure/2019/May/10
+    - http://seclists.org/fulldisclosure/2019/May/11
+    - http://seclists.org/fulldisclosure/2019/May/13
+    - https://github.com/twbs/bootstrap/issues/26428
+    - https://github.com/twbs/bootstrap/commit/2d90d369bbc2bd2647620246c55cec8c4705e3d0
+    - https://github.com/rubysec/ruby-advisory-db/blob/master/gems/bootstrap/CVE-2018-14042.yml
+    - https://www.tenable.com/security/tns-2021-14
+    - https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d
+    - https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2
+    - https://github.com/advisories/GHSA-7mvr-5x2g-wfc8

--- a/gems/bootstrap-sass/CVE-2018-20676.yml
+++ b/gems/bootstrap-sass/CVE-2018-20676.yml
@@ -1,0 +1,31 @@
+---
+gem: bootstrap-sass
+cve: 2018-20676
+ghsa: 3mgp-fx93-9xv5
+url: https://github.com/advisories/GHSA-3mgp-fx93-9xv5
+title: XSS vulnerability that affects bootstrap
+date: 2019-01-17
+description: |
+  In Bootstrap before 3.4.0, XSS is possible in the tooltip
+  data-viewport  attribute.
+cvss_v2: 4.3
+cvss_v3: 6.1
+patched_versions:
+  - ">= 3.4.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-20676
+    - https://github.com/twbs/bootstrap/issues/27044
+    - https://github.com/twbs/bootstrap/issues/27915#issuecomment-452140906
+    - https://github.com/twbs/bootstrap/issues/27915#issuecomment-452196628
+    - https://github.com/twbs/bootstrap/pull/27047
+    - https://access.redhat.com/errata/RHBA-2019:1076
+    - https://access.redhat.com/errata/RHBA-2019:1570
+    - https://access.redhat.com/errata/RHSA-2019:1456
+    - https://access.redhat.com/errata/RHSA-2019:3023
+    - https://access.redhat.com/errata/RHSA-2020:0132
+    - https://access.redhat.com/errata/RHSA-2020:0133
+    - https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@
+    - https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d
+    - https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0
+    - https://github.com/advisories/GHSA-3mgp-fx93-9xv5

--- a/gems/bootstrap-sass/CVE-2018-20677.yml
+++ b/gems/bootstrap-sass/CVE-2018-20677.yml
@@ -1,0 +1,32 @@
+---
+gem: bootstrap-sass
+cve: 2018-20677
+ghsa: ph58-4vrj-w6hr
+url: https://github.com/advisories/GHSA-ph58-4vrj-w6hr
+title: bootstrap Cross-site Scripting vulnerability
+date: 2019-01-17
+description: |
+  In Bootstrap before 3.4.0, XSS is possible in the affix
+  configuration target property.
+cvss_v2: 4.3
+cvss_v3: 6.1
+patched_versions:
+  - ">= 3.4.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-20677
+    - https://github.com/twbs/bootstrap/issues/27045
+    - https://github.com/twbs/bootstrap/issues/27915#issuecomment-452140906
+    - https://github.com/twbs/bootstrap/issues/27915#issuecomment-452196628
+    - https://github.com/twbs/bootstrap/pull/27047
+    - https://access.redhat.com/errata/RHBA-2019:1076
+    - https://access.redhat.com/errata/RHBA-2019:1570
+    - https://access.redhat.com/errata/RHSA-2019:1456
+    - https://access.redhat.com/errata/RHSA-2019:3023
+    - https://access.redhat.com/errata/RHSA-2020:0132
+    - https://access.redhat.com/errata/RHSA-2020:0133
+    - https://lists.apache.org/thread.html/52e0e6b5df827ee7f1e68f7cc3babe61af3b2160f5d74a85469b7b0e@
+    - https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@
+    - https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d
+    - https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0
+    - https://github.com/advisories/GHSA-ph58-4vrj-w6hr

--- a/gems/bootstrap-sass/CVE-2024-6484.yml
+++ b/gems/bootstrap-sass/CVE-2024-6484.yml
@@ -1,0 +1,23 @@
+---
+gem: bootstrap-sass
+cve: 2024-6484
+ghsa: 9mvj-f7w8-pvh2
+url: https://github.com/advisories/GHSA-9mvj-f7w8-pvh2
+title: Bootstrap Cross-Site Scripting (XSS) vulnerability
+date: 2024-07-11
+description: |
+  A vulnerability has been identified in Bootstrap that exposes users
+  to Cross-Site Scripting (XSS) attacks. The issue is present in the
+  carousel component, where the data-slide and data-slide-to attributes
+  can be exploited through the href attribute of an <a> tag due to
+  inadequate sanitization. This vulnerability could potentially enable
+  attackers to execute arbitrary JavaScript within the victim's browser.
+cvss_v3: 6.4
+unaffected_versions:
+  - "< 2.0.0"
+notes: Never patched
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-6484
+    - https://www.herodevs.com/vulnerability-directory/cve-2024-6484
+    - https://github.com/advisories/GHSA-9mvj-f7w8-pvh2

--- a/gems/bootstrap/CVE-2016-10735.yml
+++ b/gems/bootstrap/CVE-2016-10735.yml
@@ -1,6 +1,7 @@
 ---
 gem: bootstrap
 cve: 2016-10735
+ghsa: 4p24-vmcr-4gqj
 url: https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2/
 title: XSS vulnerability via data-target in bootstrap
 date: 2016-07-27
@@ -11,7 +12,6 @@ cvss_v2: 4.3
 cvss_v3: 6.1
 patched_versions:
   - ">= 4.0.0-beta.2"
-
 related:
   url:
     - https://github.com/twbs/bootstrap/issues/20184

--- a/gems/bootstrap/CVE-2018-20676.yml
+++ b/gems/bootstrap/CVE-2018-20676.yml
@@ -1,0 +1,31 @@
+---
+gem: bootstrap
+cve: 2018-20676
+ghsa: 3mgp-fx93-9xv5
+url: https://github.com/advisories/GHSA-3mgp-fx93-9xv5
+title: XSS vulnerability that affects bootstrap
+date: 2019-01-17
+description: |
+  In Bootstrap before 3.4.0, XSS is possible in the tooltip data-viewport
+  attribute.
+cvss_v2: 4.3
+cvss_v3: 6.1
+patched_versions:
+  - ">= 3.4.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-20676
+    - https://github.com/twbs/bootstrap/issues/27044
+    - https://github.com/twbs/bootstrap/issues/27915#issuecomment-452140906
+    - https://github.com/twbs/bootstrap/issues/27915#issuecomment-452196628
+    - https://github.com/twbs/bootstrap/pull/27047
+    - https://access.redhat.com/errata/RHBA-2019:1076
+    - https://access.redhat.com/errata/RHBA-2019:1570
+    - https://access.redhat.com/errata/RHSA-2019:1456
+    - https://access.redhat.com/errata/RHSA-2019:3023
+    - https://access.redhat.com/errata/RHSA-2020:0132
+    - https://access.redhat.com/errata/RHSA-2020:0133
+    - https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@
+    - https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d
+    - https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0
+    - https://github.com/advisories/GHSA-3mgp-fx93-9xv5

--- a/gems/bootstrap/CVE-2018-20677.yml
+++ b/gems/bootstrap/CVE-2018-20677.yml
@@ -1,0 +1,32 @@
+---
+gem: bootstrap
+cve: 2018-20677
+ghsa: ph58-4vrj-w6hr
+url: https://github.com/advisories/GHSA-ph58-4vrj-w6hr
+title: bootstrap Cross-site Scripting vulnerability
+date: 2019-01-17
+description: |
+  In Bootstrap before 3.4.0, XSS is possible in the affix
+  configuration target property.
+cvss_v2: 4.3
+cvss_v3: 6.1
+patched_versions:
+  - ">= 3.4.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-20677
+    - https://github.com/twbs/bootstrap/issues/27045
+    - https://github.com/twbs/bootstrap/issues/27915#issuecomment-452140906
+    - https://github.com/twbs/bootstrap/issues/27915#issuecomment-452196628
+    - https://github.com/twbs/bootstrap/pull/27047
+    - https://access.redhat.com/errata/RHBA-2019:1076
+    - https://access.redhat.com/errata/RHBA-2019:1570
+    - https://access.redhat.com/errata/RHSA-2019:1456
+    - https://access.redhat.com/errata/RHSA-2019:3023
+    - https://access.redhat.com/errata/RHSA-2020:0132
+    - https://access.redhat.com/errata/RHSA-2020:0133
+    - https://lists.apache.org/thread.html/52e0e6b5df827ee7f1e68f7cc3babe61af3b2160f5d74a85469b7b0e@
+    - https://lists.apache.org/thread.html/rd0e44e8ef71eeaaa3cf3d1b8b41eb25894372e2995ec908ce7624d26@
+    - https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d
+    - https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0
+    - https://github.com/advisories/GHSA-ph58-4vrj-w6hr

--- a/gems/bootstrap/CVE-2024-6484.yml
+++ b/gems/bootstrap/CVE-2024-6484.yml
@@ -1,0 +1,23 @@
+---
+gem: bootstrap
+cve: 2024-6484
+ghsa: 9mvj-f7w8-pvh2
+url: https://github.com/advisories/GHSA-9mvj-f7w8-pvh2
+title: Bootstrap Cross-Site Scripting (XSS) vulnerability
+date: 2024-07-11
+description: |
+  A vulnerability has been identified in Bootstrap that exposes users
+  to Cross-Site Scripting (XSS) attacks. The issue is present in the
+  carousel component, where the data-slide and data-slide-to attributes
+  can be exploited through the href attribute of an <a> tag due to
+  inadequate sanitization. This vulnerability could potentially enable
+  attackers to execute arbitrary JavaScript within the victim's browser.
+cvss_v3: 6.4
+unaffected_versions:
+  - "< 2.0.0"
+notes: Never patched
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-6484
+    - https://www.herodevs.com/vulnerability-directory/cve-2024-6484
+    - https://github.com/advisories/GHSA-9mvj-f7w8-pvh2

--- a/gems/bootstrap/CVE-2024-6484.yml
+++ b/gems/bootstrap/CVE-2024-6484.yml
@@ -15,7 +15,8 @@ description: |
 cvss_v3: 6.4
 unaffected_versions:
   - "< 2.0.0"
-notes: Never patched
+patched_versions:
+  - "> 3.4.1"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-6484

--- a/gems/bootstrap/CVE-2024-6531.yml
+++ b/gems/bootstrap/CVE-2024-6531.yml
@@ -1,0 +1,23 @@
+---
+gem: bootstrap
+cve: 2024-6531
+ghsa: vc8w-jr9v-vj7f
+url: https://github.com/advisories/GHSA-vc8w-jr9v-vj7f
+title: Bootstrap Cross-Site Scripting (XSS) vulnerability
+date: 2024-07-11
+description: |
+  A vulnerability has been identified in Bootstrap that exposes users
+  to Cross-Site Scripting (XSS) attacks. The issue is present in the
+  carousel component, where the data-slide and data-slide-to attributes
+  can be exploited through the href attribute of an <a> tag due to
+  inadequate sanitization. This vulnerability could potentially enable
+  attackers to execute arbitrary JavaScript within the victim's browser.
+cvss_v3: 6.4
+unaffected_versions:
+  - "< 4.0.0"
+notes: Never patched
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-6531
+    - https://www.herodevs.com/vulnerability-directory/cve-2024-6531
+    - https://github.com/advisories/GHSA-vc8w-jr9v-vj7f

--- a/gems/bootstrap/CVE-2024-6531.yml
+++ b/gems/bootstrap/CVE-2024-6531.yml
@@ -15,7 +15,8 @@ description: |
 cvss_v3: 6.4
 unaffected_versions:
   - "< 4.0.0"
-notes: Never patched
+patched_versions:
+  - "> 4.6.2"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-6531

--- a/gems/rexml/CVE-2024-41123.yml
+++ b/gems/rexml/CVE-2024-41123.yml
@@ -1,6 +1,7 @@
 ---
 gem: rexml
 cve: 2024-41123
+ghsa: r55c-59qm-vjw6
 url: https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123
 title: DoS vulnerabilities in REXML
 date: 2024-08-01
@@ -27,7 +28,7 @@ description: |
   ## History
 
   Originally published at 2024-08-01 03:00:00 (UTC)
-
+cvss_v3: 5.3
 patched_versions:
   - ">= 3.3.3"
 related:


### PR DESCRIPTION
GHSA SYNC: 3 modified and 8 brand new advisories:
Modified:
 * gems/bootstrap-sass/CVE-2016-10735.yml
 * gems/bootstrap/CVE-2016-10735.yml
 * gems/rexml/CVE-2024-41123.yml

Brand New: **NOTE that several  of these CVEs were fixed privately by https://www.herodevs.com company)**
 * gems/bootstrap-sass/CVE-2018-14042.yml
 * gems/bootstrap-sass/CVE-2018-20676.yml
 * gems/bootstrap-sass/CVE-2018-20677.yml
 * gems/bootstrap-sass/CVE-2024-6484.yml
 * gems/bootstrap/CVE-2018-20676.yml
 * gems/bootstrap/CVE-2018-20677.yml
 * gems/bootstrap/CVE-2024-6484.yml
 * gems/bootstrap/CVE-2024-6531.yml
