### PR TITLE
GHSA SYNC: Update old advisory to match GHSA DB

### DIFF
--- a/gems/spree/CVE-2013-1656.yml
+++ b/gems/spree/CVE-2013-1656.yml
@@ -2,11 +2,11 @@
 gem: spree
 cve: 2013-1656
 ghsa: jxx8-v83v-rhw3
-url: https://blog.convisoappsec.com/en/spree-commerce-multiple-unsafe-reflection-vulnerabilities-cve-2013-1656
+url: https://github.com/advisories/GHSA-jxx8-v83v-rhw3
 title: Spree controller Parameter Arbitrary Ruby Object Instantiation Command Execution
 date: 2013-02-21
 description: |
-  Spree Commerce 1.0.x through 1.3.2 allows remote authenticated
+  Spree Commerce 1.0.x before 2.0.0.rc1 allows remote authenticated
   administrators to instantiate arbitrary Ruby objects and executd
   arbitrary commands via the
   (1) payment_method parameter to core/app/controllers/spree/admin/
@@ -18,7 +18,12 @@ description: |
       of the constantize function.
 cvss_v2: 4.3
 patched_versions:
-  - ">= 2.0.0"
+  - ">= 2.0.0.rc1"
 related:
   url:
-    - https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+    - https://nvd.nist.gov/vuln/detail/CVE-2013-1656
+    - https://github.com/spree/spree/commit/70092eb55b8be8fe5d21a7658b62da658612fba7
+    - https://web.archive.org/web/20130907044454/https://www.conviso.com.br/advisories/CVE-2013-1656.txt
+    - https://web.archive.org/web/20140329142330/http://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+    - https://web.archive.org/web/20140618100330/http://blog.conviso.com.br/2013/03/spree-commerce-multiple-unsafe.html
+    - https://github.com/advisories/GHSA-jxx8-v83v-rhw3


### PR DESCRIPTION
GHSA SYNC: Update old advisory to match GHSA DB
 * gems/spree/CVE-2013-1656.yml
 
 This also covered PR#702.