### PR TITLE
GHSA SYNC[ruby-saml]: 3 new advisories: CVE 2025-25291, CVE 2025-25292 and CVE 2025-25293

### DIFF
--- a/gems/ruby-saml/CVE-2025-25291.yml
+++ b/gems/ruby-saml/CVE-2025-25291.yml
@@ -1,0 +1,32 @@
+---
+gem: ruby-saml
+cve: 2025-25291
+ghsa: 4vc4-m8qh-g8jm
+url: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-4vc4-m8qh-g8jm
+title: Ruby SAML allows a SAML authentication bypass due to DOCTYPE handling (parser differential)
+date: 2025-03-12
+description: |-
+  ### Summary
+  An authentication bypass vulnerability was found in ruby-saml due to a parser differential.
+  ReXML and Nokogiri parse XML differently, the parsers can generate entirely
+  different document structures from the same XML input. That allows an attacker
+  to be able to execute a Signature Wrapping attack.
+
+  ### Impact
+  This issue may lead to authentication bypass.
+cvss_v4: 8.8
+patched_versions:
+  - "~> 1.12.4"
+  - ">= 1.18.0"
+related:
+  url:
+    - https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-4vc4-m8qh-g8jm
+    - https://github.com/SAML-Toolkits/ruby-saml/commit/e9c1cdbd0f9afa467b585de279db0cbd0fb8ae97
+    - https://github.com/omniauth/omniauth-saml/security/advisories/GHSA-hw46-3hmr-x9xv
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-25291
+    - https://github.com/SAML-Toolkits/ruby-saml/commit/e76c5b36bac40aedbf1ba7ffaaf495be63328cd9
+    - https://about.gitlab.com/releases/2025/03/12/patch-release-gitlab-17-9-2-released
+    - https://github.blog/security/sign-in-as-anyone-bypassing-saml-sso-authentication-with-parser-differentials
+    - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.12.4
+    - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.18.0
+    - https://github.com/advisories/GHSA-4vc4-m8qh-g8jm

--- a/gems/ruby-saml/CVE-2025-25292.yml
+++ b/gems/ruby-saml/CVE-2025-25292.yml
@@ -1,0 +1,32 @@
+---
+gem: ruby-saml
+cve: 2025-25292
+ghsa: 754f-8gm6-c4r2
+url: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-754f-8gm6-c4r2
+title: Ruby SAML allows a SAML authentication bypass due to namespace handling (parser differential)
+date: 2025-03-12
+description: |-
+  ### Summary
+  An authentication bypass vulnerability was found in ruby-saml due to a parser differential.
+  ReXML and Nokogiri parse XML differently, the parsers can generate entirely
+  different document structures from the same XML input. That allows an
+  attacker to be able to execute a Signature Wrapping attack.
+
+  ### Impact
+  This issue may lead to authentication bypass.
+cvss_v4: 8.8
+patched_versions:
+  - "~> 1.12.4"
+  - ">= 1.18.0"
+related:
+  url:
+    - https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-754f-8gm6-c4r2
+    - https://github.com/omniauth/omniauth-saml/security/advisories/GHSA-hw46-3hmr-x9xv
+    - https://github.com/SAML-Toolkits/ruby-saml/commit/e76c5b36bac40aedbf1ba7ffaaf495be63328cd9
+    - https://github.com/SAML-Toolkits/ruby-saml/commit/e9c1cdbd0f9afa467b585de279db0cbd0fb8ae97
+    - https://about.gitlab.com/releases/2025/03/12/patch-release-gitlab-17-9-2-released
+    - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.12.4
+    - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.18.0
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-25292
+    - https://github.blog/security/sign-in-as-anyone-bypassing-saml-sso-authentication-with-parser-differentials
+    - https://github.com/advisories/GHSA-754f-8gm6-c4r2

--- a/gems/ruby-saml/CVE-2025-25293.yml
+++ b/gems/ruby-saml/CVE-2025-25293.yml
@@ -1,0 +1,33 @@
+---
+gem: ruby-saml
+cve: 2025-25293
+ghsa: 92rq-c8cf-prrq
+url: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-92rq-c8cf-prrq
+title: Ruby SAML allows remote Denial of Service (DoS) with compressed SAML responses
+date: 2025-03-12
+description: |-
+  ### Summary
+  ruby-saml is susceptible to remote Denial of Service (DoS) with compressed SAML responses.
+
+  Ruby-saml uses zlib to decompress SAML responses in case they're compressed.
+  It is possible to bypass the message size check with a compressed assertion
+  since the message size is checked before inflation and not after.
+
+  ### Impact
+  This issue may lead to remote Denial of Service (DoS).
+cvss_v4: 8.8
+patched_versions:
+  - "~> 1.12.4"
+  - ">= 1.18.0"
+related:
+  url:
+    - https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-92rq-c8cf-prrq
+    - https://github.com/SAML-Toolkits/ruby-saml/commit/acac9e9cc0b9a507882c614f25d41f8b47be349a
+    - https://github.com/omniauth/omniauth-saml/security/advisories/GHSA-hw46-3hmr-x9xv
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-25293
+    - https://github.com/SAML-Toolkits/ruby-saml/commit/e2da4c6dae7dc01a4d9cd221395140a67e2b3eb1
+    - https://about.gitlab.com/releases/2025/03/12/patch-release-gitlab-17-9-2-released
+    - https://github.blog/security/sign-in-as-anyone-bypassing-saml-sso-authentication-with-parser-differentials
+    - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.12.4
+    - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.18.0
+    - https://github.com/advisories/GHSA-92rq-c8cf-prrq


### PR DESCRIPTION
Added 3 new advisories of CVEs affecting the `ruby-saml` gem