### PR TITLE
Remove Rails LTS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ description: |
 
   Versions Affected: All
   Not affected: None
-  Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1
+  Fixed Versions: 6.1.7.1, 7.0.4.1
 
   # Impact
 
@@ -85,7 +85,7 @@ description: |
 
   Users on Ruby 3.2.0 or greater are not affected by this vulnerability.
 patched_versions:
-  - "~> 5.2.8, >= 5.2.8.15"  # Rails LTS
+  - "~> 5.2.8"
   - "~> 6.1.7, >= 6.1.7.1"
   - ">= 7.0.4.1"
 ```

--- a/gems/actionpack/CVE-2023-22792.yml
+++ b/gems/actionpack/CVE-2023-22792.yml
@@ -13,7 +13,7 @@ description: |
 
   Versions Affected: >= 3.0.0
   Not affected: < 3.0.0
-  Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1
+  Fixed Versions: 6.1.7.1, 7.0.4.1
 
   # Impact
 
@@ -33,6 +33,6 @@ description: |
 unaffected_versions:
   - "< 3.0.0"
 patched_versions:
-  - "~> 5.2.8, >= 5.2.8.15"  # Rails LTS
+  - "~> 5.2.8"
   - "~> 6.1.7, >= 6.1.7.1"
   - ">= 7.0.4.1"

--- a/gems/actionpack/CVE-2023-22795.yml
+++ b/gems/actionpack/CVE-2023-22795.yml
@@ -13,7 +13,7 @@ description: |
 
   Versions Affected: All
   Not affected: None
-  Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1
+  Fixed Versions: 6.1.7.1, 7.0.4.1
 
   # Impact
 
@@ -33,6 +33,6 @@ description: |
 
   Users on Ruby 3.2.0 or greater are not affected by this vulnerability.
 patched_versions:
-  - "~> 5.2.8, >= 5.2.8.15"  # Rails LTS
+  - "~> 5.2.8"
   - "~> 6.1.7, >= 6.1.7.1"
   - ">= 7.0.4.1"

--- a/gems/activerecord/CVE-2022-44566.yml
+++ b/gems/activerecord/CVE-2022-44566.yml
@@ -14,7 +14,7 @@ description: |
 
   Versions Affected: All.
   Not affected: None.
-  Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1
+  Fixed Versions: 6.1.7.1, 7.0.4.1
 
   # Impact
 
@@ -30,6 +30,6 @@ description: |
   not contain integers wider than a signed 64bit representation or floats.
 cvss_v3: 7.5
 patched_versions:
-  - "~> 5.2.8, >= 5.2.8.15"  # Rails LTS
+  - "~> 5.2.8"
   - "~> 6.1.7, >= 6.1.7.1"
   - ">= 7.0.4.1"

--- a/gems/activesupport/CVE-2023-22796.yml
+++ b/gems/activesupport/CVE-2023-22796.yml
@@ -13,7 +13,7 @@ description: |
 
   Versions Affected: All
   Not affected: None
-  Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1
+  Fixed Versions: 6.1.7.1, 7.0.4.1
 
   # Impact
 
@@ -35,6 +35,6 @@ description: |
   Users on Ruby 3.2.0 or greater may be able to reduce the impact by
   configuring Regexp.timeout.
 patched_versions:
-  - "~> 5.2.8, >= 5.2.8.15"  # Rails LTS
+  - "~> 5.2.8"
   - "~> 6.1.7, >= 6.1.7.1"
   - ">= 7.0.4.1"


### PR DESCRIPTION
We (the Rails LTS team) noticed that some CVEs are marked as fixed by Rails LTS in the ruby-advisory-db. While we appreciate and are grateful for the effort, we would prefer not to list our commercial versions in the official database as fixed versions.

Currently, we do not have the capacity to actively monitor all versions listed in the ruby-advisory-db, verify their accuracy, and ensure correctness. Additionally, some fixes require extra context or additional information that may not be adequately reflected in the database. Most Rails LTS versions are a commercial offering, and we maintain a comprehensive list of all CVEs we have addressed—along with the necessary details—at https://makandracards.com/railslts/474590-list-cves-addressed-rails-lts. Every Rails LTS customer also receives a newsletter with updates and additional information for all patches.

We would prefer to keep our own documentation as the single source of truth for Rails LTS related fixes. Thank you for your understanding.