### PR TITLE
GSHA SYNC: 1 brand new advisory

### DIFF
--- a/gems/fugit/CVE-2024-43380.yml
+++ b/gems/fugit/CVE-2024-43380.yml
@@ -1,0 +1,46 @@
+---
+gem: fugit
+cve: 2024-43380
+ghsa: 2m96-52r3-2f3g
+url: https://github.com/floraison/fugit/security/advisories/GHSA-2m96-52r3-2f3g
+title: fugit parse and parse_nat stall on lengthy input
+date: 2024-08-19
+description: |
+  ### Impact
+
+  The fugit "natural" parser, that turns "every wednesday at 5pm" into
+  "0 17 * * 3", accepted any length of input and went on attempting to
+  parse it, not returning promptly, as expected. The parse call could
+  hold the thread with no end in sight.
+
+  Fugit dependents that do not check (user) input length for
+  plausability are impacted.
+
+  ### Patches
+
+  Problem was reported in #104 and the fix was released in
+  [fugit 1.11.1](https://rubygems.org/gems/fugit/versions/1.11.1)
+
+  ### Workarounds
+
+  By making sure that `Fugit.parse(s)`, `Fugit.do_parse(s)`,
+  `Fugit.parse_nat(s)`, `Fugit.do_parse_nat(s)`, `Fugit::Nat.parse(s)`,
+  and `Fugit::Nat.do_parse(s)` are not fed strings too long.
+  1000 chars feels ok, while 10_000 chars makes it stall.
+
+  In fewer words, making sure those fugit methods are not fed
+  unvetted input strings.
+
+  ### References
+
+  gh-104
+cvss_v3: 5.3
+patched_versions:
+  - ">= 1.11.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-43380
+    - https://github.com/floraison/fugit/security/advisories/GHSA-2m96-52r3-2f3g
+    - https://github.com/floraison/fugit/issues/104
+    - https://github.com/floraison/fugit/commit/ad2c1c9c737213d585fff0b51c927d178b2c05a5
+    - https://github.com/advisories/GHSA-2m96-52r3-2f3g

--- a/gems/fugit/CVE-2024-43380.yml
+++ b/gems/fugit/CVE-2024-43380.yml
@@ -30,10 +30,6 @@ description: |
 
   In fewer words, making sure those fugit methods are not fed
   unvetted input strings.
-
-  ### References
-
-  gh-104
 cvss_v3: 5.3
 patched_versions:
   - ">= 1.11.1"


### PR DESCRIPTION
GSHA SYNC: 1 brand new advisory: gems/fugit/CVE-2024-43380.yml 