### PR TITLE
Add advisory CVE-2025-49007 / GHSA-47m2-26rw-j2jw for rack

### DIFF
--- a/gems/rack/CVE-2025-49007.yml
+++ b/gems/rack/CVE-2025-49007.yml
@@ -1,39 +1,14 @@
 ---
-gem: rack
-cve: 2025-49007
-ghsa: 47m2-26rw-j2jw
-url: https://github.com/rack/rack/security/advisories/GHSA-47m2-26rw-j2jw
-title: ReDoS Vulnerability in Rack::Multipart handle_mime_head
+title: "ReDoS Vulnerability in Rack::Multipart handle_mime_head"
 date: 2025-06-05
 description: |
-  ### Summary
-
-  There is a denial of service vulnerability in the
-  Content-Disposition parsing component of Rack. This is very
-  similar to the previous security issue CVE-2022-44571.
-
-  ### Details
-
-  Carefully crafted input can cause Content-Disposition header
-  parsing in Rack to take an unexpected amount of time, possibly
-  resulting in a denial of service attack vector. This header is
-  used typically used in multipart parsing. Any applications that
-  parse multipart posts using Rack (virtually all Rails applications)
-  are impacted.
-
-  ### Credits
-
-  Thanks to [scyoon](https://hackerone.com/scyoon) for reporting
-  this to the Rails security team
-cvss_v4: 6.6
-unaffected_versions:
-  - "< 3.1.0"
-patched_versions:
-  - ">= 3.1.16"
-related:
-  url:
-    - https://nvd.nist.gov/vuln/detail/CVE-2025-49007
-    - https://github.com/rack/rack/security/advisories/GHSA-47m2-26rw-j2jw
-    - https://github.com/rack/rack/commit/4795831a0a310c2d31102749e551b38faab6401f
-    - https://github.com/rack/rack/commit/aed514df37e33907df3c971ed3ca9a0a20ac2901
-    - https://github.com/advisories/GHSA-47m2-26rw-j2jw
+  A regular-expression denial-of-service (ReDoS) vulnerability exists in
+  Rack::Multipart’s `handle_mime_head` when parsing certain headers.
+  See upstream GHSA for full details.
+cve: CVE-2025-49007
+ghsa: GHSA-47m2-26rw-j2jw
+url: https://github.com/rack/rack/security/advisories/GHSA-47m2-26rw-j2jw
+criticality: Unknown
+gem: rack
+vulnerable_versions: "< 3.1.16"
+patched_versions: ">= 3.1.16"


### PR DESCRIPTION
This PR adds a new advisory for Rack 3.1.15: a ReDoS in Multipart.handle_mime_head, patched in 3.1.16.