### PR TITLE
GHSA SYNC: 7 brand new advisories

### DIFF
--- a/gems/lodash-rails/CVE-2018-16487.yml
+++ b/gems/lodash-rails/CVE-2018-16487.yml
@@ -1,0 +1,32 @@
+---
+gem: lodash-rails
+cve: 2018-16487
+ghsa: 4xc9-xhrj-v574
+url: https://github.com/advisories/GHSA-4xc9-xhrj-v574
+title: Prototype Pollution in lodash
+date: 2019-02-07
+description: |
+  Versions of `lodash` before 4.17.11 are vulnerable to
+  prototype pollution.
+
+  The vulnerable functions are 'defaultsDeep', 'merge', and
+  'mergeWith' which allow a malicious user to modify the
+  prototype of `Object` via `{constructor: {prototype:
+  {...}}}` causing the addition or modification of an existing
+  property that will exist on all objects.
+
+  ## Recommendation
+
+  Update to version 4.17.11 or later.
+cvss_v2: 6.8
+cvss_v3: 5.6
+patched_versions:
+  - ">= 4.17.11"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-16487
+    - https://hackerone.com/reports/380873
+    - https://www.npmjs.com/advisories/782
+    - https://github.com/lodash/lodash/commit/90e6199a161b6445b01454517b40ef65ebecd2ad
+    - https://security.netapp.com/advisory/ntap-20190919-0004
+    - https://github.com/advisories/GHSA-4xc9-xhrj-v574

--- a/gems/lodash-rails/CVE-2018-3721.yml
+++ b/gems/lodash-rails/CVE-2018-3721.yml
@@ -1,0 +1,32 @@
+---
+gem: lodash-rails
+cve: 2018-3721
+ghsa: fvqr-27wr-82fm
+url: https://github.com/advisories/GHSA-fvqr-27wr-82fm
+title: Prototype Pollution in lodash
+date: 2018-07-26
+description: |
+  Versions of `lodash` before 4.17.5 are vulnerable to
+  prototype pollution.
+
+  The vulnerable functions are 'defaultsDeep', 'merge', and
+  'mergeWith' which allow a malicious user to modify the
+  prototype of `Object` via `__proto__` causing the addition
+  or modification of an existing property that will exist
+  on all objects.
+
+  ## Recommendation
+
+  Update to version 4.17.5 or later."
+cvss_v2: 4.0
+cvss_v3: 6.5
+patched_versions:
+  - ">= 4.17.5"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2018-3721
+    - https://hackerone.com/reports/310443
+    - https://www.npmjs.com/advisories/577
+    - https://github.com/lodash/lodash/commit/d8e069cc3410082e44eb18fcf8e7f3d08ebe1d4a
+    - https://security.netapp.com/advisory/ntap-20190919-0004
+    - https://github.com/advisories/GHSA-fvqr-27wr-82fm

--- a/gems/lodash-rails/CVE-2019-1010266.yml
+++ b/gems/lodash-rails/CVE-2019-1010266.yml
@@ -1,0 +1,26 @@
+---
+gem: lodash-rails
+cve: 2019-1010266
+ghsa: x5rq-j2xg-h7qm
+url: https://github.com/advisories/GHSA-x5rq-j2xg-h7qm
+title: Regular Expression Denial of Service (ReDoS) in lodash
+date: 2019-07-19
+description: |
+  lodash prior to 4.7.11 is affected by: CWE-400: Uncontrolled
+  Resource Consumption. The impact is: Denial of service. The
+  component is: Date handler. The attack vector is: Attacker
+  provides very long strings, which the library attempts
+  to match using a regular expression.
+
+  The fixed version is: 4.7.11.
+patched_versions:
+  - ">= 4.17.11"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-1010266
+    - https://github.com/lodash/lodash/issues/3359
+    - https://snyk.io/vuln/SNYK-JS-LODASH-73639
+    - https://github.com/lodash/lodash/commit/5c08f18d365b64063bfbfa686cbb97cdd6267347
+    - https://github.com/lodash/lodash/wiki/Changelog
+    - https://security.netapp.com/advisory/ntap-20190919-0004
+    - https://github.com/advisories/GHSA-x5rq-j2xg-h7qm

