### PR TITLE
GHSA SYNC: 1 brand new and 4 modified advisories

### DIFF
--- a/gems/activestorage/CVE-2024-26144.yml
+++ b/gems/activestorage/CVE-2024-26144.yml
@@ -14,7 +14,11 @@ description: |
 
   This vulnerability has been assigned the CVE identifier CVE-2024-26144.
 
-  Versions Affected: >= 5.2.0, < 7.1.0 Not affected: < 5.2.0, >= 7.1.0 Fixed Versions: 7.0.8.1, 6.1.7.7
+  Versions Affected: >= 5.2.0, < 7.1.0
+
+  Not affected: < 5.2.0, >= 7.1.0
+
+  Fixed Versions: 7.0.8.1, 6.1.7.7
 
   # Impact
 
@@ -43,3 +47,7 @@ unaffected_versions:
 patched_versions:
   - "~> 6.1.7, >= 6.1.7.7"
   - ">= 7.0.8.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-26144
+    - https://hackerone.com/reports/3082917

--- a/gems/cgi/CVE-2025-27219.yml
+++ b/gems/cgi/CVE-2025-27219.yml
@@ -35,4 +35,5 @@ related:
   url:
     - https://www.cve.org/CVERecord?id=CVE-2025-27219
     - https://www.suse.com/security/cve/CVE-2025-27219.html
+    - https://hackerone.com/reports/3013913
     - https://www.ruby-lang.org/en/news/2025/02/26/security-advisories

--- a/gems/net-imap/CVE-2025-25186.yml
+++ b/gems/net-imap/CVE-2025-25186.yml
@@ -152,6 +152,8 @@ related:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-25186
     - https://www.ruby-lang.org/en/news/2025/02/10/dos-net-imap-cve-2025-25186
     - https://github.com/ruby/net-imap/security/advisories/GHSA-7fc5-f82f-cx69
+    - https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj
+    - https://hackerone.com/reports/3108869
     - https://github.com/ruby/net-imap/commit/70e3ddd071a94e450b3238570af482c296380b35
     - https://github.com/ruby/net-imap/commit/c8c5a643739d2669f0c9a6bb9770d0c045fd74a3
     - https://github.com/ruby/net-imap/commit/cb92191b1ddce2d978d01b56a0883b6ecf0b1022

--- a/gems/net-imap/CVE-2025-25186.yml
+++ b/gems/net-imap/CVE-2025-25186.yml
@@ -152,8 +152,6 @@ related:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-25186
     - https://www.ruby-lang.org/en/news/2025/02/10/dos-net-imap-cve-2025-25186
     - https://github.com/ruby/net-imap/security/advisories/GHSA-7fc5-f82f-cx69
-    - https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj
-    - https://hackerone.com/reports/3108869
     - https://github.com/ruby/net-imap/commit/70e3ddd071a94e450b3238570af482c296380b35
     - https://github.com/ruby/net-imap/commit/c8c5a643739d2669f0c9a6bb9770d0c045fd74a3
     - https://github.com/ruby/net-imap/commit/cb92191b1ddce2d978d01b56a0883b6ecf0b1022

