### PR TITLE
Update patched versions to include 7.1.5 for CVE-2024-47889, CVE-2024-47888, CVE-2024-47887, CVE-2024-41128

### DIFF
--- a/gems/actionmailer/CVE-2024-47889.yml
+++ b/gems/actionmailer/CVE-2024-47889.yml
@@ -39,7 +39,7 @@ unaffected_versions:
 patched_versions:
   - "~> 6.1.7.9"
   - "~> 7.0.8.5"
-  - "~> 7.1.4.1"
+  - ">= 7.1.4.1, < 7.2"
   - ">= 7.2.1.1"
 related:
   url:

--- a/gems/actionpack/CVE-2024-41128.yml
+++ b/gems/actionpack/CVE-2024-41128.yml
@@ -38,7 +38,7 @@ unaffected_versions:
 patched_versions:
   - "~> 6.1.7.9"
   - "~> 7.0.8.5"
-  - "~> 7.1.4.1"
+  - ">= 7.1.4.1, < 7.2"
   - ">= 7.2.1.1"
 related:
   url:

--- a/gems/actionpack/CVE-2024-47887.yml
+++ b/gems/actionpack/CVE-2024-47887.yml
@@ -41,7 +41,7 @@ unaffected_versions:
 patched_versions:
   - "~> 6.1.7.9"
   - "~> 7.0.8.5"
-  - "~> 7.1.4.1"
+  - ">= 7.1.4.1, < 7.2"
   - ">= 7.2.1.1"
 related:
   url:

--- a/gems/actiontext/CVE-2024-47888.yml
+++ b/gems/actiontext/CVE-2024-47888.yml
@@ -40,7 +40,7 @@ unaffected_versions:
 patched_versions:
   - "~> 6.1.7.9"
   - "~> 7.0.8.5"
-  - "~> 7.1.4.1"
+  - ">= 7.1.4.1, < 7.2"
   - ">= 7.2.1.1"
 related:
   url:


### PR DESCRIPTION
With new version of Rails (7.1.5), false alarms are now ringing bells because of too restrictive version specified in the "patched versions" section of affected gems.
The change updates the version range, so that `7.1.5` doesn't fail the validation.

Failures with the existing version range:
```
Name: actionmailer
Version: 7.1.5
CVE: CVE-2024-47889
GHSA: GHSA-h47h-mwp9-c6q6
Criticality: Unknown
URL: https://github.com/rails/rails/security/advisories/GHSA-h47h-mwp9-c6q6
Title: Possible ReDoS vulnerability in block_format in Action Mailer
Solution: update to '~> 6.1.7.9', '~> 7.0.8.5', '~> 7.1.4.1', '>= 7.2.1.1'

Name: actionpack
Version: 7.1.5
CVE: CVE-2024-41128
GHSA: GHSA-x76w-6vjr-8xgj
Criticality: Unknown
URL: https://github.com/rails/rails/security/advisories/GHSA-x76w-6vjr-8xgj
Title: Possible ReDoS vulnerability in query parameter filtering in Action Dispatch
Solution: update to '~> 6.1.7.9', '~> 7.0.8.5', '~> 7.1.4.1', '>= 7.2.1.1'

Name: actionpack
Version: 7.1.5
CVE: CVE-2024-47887
GHSA: GHSA-vfg9-r3fq-jvx4
Criticality: Unknown
URL: https://github.com/rails/rails/security/advisories/GHSA-vfg9-r3fq-jvx4
Title: Possible ReDoS vulnerability in HTTP Token authentication in Action Controller
Solution: update to '~> 6.1.7.9', '~> 7.0.8.5', '~> 7.1.4.1', '>= 7.2.1.1'

Name: actiontext
Version: 7.1.5
CVE: CVE-2024-47888
GHSA: GHSA-wwhv-wxv9-rpgw
Criticality: Unknown
URL: https://github.com/rails/rails/security/advisories/GHSA-wwhv-wxv9-rpgw
Title: Possible ReDoS vulnerability in plain_text_for_blockquote_node in Action Text
Solution: update to '~> 6.1.7.9', '~> 7.0.8.5', '~> 7.1.4.1', '>= 7.2.1.1'
```