--- a/gems/lodash-rails/CVE-2019-10744.yml
+++ b/gems/lodash-rails/CVE-2019-10744.yml
@@ -1,0 +1,33 @@
+---
+gem: lodash-rails
+cve: 2019-10744
+ghsa: jf85-cpcp-j695
+url: https://github.com/advisories/GHSA-jf85-cpcp-j695
+title: Prototype Pollution in lodash
+date: 2019-07-10
+description: |
+  Versions of `lodash` before 4.17.12 are vulnerable to Prototype
+  Pollution.  The function `defaultsDeep` allows a malicious user
+  to modify the prototype of `Object` via
+  `{constructor: {prototype: {...}}}` causing the addition or
+  modification of an existing property that will exist on all objects.
+
+  ## Recommendation
+
+  Update to version 4.17.12 or later.
+cvss_v2: 6.4
+cvss_v3: 9.1
+patched_versions:
+  - ">= 4.17.12"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-10744
+    - https://github.com/lodash/lodash/pull/4336
+    - https://snyk.io/vuln/SNYK-JS-LODASH-450202
+    - https://www.npmjs.com/advisories/1065
+    - https://access.redhat.com/errata/RHSA-2019:3024
+    - https://support.f5.com/csp/article/K47105354
+    - https://www.oracle.com/security-alerts/cpujan2021.html
+    - https://www.oracle.com/security-alerts/cpuoct2020.html
+    - https://security.netapp.com/advisory/ntap-20191004-0005
+    - https://github.com/advisories/GHSA-jf85-cpcp-j695

--- a/gems/lodash-rails/CVE-2020-28500.yml
+++ b/gems/lodash-rails/CVE-2020-28500.yml
@@ -1,0 +1,60 @@
+---
+gem: lodash-rails
+cve: 2020-28500
+ghsa: 29mw-wpgm-hmr9
+url: https://github.com/advisories/GHSA-29mw-wpgm-hmr9
+title: Regular Expression Denial of Service (ReDoS) in lodash
+date: 2022-01-06
+description: |
+  All versions of package lodash prior to 4.17.21 are vulnerable
+  to Regular Expression Denial of Service (ReDoS) via the
+  `toNumber`, `trim` and `trimEnd` functions.
+
+  Steps to reproduce (provided by reporter Liyuan Chen):
+
+  ```
+    var lo = require('lodash');
+
+    function build_blank(n) {
+       var ret = "1"
+       for (var i = 0; i < n; i++) {
+           ret += " "
+       }
+       return ret + "1";
+   }
+   var s = build_blank(50000) var time0 = Date.now();
+   lo.trim(s)
+   var time_cost0 = Date.now() - time0;
+   console.log("time_cost0: " + time_cost0);
+   var time1 = Date.now();
+   lo.toNumber(s) var time_cost1 = Date.now() - time1;
+   console.log("time_cost1: " + time_cost1);
+   var time2 = Date.now();
+   lo.trimEnd(s);
+   var time_cost2 = Date.now() - time2;
+   console.log("time_cost2: " + time_cost2);
+  ```
+cvss_v2: 5.0
+cvss_v3: 5.3
+patched_versions:
+  - ">= 4.17.21"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-28500
+    - https://github.com/lodash/lodash/pull/5065
+    - https://github.com/lodash/lodash/pull/5065/commits/02906b8191d3c100c193fe6f7b27d1c40f200bb7
+    - https://github.com/lodash/lodash/blob/npm/trimEnd.js
+    - https://snyk.io/vuln/SNYK-JS-LODASH-1018905
+    - https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074896
+    - https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074894
+    - https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074892
+    - https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074895
+    - https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074893
+    - https://www.oracle.com//security-alerts/cpujul2021.html
+    - https://www.oracle.com/security-alerts/cpuoct2021.html
+    - https://www.oracle.com/security-alerts/cpujan2022.html
+    - https://www.oracle.com/security-alerts/cpujul2022.html
+    - https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf
+    - https://github.com/lodash/lodash/commit/c4847ebe7d14540bb28a8b932a9ce1b9ecbfee1a
+    - https://security.netapp.com/advisory/ntap-20210312-0006
+    - https://github.com/advisories/GHSA-29mw-wpgm-hmr9