--- a/gems/net-imap/CVE-2025-43857.yml
+++ b/gems/net-imap/CVE-2025-43857.yml
@@ -1,0 +1,122 @@
+---
+gem: net-imap
+cve: 2025-43857
+ghsa: j3g3-5qv5-52mj
+url: https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj
+title: net-imap rubygem vulnerable to possible DoS by memory exhaustion
+date: 2025-04-28
+description: |
+  ### Summary
+
+  There is a possibility for denial of service by memory exhaustion
+  when `net-imap` reads server responses.  At any time while the client
+  is connected, a malicious server can send can send a "literal" byte
+  count, which is automatically read by the client's receiver thread.
+  The response reader immediately allocates memory for the number of
+  bytes indicated by the server response.
+
+  This should not be an issue when securely connecting to trusted IMAP
+  servers that are well-behaved.  It can affect insecure connections
+  and buggy, untrusted, or compromised servers (for example, connecting
+  to a user supplied hostname).
+
+  ### Details
+
+  The IMAP protocol allows "literal" strings to be sent in responses,
+  prefixed with their size in curly braces (e.g. `{1234567890}`).
+  When `Net::IMAP` receives a response containing a literal string,
+  it calls `IO#read` with that size.  When called with a size,
+  `IO#read` immediately allocates memory to buffer the entire string
+  before processing continues.  The server does not need to send any
+  more data.  There is no limit on the size of literals that will be
+  accepted.
+
+  ### Fix
+  #### Upgrade
+  Users should upgrade to `net-imap` 0.5.7 or later.  A configurable
+  `max_response_size` limit has been added to `Net::IMAP`'s response
+  reader.  The `max_response_size` limit has also been backported to
+  `net-imap` 0.2.5, 0.3.9, and 0.4.20.
+
+  To set a global value for `max_response_size`, users must upgrade
+  to `net-imap` ~> 0.4.20, or > 0.5.7.
+
+  #### Configuration
+
+  To avoid backward compatibility issues for secure connections to
+  trusted well-behaved servers, the default `max_response_size` for
+  `net-imap` 0.5.7 is _very high_ (512MiB), and the default
+  `max_response_size` for `net-imap` ~> 0.4.20, ~> 0.3.9, and 0.2.5
+  is `nil` (unlimited).
+
+  When connecting to untrusted servers or using insecure connections,
+  a much lower `max_response_size` should be used.
+  ```ruby
+  # Set the global max_response_size (only ~> v0.4.20, > 0.5.7)
+  Net::IMAP.config.max_response_size = 256 << 10 # 256 KiB
+
+  # Set when creating the connection
+  imap = Net::IMAP.new(hostname, ssl: true,
+                       max_response_size: 16 << 10) # 16 KiB
+
+  # Set after creating the connection
+  imap.max_response_size = 256 << 20 # 256 KiB
+  # flush currently waiting read, to ensure the new setting is loaded
+  imap.noop
+  ```
+
+  _**Please Note:**_ `max_response_size` only limits the size _per
+  response_.  It does not prevent a flood of individual responses
+  and it does not limit how many unhandled responses may be stored
+  on the responses hash.  Users are responsible for adding response
+  handlers to prune excessive unhandled responses.
+
+  #### Compatibility with lower `max_response_size`
+
+  A lower `max_response_size` may cause a few commands which
+  legitimately return very large responses to raise an exception
+  and close the connection.  The `max_response_size` could be
+  temporarily set to a higher value, but paginated or limited
+  versions of commands should be used whenever possible.  For
+  example, to fetch message bodies:
+
+  ```ruby
+  imap.max_response_size = 256 << 20 # 256 KiB
+  imap.noop # flush currently waiting read
+
+  # fetch a message in 252KiB chunks
+  size = imap.uid_fetch(uid, "RFC822.SIZE").first.rfc822_size
+  limit = 252 << 10
+  message = ((0..size)limit).each_with_object("") {|offset, str|
+    str << imap.uid_fetch(uid,
+    "BODY.PEEK[]<#{offset}.#{limit}>").first.message(offset:)
+  }
+
+  imap.max_response_size = 16 << 20 # 16 KiB
+  imap.noop # flush currently waiting read
+  ```
+
+  ### References
+
+  * PR to introduce max_response_size: https://github.com/ruby/net-imap/pull/442
+    * Specific commit: [0ae8576c1 - lib/net/imap/response_reader.rb](https://github.com/ruby/net-imap/pull/444/commits/0ae8576c1a90bcd9573f81bdad4b4b824642d105#diff-53721cb4d9c3fb86b95cc8476ca2df90968ad8c481645220c607034399151462)
+  * Backport to 0.4: https://github.com/ruby/net-imap/pull/445
+  * Backport to 0.3: https://github.com/ruby/net-imap/pull/446
+  * Backport to 0.2: https://github.com/ruby/net-imap/pull/447
+cvss_v4: 6.0
+patched_versions:
+  - "~> 0.2.5"
+  - "~> 0.3.9"
+  - "~> 0.4.20"
+  - ">= 0.5.7"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-43857
+    - https://github.com/ruby/net-imap/security/advisories/GHSA-j3g3-5qv5-52mj
+    - https://github.com/ruby/net-imap/pull/442
+    - https://github.com/ruby/net-imap/pull/444/commits/0ae8576c1a90bcd9573f81bdad4b4b824642d105#diff-53721cb4d9c3fb86b95cc8476ca2df90968ad8c481645220c607034399151462
+    - https://github.com/ruby/net-imap/pull/445
+    - https://github.com/ruby/net-imap/pull/446
+    - https://github.com/ruby/net-imap/pull/447
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-43857
+    - https://github.com/advisories/GHSA-j3g3-5qv5-52mj

--- a/gems/net-imap/CVE-2025-43857.yml
+++ b/gems/net-imap/CVE-2025-43857.yml
@@ -120,3 +120,4 @@ related:
     - https://github.com/ruby/net-imap/pull/447
     - https://nvd.nist.gov/vuln/detail/CVE-2025-43857
     - https://github.com/advisories/GHSA-j3g3-5qv5-52mj
+    - https://hackerone.com/reports/3108869

--- a/gems/rexml/CVE-2024-43398.yml
+++ b/gems/rexml/CVE-2024-43398.yml
@@ -49,5 +49,6 @@ related:
     - https://github.com/ruby/rexml/security/advisories/GHSA-vmwr-mc7x-5vc3
     - https://github.com/ruby/rexml/commit/7cb5eaeb221c322b9912f724183294d8ce96bae3
     - https://github.com/ruby/rexml/releases/tag/v3.3.6
+    - https://hackerone.com/reports/3002543
     - https://hackerone.com/reports/2666849
     - https://github.com/advisories/GHSA-vmwr-mc7x-5vc3


### PR DESCRIPTION
GHSA SYNC: 1 brand new and 4 modified advisories:
 * New: gems/net-imap/CVE-2025-43857.yml

 * Modified (mostly additional hackerone references)
    * gems/rexml/CVE-2024-43398.yml
    * gems/cgi/CVE-2025-27219.yml
    * gems/activestorage/CVE-2024-26144.yml
    * gems/net-imap/CVE-2025-25186.yml
