### PR TITLE
Added patched_versions to CVE 2024-21510

### DIFF
--- a/gems/sinatra/CVE-2024-21510.yml
+++ b/gems/sinatra/CVE-2024-21510.yml
@@ -4,7 +4,7 @@ cve: 2024-21510
 ghsa: hxx2-7vcw-mqr3
 url: https://github.com/advisories/GHSA-hxx2-7vcw-mqr3
 title: Sinatra vulnerable to Reliance on Untrusted Inputs in a Security Decision
-date: 2024-11-19
+date: 2024-11-01
 description: |
   Versions of the package sinatra from 0.0.0 are vulnerable to
   Reliance on Untrusted Inputs in a Security Decision via the

--- a/gems/sinatra/CVE-2024-21510.yml
+++ b/gems/sinatra/CVE-2024-21510.yml
@@ -4,7 +4,7 @@ cve: 2024-21510
 ghsa: hxx2-7vcw-mqr3
 url: https://github.com/advisories/GHSA-hxx2-7vcw-mqr3
 title: Sinatra vulnerable to Reliance on Untrusted Inputs in a Security Decision
-date: 2024-11-01
+date: 2024-11-19
 description: |
   Versions of the package sinatra from 0.0.0 are vulnerable to
   Reliance on Untrusted Inputs in a Security Decision via the
@@ -17,12 +17,16 @@ description: |
   handling the X-Forwarded-Host header, attackers can potentially
   exploit Cache Poisoning or Routing-based SSRF.
 cvss_v3: 5.4
-notes: Never patched
+patched_versions:
+  - ">= 4.1.0"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2024-21510
     - https://security.snyk.io/vuln/SNYK-RUBY-SINATRA-6483832
-    - https://github.com/sinatra/sinatra/pull/2010
+    - https://github.com/advisories/GHSA-hxx2-7vcw-mqr3
     - https://github.com/sinatra/sinatra/blob/b626e2d82c23b4fde0b51782fd32ca27ccde1d1a/lib/sinatra/base.rb#L319
     - https://github.com/sinatra/sinatra/blob/b626e2d82c23b4fde0b51782fd32ca27ccde1d1a/lib/sinatra/base.rb#L323C1-L343C17
-    - https://github.com/advisories/GHSA-hxx2-7vcw-mqr3
+    - https://github.com/sinatra/sinatra/issues/2052
+    - https://github.com/sinatra/sinatra/pull/2010
+    - https://github.com/sinatra/sinatra/pull/2053
+    - https://github.com/sinatra/sinatra/commit/cd3e00de20ddaff34ea30f7a74a7b9dad189d1d8


### PR DESCRIPTION
CVE 2024-21510 should be patched with version `4.1.0`.

See the [CHANGELOG](https://github.com/sinatra/sinatra/blob/main/CHANGELOG.md) for details and [the advisory-database](https://github.com/github/advisory-database/pull/5018).