--- a/gems/lodash-rails/CVE-2020-8203.yml
+++ b/gems/lodash-rails/CVE-2020-8203.yml
@@ -1,0 +1,37 @@
+---
+gem: lodash-rails
+cve: 2020-8203
+ghsa: p6mc-m468-83gw
+url: https://github.com/advisories/GHSA-p6mc-m468-83gw
+title: Prototype Pollution in lodash
+date: 2020-07-15
+description: |
+  Versions of lodash prior to 4.17.19 are vulnerable to Prototype
+  Pollution. The functions `pick`, `set`, `setWith`, `update`,
+  `updateWith`, and `zipObjectDeep` allow a malicious user to
+  modify the prototype of Object if the property identifiers are
+  user-supplied. Being affected by this issue requires manipulating
+  objects based on user-provided property values or arrays.
+
+  This vulnerability causes the addition or modification of an
+  existing property that will exist on all objects and may lead to
+  Denial of Service or Code Execution under specific circumstances.
+cvss_v2: 5.8
+cvss_v3: 7.4
+unaffected_versions:
+  - "< 3.7.0"
+patched_versions:
+  - ">= 4.17.19"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-8203
+    - https://hackerone.com/reports/712065
+    - https://github.com/lodash/lodash/issues/4744
+    - https://github.com/lodash/lodash/commit/c84fe82760fb2d3e03a63379b297a1cc1a2fce12
+    - https://github.com/lodash/lodash/issues/4874
+    - https://github.com/github/advisory-database/pull/2884
+    - https://hackerone.com/reports/864701
+    - https://github.com/lodash/lodash/wiki/Changelog#v41719
+    - https://web.archive.org/web/20210914001339/https://github.com/lodash/lodash/issues/4744
+    - https://security.netapp.com/advisory/ntap-20200724-0006
+    - https://github.com/advisories/GHSA-p6mc-m468-83gw

--- a/gems/lodash-rails/CVE-2021-23337.yml
+++ b/gems/lodash-rails/CVE-2021-23337.yml
@@ -1,0 +1,33 @@
+---
+gem: lodash-rails
+cve: 2021-23337
+ghsa: 35jh-r3h4-6jhm
+url: https://github.com/advisories/GHSA-35jh-r3h4-6jhm
+title: Command Injection in lodash
+date: 2021-05-06
+description: |
+  lodash versions prior to 4.17.21 are vulnerable to
+  Command Injection via the template function.
+cvss_v2: 6.5
+cvss_v3: 7.2
+patched_versions:
+  - ">= 4.17.21"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-23337
+    - https://github.com/lodash/lodash/commit/3469357cff396a26c363f8c1b5a91dde28ba4b1c
+    - https://snyk.io/vuln/SNYK-JS-LODASH-1040724
+    - https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js#L14851
+    - https://github.com/lodash/lodash/blob/ddfd9b11a0126db2302cb70ec9973b66baec0975/lodash.js
+    - https://snyk.io/vuln/SNYK-JAVA-ORGFUJIONWEBJARS-1074932
+    - https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARS-1074930
+    - https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWER-1074928
+    - https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSBOWERGITHUBLODASH-1074931
+    - https://snyk.io/vuln/SNYK-JAVA-ORGWEBJARSNPM-1074929
+    - https://www.oracle.com//security-alerts/cpujul2021.html
+    - https://www.oracle.com/security-alerts/cpuoct2021.html
+    - https://www.oracle.com/security-alerts/cpujan2022.html
+    - https://www.oracle.com/security-alerts/cpujul2022.html
+    - https://cert-portal.siemens.com/productcert/pdf/ssa-637483.pdf
+    - https://security.netapp.com/advisory/ntap-20210312-0006
+    - https://github.com/advisories/GHSA-35jh-r3h4-6jhm


### PR DESCRIPTION
GHSA SYNC: 7 brand new advisories:
 * gems/lodash-rails/CVE-2018-16487.yml
 * gems/lodash-rails/CVE-2018-3721.yml
 * gems/lodash-rails/CVE-2019-1010266.yml
 * gems/lodash-rails/CVE-2019-10744.yml
 * gems/lodash-rails/CVE-2020-28500.yml
 * gems/lodash-rails/CVE-2020-8203.yml
 * gems/lodash-rails/CVE-2021-23337.yml
