### PR TITLE
Update CVE-2024-32464.yml with better Rails version constraints

### DIFF
--- a/gems/actiontext/CVE-2024-32464.yml
+++ b/gems/actiontext/CVE-2024-32464.yml
@@ -49,7 +49,7 @@ cvss_v3: 6.1
 unaffected_versions:
   - "< 7.1.0"
 patched_versions:
-  - "~> 7.1.3.4"
+  - "~> 7.1.3, >= 7.1.3.4"
   - ">= 7.2.0.beta2"
 related:
   url:


### PR DESCRIPTION
Correctly update the patched Rails versions to include recently released `7.1.4`.

Addresses part of #806 (PR #807 handles the other).