### PR TITLE
GHSA SYNC: 2 brand new advisories

### DIFF
--- a/gems/activerecord/CVE-2025-55193.yml
+++ b/gems/activerecord/CVE-2025-55193.yml
@@ -1,0 +1,37 @@
+---
+gem: activerecord
+framework: rails
+cve: 2025-55193
+ghsa: 76r7-hhxj-r776
+url: https://github.com/rails/rails/security/advisories/GHSA-76r7-hhxj-r776
+title: Active Record logging vulnerable to ANSI escape injection
+date: 2025-08-13
+description: |
+  This vulnerability has been assigned the CVE identifier CVE-2025-55193
+
+  ### Impact
+
+  The ID passed to `find` or similar methods may be logged without
+  escaping. If this is directly to the terminal, it may include
+  unescaped ANSI sequences.
+
+  ### Releases
+
+  The fixed releases are available at the normal locations.
+
+  ### Credits
+
+  Thanks to [lio346](https://hackerone.com/lio346) for reporting
+  this vulnerability.
+patched_versions:
+  - "~> 7.1.5.2"
+  - "~> 7.2.2.2"
+  - ">= 8.0.2.1"
+related:
+  url:
+    - https://github.com/rails/rails/security/advisories/GHSA-76r7-hhxj-r776
+    - https://github.com/rails/rails/commit/3beef20013736fd52c5dcfdf061f7999ba318290
+    - https://github.com/rails/rails/commit/568c0bc2f1e74c65d150a84b89a080949bf9eb9b
+    - https://github.com/rails/rails/commit/6a944ca4805e72050a0fbb1a461534eb760d3202
+    - https://cert.kenet.or.ke/cve-2025-55193-ruby-rails-ansi-sequence-injection-vulnerability
+    - https://github.com/advisories/GHSA-76r7-hhxj-r776

--- a/gems/activestorage/CVE-2025-24293.yml
+++ b/gems/activestorage/CVE-2025-24293.yml
@@ -1,0 +1,70 @@
+---
+gem: activestorage
+cve: 2025-24293
+ghsa: r4mg-4433-c7g3
+url: https://github.com/rails/rails/security/advisories/GHSA-r4mg-4433-c7g3
+title: Active Storage allowed transformation methods that were
+  potentially unsafe
+date: 2025-08-14
+description: |
+  Active Storage attempts to prevent the use of potentially unsafe
+  image transformation methods and parameters by default.
+  The default allowed list contains three methods allowing for the
+  circumvention of the safe defaults which enables potential command
+  injection vulnerabilities in cases where arbitrary user supplied
+  input is accepted as valid transformation methods or parameters.
+
+  This has been assigned the CVE identifier CVE-2025-24293.
+
+  Versions Affected:  >= 5.2.0
+  Not affected:       < 5.2.0
+  Fixed Versions:     7.1.5.2, 7.2.2.2, 8.0.2.1
+
+  ## Impact
+
+  This vulnerability impacts applications that use Active Storage
+  with the image_processing processing gem in addition to
+  mini_magick as the image processor.
+
+  Vulnerable code will look something similar to this:
+
+  ```
+  <= image_tag blob.variant(params[:t] => params[:v]) >
+  ```
+
+  Where the transformation method or its arguments are untrusted
+  arbitrary input.
+
+  All users running an affected release should either upgrade or
+  use one of the workarounds immediately.
+
+  ## Releases
+
+  The fixed releases are available at the normal locations.
+
+  ## Workarounds
+
+  Consuming user supplied input for image transformation methods
+  or their parameters is unsupported behavior and should be
+  considered dangerous.
+
+  Strict validation of user supplied methods and parameters should
+  be performed as well as having a strong
+  [ImageMagick security policy](https://imagemagick.org/script/security-policy.php) deployed.
+
+  ## Credits
+
+  Thank you [lio346](https://hackerone.com/lio346) for reporting this!
+unaffected_versions:
+  - "< 5.20"
+patched_versions:
+  - "~> 7.1.5.2"
+  - "~> 7.2.2.2"
+  - ">= 8.0.2.1"
+related:
+  url:
+    - https://github.com/rails/rails/security/advisories/GHSA-r4mg-4433-c7g3
+    - https://github.com/rails/rails/commit/1b1adf6ee6ca0f3104fcfce79360b2ec1e06a354
+    - https://github.com/rails/rails/commit/2d612735ac0d9712fdfffaf80afa627e7295f6ce
+    - https://github.com/rails/rails/commit/fb8f3a18c3d97524c0efc29150d1e5f3162fbb13
+    - https://github.com/advisories/GHSA-r4mg-4433-c7g3


### PR DESCRIPTION
GHSA SYNC: 2 brand new advisories:
 * gems/activerecord/CVE-2025-55193.yml
 * gems/activestorage/CVE-2025-24293.yml