### PR TITLE
GSHA SYNC: 2 brand new advisories

### DIFF
--- a/gems/sequenceserver/CVE-2024-42360.yml
+++ b/gems/sequenceserver/CVE-2024-42360.yml
@@ -1,0 +1,29 @@
+---
+gem: sequenceserver
+cve: 2024-42360
+ghsa: qv32-5wm2-p32h
+url: https://github.com/wurmlab/sequenceserver/security/advisories/GHSA-qv32-5wm2-p32h
+title: Command Injection in sequenceserver gem
+date: 2024-08-13
+description: |
+  ### Impact
+
+  Several HTTP endpoints did not properly sanitize user input
+  and/or query parameters. This could be exploited to inject
+  and run unwanted shell commands
+
+  ### Patches
+
+  Fixed in 3.1.2
+
+  ### Workarounds
+
+  No known workarounds
+cvss_v3: 9.8
+patched_versions:
+  - ">= 3.1.2"
+related:
+  url:
+    - https://github.com/wurmlab/sequenceserver/security/advisories/GHSA-qv32-5wm2-p32h
+    - https://github.com/wurmlab/sequenceserver/commit/457e52709f7f9ed2fceed59b3db564cb50785dba
+    - https://github.com/advisories/GHSA-qv32-5wm2-p32h

--- a/gems/spina/CVE-2024-7106.yml
+++ b/gems/spina/CVE-2024-7106.yml
@@ -1,0 +1,35 @@
+---
+gem: spina
+cve: 2024-7106
+ghsa: wqw3-p83g-r24v
+url: https://github.com/advisories/GHSA-wqw3-p83g-r24v
+title: Cross-Site Request Forgery in Spina
+date: 2024-07-25
+description: |
+  A vulnerability classified as problematic was found in
+  Spina CMS 2.18.0.
+
+  Affected by this vulnerability is an unknown functionality
+  of the file /admin/media_folders.
+
+  The manipulation leads to cross-site request forgery.
+  The attack can be launched remotely.
+
+  The exploit has been disclosed to the public and may be used.
+
+  The associated identifier of this vulnerability is VDB-272431.
+
+  NOTE: The vendor was contacted early about this disclosure
+  but did not respond in any way.
+cvss_v2: 5.0
+cvss_v3: 4.3
+cvss_v4: 6.9
+notes: Never patched
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-7106
+    - https://github.com/topsky979/Security-Collections/blob/main/cve3/README.md
+    - https://vuldb.com/?ctiid.272431
+    - https://vuldb.com/?id.272431
+    - https://vuldb.com/?submit.376769
+    - https://github.com/advisories/GHSA-wqw3-p83g-r24v


### PR DESCRIPTION
GSHA SYNC: 2 brand new advisories:
 * gems/sequenceserver/CVE-2024-42360.yml
 * gems/spina/CVE-2024-7106.yml
