### PR TITLE
GHSA SYNC: 5 brand new advisories

### DIFF
--- a/gems/rails-html-sanitizer/CVE-2024-53985.yml
+++ b/gems/rails-html-sanitizer/CVE-2024-53985.yml
@@ -1,0 +1,132 @@
+---
+gem: rails-html-sanitizer
+framework: rails
+cve: 2024-53985
+ghsa: w8gc-x259-rc7x
+url: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-w8gc-x259-rc7x
+title: rails-html-sanitizer has XSS vulnerability with certain configurations
+date: 2024-12-02
+description: |
+  ## Summary
+
+  There is a possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer 1.6.0 when used with Rails >= 7.1.0 and
+  Nokogiri < 1.15.7, or 1.16.x < 1.16.8.
+
+  * Versions affected: 1.6.0
+  * Not affected: < 1.6.0
+  * Fixed versions: 1.6.1
+
+  Please note that the fix in v1.6.1 is to update the dependency on
+  Nokogiri to 1.15.7 or >= 1.16.8.
+
+  ## Impact
+
+  A possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer may allow an attacker to inject content if
+  HTML5 sanitization is enabled and the application developer has
+  overridden the sanitizer's allowed tags in either of the following ways:
+
+  * allow both "math" and "style" elements
+  * or allow both "svg" and "style" elements
+
+  Code is only impacted if Rails is configured to use HTML5 sanitization,
+  please see documentation for
+  [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+  and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+  for more information on these configuration options.
+
+  Code is only impacted if allowed tags are being overridden.
+  Applications may be doing this in a few different ways:
+
+  1. using application configuration to configure Action View
+     sanitizers' allowed tags:
+
+    ```ruby
+    # In config/application.rb
+    config.action_view.sanitized_allowed_tags = ["math", "style"]
+    # or
+    config.action_view.sanitized_allowed_tags = ["svg", "style"]
+    ```
+
+    see https://guides.rubyonrails.org/configuring.html#configuring-action-view
+
+  2. using a `:tags` option to the Action View helper `sanitize`:
+
+    ```
+    <= sanitize @comment.body, tags: ["math", "style"] >
+    <# or>
+    <= sanitize @comment.body, tags: ["svg", "style"] >
+    ```
+
+    see https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+
+  3. setting Rails::HTML5::SafeListSanitizer class attribute `allowed_tags`:
+
+    ```ruby
+    # class-level option
+    Rails::HTML5::SafeListSanitizer.allowed_tags = ["math", "style"]
+    # or
+    Rails::HTML5::SafeListSanitizer.allowed_tags = ["svg", "style"]
+    ```
+
+    (note that this class may also be referenced as
+    `Rails::Html::SafeListSanitizer`)
+
+  4. using a `:tags` options to the Rails::HTML5::SafeListSanitizer
+     instance method `sanitize`:
+
+    ```ruby
+    # instance-level option
+    Rails::HTML5::SafeListSanitizer.new.sanitize(@article.body, tags: ["math", "style"])
+    # or
+    Rails::HTML5::SafeListSanitizer.new.sanitize(@article.body, tags: ["svg", "style"])
+    ```
+    (note that this class may also be referenced as `Rails::Html::SafeListSanitizer`)
+
+  5. setting ActionText::ContentHelper module attribute `allowed_tags`:
+
+    ```ruby
+    ActionText::ContentHelper.allowed_tags = ["math", "style"]
+    # or
+    ActionText::ContentHelper.allowed_tags = ["svg", "style"]
+    ```
+
+  All users overriding the allowed tags by any of the above mechanisms
+  to include (("math" or "svg") and "style") should either upgrade or
+  use one of the workarounds.
+
+  ## Workarounds
+
+  Any one of the following actions will work around this issue:
+
+  - Remove "style" from the overridden allowed tags,
+  - Or, remove "math" and "svg" from the overridden allowed tags,
+  - Or, downgrade sanitization to HTML4 (see documentation for
+    [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+    and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+    for more information)
+  - Or, independently upgrade Nokogiri to v1.15.7 or >= 1.16.8.
+
+  ## References
+
+  - [CWE - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') (4.9)](https://cwe.mitre.org/data/definitions/79.html)
+  - Original report: https://hackerone.com/reports/2503220
+
+  ## Credit
+
+  This vulnerability was responsibly reported by HackerOne user
+  [@taise](https://hackerone.com/taise?type=user).
+cvss_v4: 2.3
+unaffected_versions:
+  - "< 1.6.0"
+patched_versions:
+  - ">= 1.6.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-53985
+    - https://github.com/rails/rails-html-sanitizer/blob/v1.6.1/CHANGELOG.md
+    - https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-w8gc-x259-rc7x
+    - https://github.com/rails/rails-html-sanitizer/commit/b0220b8850d52199a15f83c472d175a4122dd7b1
+    - https://github.com/rails/rails-html-sanitizer/commit/cd18b0ef00aad1d4a9e1c5d860cd23f80f63c505
+    - https://github.com/advisories/GHSA-w8gc-x259-rc7x

--- a/gems/rails-html-sanitizer/CVE-2024-53986.yml
+++ b/gems/rails-html-sanitizer/CVE-2024-53986.yml
@@ -1,0 +1,116 @@
+---
+gem: rails-html-sanitizer
+framework: rails
+cve: 2024-53986
+ghsa: 638j-pmjw-jq48
+url: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-638j-pmjw-jq48
+title: rails-html-sanitizer has XSS vulnerability with certain configurations
+date: 2024-12-02
+description: |
+  ## Summary
+
+  There is a possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer 1.6.0 when used with Rails >= 7.1.0.
+
+  * Versions affected: 1.6.0
+  * Not affected: < 1.6.0
+  * Fixed versions: 1.6.1
+
+  ## Impact
+
+  A possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer may allow an attacker to inject content if
+  HTML5 sanitization is enabled and the application developer has
+  overridden the sanitizer's allowed tags in the following way:
+
+  - the "math" and "style" elements are both explicitly allowed
+
+  Code is only impacted if Rails is configured to use HTML5 sanitization,
+  please see documentation for
+  [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+  and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+  for more information on these configuration options.
+
+  The default configuration is to disallow these elements. Code is only
+  impacted if allowed tags are being overridden. Applications may be
+  doing this in a few different ways:
+
+  1. using application configuration to configure Action View sanitizers'
+     allowed tags:
+
+    ```ruby
+    # In config/application.rb
+    config.action_view.sanitized_allowed_tags = ["math", "style"]
+    ```
+
+    see https://guides.rubyonrails.org/configuring.html#configuring-action-view
+
+  2. using a `:tags` option to the Action View helper `sanitize`:
+
+    ```
+    <= sanitize @comment.body, tags: ["math", "style"]>
+    ```
+
+    see https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+
+  3. setting Rails::HTML5::SafeListSanitizer class attribute `allowed_tags`:
+
+    ```ruby
+    # class-level option
+    Rails::HTML5::SafeListSanitizer.allowed_tags = ["math", "style"]
+    ```
+
+    (note that this class may also be referenced as
+    `Rails::Html::SafeListSanitizer`)
+
+  4. using a `:tags` options to the Rails::HTML5::SafeListSanitizer
+     instance method `sanitize`:
+
+    ```ruby
+    # instance-level option
+    Rails::HTML5::SafeListSanitizer.new.sanitize(@article.body, tags: ["math", "style"])
+    ```
+
+    (note that this class may also be referenced as
+     `Rails::Html::SafeListSanitizer`)
+
+  5. setting ActionText::ContentHelper module attribute `allowed_tags`:
+
+    ```ruby
+    ActionText::ContentHelper.allowed_tags = ["math", "style"]
+    ```
+
+  All users overriding the allowed tags by any of the above mechanisms
+  to include both "math" and "style" should either upgrade or use one
+  of the workarounds.
+
+  ## Workarounds
+
+  Any one of the following actions will work around this issue:
+
+  - Remove "math" or "style" from the overridden allowed tags,
+  - Or, downgrade sanitization to HTML4 (see documentation for
+    [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+    and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+    for more information).
+
+  ## References
+
+  - [CWE - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') (4.9)](https://cwe.mitre.org/data/definitions/79.html)
+  - Original report: https://hackerone.com/reports/2519941
+
+  ## Credit
+
+  This vulnerability was responsibly reported by So Sakaguchi (mokusou).
+cvss_v4: 2.3
+unaffected_versions:
+  - "< 1.6.0"
+patched_versions:
+  - ">= 1.6.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-53986
+    - https://github.com/rails/rails-html-sanitizer/blob/v1.6.1/CHANGELOG.md
+    - https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-638j-pmjw-jq48
+    - https://github.com/rails/rails-html-sanitizer/commit/f02ffbb8465e73920b6de0da940f5530f855965e
+    - https://github.com/advisories/GHSA-638j-pmjw-jq48

--- a/gems/rails-html-sanitizer/CVE-2024-53987.yml
+++ b/gems/rails-html-sanitizer/CVE-2024-53987.yml
@@ -1,0 +1,114 @@
+---
+gem: rails-html-sanitizer
+framework: rails
+cve: 2024-53987
+ghsa: 2x5m-9ch4-qgrr
+url: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-2x5m-9ch4-qgrr
+title: rails-html-sanitizer has XSS vulnerability with certain configurations
+date: 2024-12-02
+description: |
+  ## Summary
+
+  There is a possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer 1.6.0 when used with Rails >= 7.1.0.
+
+  * Versions affected: 1.6.0
+  * Not affected: < 1.6.0
+  * Fixed versions: 1.6.1
+
+  ## Impact
+
+  A possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer may allow an attacker to inject content if
+  HTML5 sanitization is enabled and the application developer has
+  overridden the sanitizer's allowed tags in the following way:
+
+  - the "style" element is explicitly allowed
+  - the "svg" or "math" element is not allowed
+
+  Code is only impacted if Rails is configured to use HTML5 sanitization,
+  please see documentation for [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+  and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+  for more information on these configuration options.
+
+  The default configuration is to disallow all of these elements. Code
+  is only impacted if allowed tags are being overridden. Applications
+  may be doing this in a few different ways:
+
+  1. using application configuration to configure Action View sanitizers'
+     allowed tags:
+
+    ```ruby
+    # In config/application.rb
+    config.action_view.sanitized_allowed_tags = ["style"]
+    ```
+
+    see https://guides.rubyonrails.org/configuring.html#configuring-action-view
+
+  2. using a `:tags` option to the Action View helper `sanitize`:
+
+    ```
+    <= sanitize @comment.body, tags: ["style"] >
+    ```
+
+    see https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+
+  3. setting Rails::HTML5::SafeListSanitizer class attribute `allowed_tags`:
+
+    ```ruby
+    # class-level option
+    Rails::HTML5::SafeListSanitizer.allowed_tags = ["style"]
+    ```
+
+    (note that this class may also be referenced as
+    `Rails::Html::SafeListSanitizer`)
+
+  4. using a `:tags` options to the Rails::HTML5::SafeListSanitizer instance method `sanitize`:
+
+    ```ruby
+    # instance-level option
+    Rails::HTML5::SafeListSanitizer.new.sanitize(@article.body, tags: ["style"])
+    ```
+
+    (note that this class may also be referenced as
+    `Rails::Html::SafeListSanitizer`)
+
+  5. setting ActionText::ContentHelper module attribute `allowed_tags`:
+
+    ```ruby
+    ActionText::ContentHelper.allowed_tags = ["style"]
+    ```
+
+  All users overriding the allowed tags by any of the above mechanisms
+  to include "style" and omit "svg" or "math" should either upgrade
+  or use one of the workarounds.
+
+  ## Workarounds
+
+  Any one of the following actions will work around this issue:
+
+  - Remove "style" from the overridden allowed tags,
+  - Or, downgrade sanitization to HTML4 (see documentation for
+    [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+    and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+    for more information).
+
+  ## References
+
+  - [CWE - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') (4.9)](https://cwe.mitre.org/data/definitions/79.html)
+  - Original report: https://hackerone.com/reports/2519936
+
+  ## Credit
+
+  This vulnerability was responsibly reported by So Sakaguchi (mnokusou).
+cvss_v4: 2.3
+unaffected_versions:
+  - "< 1.6.0"
+patched_versions:
+  - ">= 1.6.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-53987
+    - https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-2x5m-9ch4-qgrr
+    - https://github.com/rails/rails-html-sanitizer/commit/f02ffbb8465e73920b6de0da940f5530f855965e
+    - https://github.com/advisories/GHSA-2x5m-9ch4-qgrr

--- a/gems/rails-html-sanitizer/CVE-2024-53988.yml
+++ b/gems/rails-html-sanitizer/CVE-2024-53988.yml
@@ -1,0 +1,124 @@
+---
+gem: rails-html-sanitizer
+framework: rails
+cve: 2024-53988
+ghsa: cfjx-w229-hgx5
+url: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-cfjx-w229-hgx5
+title: rails-html-sanitizer has XSS vulnerability with certain configurations
+date: 2024-12-02
+description: |
+  ## Summary
+
+  There is a possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer 1.6.0 when used with Rails >= 7.1.0.
+
+  * Versions affected: 1.6.0
+  * Not affected: < 1.6.0
+  * Fixed versions: 1.6.1
+
+  ## Impact
+
+  A possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer may allow an attacker to inject content
+  if HTML5 sanitization is enabled and the application developer
+  has overridden the sanitizer's allowed tags in the following way:
+
+  - the "math", "mtext", "table", and "style" elements are allowed
+  - and either "mglyph" or "malignmark" are allowed
+
+  Code is only impacted if Rails is configured to use HTML5 sanitization,
+  please see documentation for [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+  and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+  for more information on these configuration options.
+
+  The default configuration is to disallow all of these elements
+  except for "table". Code is only impacted if allowed tags are being
+  overridden. Applications may be doing this in a few different ways:
+
+  1. using application configuration to configure Action View sanitizers'
+     allowed tags:
+
+    ```ruby
+    # In config/application.rb
+    config.action_view.sanitized_allowed_tags = ["math", "mtext", "table", "style", "mglyph"]
+    # or
+    config.action_view.sanitized_allowed_tags = ["math", "mtext", "table", "style", "malignmark"]
+    ```
+
+    see https://guides.rubyonrails.org/configuring.html#configuring-action-view
+
+  2. using a `:tags` option to the Action View helper `sanitize`:
+
+    ```
+    <= sanitize @comment.body, tags: ["math", "mtext", "table", "style", "mglyph"] >
+    <# or >
+    <= sanitize @comment.body, tags: ["math", "mtext", "table", "style", "malignmark"] >
+    ```
+
+    see https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+
+  3. setting Rails::HTML5::SafeListSanitizer class attribute `allowed_tags`:
+
+    ```ruby
+    # class-level option
+    Rails::HTML5::SafeListSanitizer.allowed_tags = ["math", "mtext", "table", "style", "mglyph"]
+    # or
+    Rails::HTML5::SafeListSanitizer.allowed_tags = ["math", "mtext", "table", "style", "malignmark"]
+    ```
+
+    (note that this class may also be referenced as
+    `Rails::Html::SafeListSanitizer`)
+
+  4. using a `:tags` options to the Rails::HTML5::SafeListSanitizer
+     instance method `sanitize`:
+
+    ```ruby
+    # instance-level option
+    Rails::HTML5::SafeListSanitizer.new.sanitize(@article.body, tags: ["math", "mtext", "table", "style", "mglyph"])
+    # or
+    Rails::HTML5::SafeListSanitizer.new.sanitize(@article.body, tags: ["math", "mtext", "table", "style", "malignmark"])
+    ```
+
+    (note that this class may also be referenced as
+    `Rails::Html::SafeListSanitizer`)
+
+  5. setting ActionText::ContentHelper module attribute `allowed_tags`:
+
+    ```ruby
+    ActionText::ContentHelper.allowed_tags = ["math", "mtext", "table", "style", "mglyph"]
+    # or
+    ActionText::ContentHelper.allowed_tags = ["math", "mtext", "table", "style", "malignmark"]
+    ```
+
+  All users overriding the allowed tags by any of the above mechanisms
+  to include ("math" and "mtext" and "table" and "style" and ("mglyph"
+  or "malignmark")) should either upgrade or use one of the workarounds.
+
+  ## Workarounds
+
+  Any one of the following actions will work around this issue:
+
+  - Remove "mglyph" and "malignmark" from the overridden allowed tags,
+  - Or, downgrade sanitization to HTML4 (see documentation for [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+    and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+    for more information).
+
+  ## References
+
+  - [CWE - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') (4.9)](https://cwe.mitre.org/data/definitions/79.html)
+  - Original report: https://hackerone.com/reports/2519936
+
+  ## Credit
+
+  This vulnerability was responsibly reported by So Sakaguchi (mokusou).
+cvss_v4: 2.3
+unaffected_versions:
+  - "< 1.6.0"
+patched_versions:
+  - ">= 1.6.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-53988
+    - https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-cfjx-w229-hgx5
+    - https://github.com/rails/rails-html-sanitizer/commit/a0a3e8b76b696446ffc6bffcff3bc7b7c6393c72
+    - https://github.com/advisories/GHSA-cfjx-w229-hgx5

--- a/gems/rails-html-sanitizer/CVE-2024-53989.yml
+++ b/gems/rails-html-sanitizer/CVE-2024-53989.yml
@@ -1,0 +1,114 @@
+---
+gem: rails-html-sanitizer
+framework: rails
+cve: 2024-53989
+ghsa: rxv5-gxqc-xx8g
+url: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-rxv5-gxqc-xx8g
+title: rails-html-sanitizer has XSS vulnerability with certain configurations
+date: 2024-12-02
+description: |+
+  ## Summary
+
+  There is a possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer 1.6.0 when used with Rails >= 7.1.0.
+
+  * Versions affected: 1.6.0
+  * Not affected: < 1.6.0
+  * Fixed versions: 1.6.1
+
+  ## Impact
+
+  A possible XSS vulnerability with certain configurations of
+  Rails::HTML::Sanitizer may allow an attacker to inject content if
+  HTML5 sanitization is enabled and the application developer has
+  overridden the sanitizer's allowed tags in the following way:
+
+  - the "noscript" element is explicitly allowed
+
+  Code is only impacted if Rails is configured to use HTML5 sanitization,
+  please see documentation for [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+  and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+  for more information on these configuration options.
+
+  The default configuration is to disallow all of these elements. Code
+  is only impacted if allowed tags are being overridden. Applications
+  may be doing this in a few different ways:
+
+  1. using application configuration to configure Action View sanitizers'
+     allowed tags:
+
+    ```ruby
+    # In config/application.rb
+    config.action_view.sanitized_allowed_tags = ["noscript"]
+    ```
+
+    see https://guides.rubyonrails.org/configuring.html#configuring-action-view
+
+  2. using a `:tags` option to the Action View helper `sanitize`:
+
+    ```
+    <= sanitize @comment.body, tags: ["noscript"] >
+    ```
+
+    see https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize
+
+  3. setting Rails::HTML5::SafeListSanitizer class attribute `allowed_tags`:
+
+    ```ruby
+    # class-level option
+    Rails::HTML5::SafeListSanitizer.allowed_tags = ["noscript"]
+    ```
+
+    (note that this class may also be referenced as
+    `Rails::Html::SafeListSanitizer`)
+
+  4. using a `:tags` options to the Rails::HTML5::SafeListSanitizer instance method `sanitize`:
+
+    ```ruby
+    # instance-level option
+    Rails::HTML5::SafeListSanitizer.new.sanitize(@article.body, tags: ["noscript"])
+    ```
+
+    (note that this class may also be referenced as
+    `Rails::Html::SafeListSanitizer`)
+
+  5. setting ActionText::ContentHelper module attribute `allowed_tags`:
+
+    ```ruby
+    ActionText::ContentHelper.allowed_tags = ["noscript"]
+    ```
+
+  All users overriding the allowed tags by any of the above
+  mechanisms to include "noscript" should either upgrade or use
+  one of the workarounds.
+
+  ## Workarounds
+
+  Any one of the following actions will work around this issue:
+
+  - Remove "noscript" from the overridden allowed tags,
+  - Or, downgrade sanitization to HTML4 (see documentation for
+    [`config.action_view.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-view-sanitizer-vendor)
+    and [`config.action_text.sanitizer_vendor`](https://guides.rubyonrails.org/configuring.html#config-action-text-sanitizer-vendor)
+    for more information).
+
+  ## References
+
+  - [CWE - CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') (4.9)](https://cwe.mitre.org/data/definitions/79.html)
+  - Original report: https://hackerone.com/reports/2509647
+
+  ## Credit
+
+  This vulnerability was responsibly reported by HackerOne user
+  [@taise](https://hackerone.com/taise?type=user).
+cvss_v4: 2.3
+unaffected_versions:
+  - "< 1.6.0"
+patched_versions:
+  - ">= 1.6.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-53989
+    - https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-rxv5-gxqc-xx8g
+    - https://github.com/rails/rails-html-sanitizer/commit/16251735e36ebdc302e2f90f2a39cad56879414f
+    - https://github.com/advisories/GHSA-rxv5-gxqc-xx8g


### PR DESCRIPTION
GHSA SYNC: 5 brand new advisories:
 * gems/rails-html-sanitizer/CVE-2024-53985.yml
 * gems/rails-html-sanitizer/CVE-2024-53986.yml
 * gems/rails-html-sanitizer/CVE-2024-53987.yml
 * gems/rails-html-sanitizer/CVE-2024-53988.yml
 * gems/rails-html-sanitizer/CVE-2024-53989.yml

Note: Appears to be very similar.