### PR TITLE
New ruby-lang.com-based advisory

### DIFF
--- a/gems/resolv/CVE-2025-24294.yml
+++ b/gems/resolv/CVE-2025-24294.yml
@@ -1,0 +1,46 @@
+---
+gem: resolv
+cve: 2025-24294
+url: https://www.ruby-lang.org/en/news/2025/07/08/dos-resolv-cve-2025-24294
+title: Possible Denial of Service in resolv gem
+date: 2025-07-09
+description: |
+  A denial of service vulnerability has been discovered in the
+  resolv gem bundled with Ruby.
+  This vulnerability has been assigned the CVE identifier
+  CVE-2025-24294. We recommend upgrading the resolv gem.
+
+  ## Details
+  The vulnerability is caused by an insufficient check on the
+  length of a decompressed domain name within a DNS packet.
+
+  An attacker can craft a malicious DNS packet containing a highly
+  compressed domain name. When the resolv library parses such a
+  packet, the name decompression process consumes a large amount
+  of CPU resources, as the library does not limit the resulting
+  length of the name.
+
+  This resource consumption can cause the application thread to
+  become unresponsive, resulting in a Denial of Service condition.
+
+  ## Affected Version
+  The vulnerability affects the resolv gem bundled with the
+  following Ruby series:
+  * Ruby 3.2 series: resolv version 0.2.2 and earlier
+  * Ruby 3.3 series: resolv version 0.3.0
+  * Ruby 3.4 series: resolv version 0.6.1 and earlier
+
+  ## Credits
+  Thanks to Manu for discovering this issue.
+
+  ## History
+  Originally published at 2025-07-08 07:00:00 (UTC)
+patched_versions:
+  - "~> 0.2.2"
+  - "~> 0.3.0"
+  - ">= 0.6.1"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2025/07/08/dos-resolv-cve-2025-24294
+    - https://rubygems.org/gems/resolv
+    - https://www.cve.org/CVERecord?id=CVE-2025-24294


### PR DESCRIPTION
New ruby-lang-based advisory: gems/resolv/CVE-2025-24294