### PR TITLE
GHSA SYNC: Added hackerone reference to 1 existing advisory

### DIFF
--- a/gems/rexml/CVE-2024-43398.yml
+++ b/gems/rexml/CVE-2024-43398.yml
@@ -49,4 +49,5 @@ related:
     - https://github.com/ruby/rexml/security/advisories/GHSA-vmwr-mc7x-5vc3
     - https://github.com/ruby/rexml/commit/7cb5eaeb221c322b9912f724183294d8ce96bae3
     - https://github.com/ruby/rexml/releases/tag/v3.3.6
+    - https://hackerone.com/reports/2666849
     - https://github.com/advisories/GHSA-vmwr-mc7x-5vc3


### PR DESCRIPTION
 * GHSA SYNC: Added hackerone reference to 1 existing advisory: gems/rexml/CVE-2024-43398.yml
