### PR TITLE
GHSA SYNC: Add hackerone reference to 1 advisory

### DIFF
--- a/gems/net-imap/CVE-2025-25186.yml
+++ b/gems/net-imap/CVE-2025-25186.yml
@@ -155,4 +155,5 @@ related:
     - https://github.com/ruby/net-imap/commit/70e3ddd071a94e450b3238570af482c296380b35
     - https://github.com/ruby/net-imap/commit/c8c5a643739d2669f0c9a6bb9770d0c045fd74a3
     - https://github.com/ruby/net-imap/commit/cb92191b1ddce2d978d01b56a0883b6ecf0b1022
+    - https://hackerone.com/reports/2987782
     - https://github.com/advisories/GHSA-7fc5-f82f-cx69


### PR DESCRIPTION
GHSA SYNC: Add hackerone reference to 1 advisory: gems/net-imap/CVE-2025-25186.yml
