### PR TITLE
Some misc cleanup work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ gem 'rspec',   '~> 3.0'
 group :development do
   gem 'pry'
   gem 'nokogiri',      '~> 1.0'
-  gem 'activesupport', '~> 7.0'
+  gem 'activesupport', '~> 8.0'
 end

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ patched_versions:
 
 * `gem` \[String\] (required): Name of the affected gem.
 * `library` \[String\] (optional): Name of the ruby library which the affected gem belongs to.
-* `framework` \[String\] (optional): Name of the framework which the affected gem belongs to.
+* `framework` \[String\] (optional): Name of the framework which the affected gem belongs to. (e.g. rails)
 * `platform` \[String\] (optional): If this vulnerability is platform-specific, name of platform this vulnerability affects (e.g. jruby)
 * `cve` \[String\] (optional): Common Vulnerabilities and Exposures (CVE) ID.
 * `osvdb` \[Integer\] (optional): Open Sourced Vulnerability Database (OSVDB) ID.

--- a/gems/karo/CVE-2014-10075.yml
+++ b/gems/karo/CVE-2014-10075.yml
@@ -1,12 +1,9 @@
 ---
 gem: karo
-library: rubygems
-framework: rubygems
-platform: rubygems
 cve: 2014-10075
 osvdb: 108573
 ghsa: qfwq-chf4-jvwg
-url: https://nvd.nist.gov/vuln/detail/CVE-2014-10075
+url: https://github.com/advisories/GHSA-qfwq-chf4-jvwg
 title: karo Gem for Ruby db.rb Metacharacter Handling Remote Command Execution
 date: 2014-06-30
 description: |
@@ -21,13 +18,13 @@ description: |
     in a Command ('Command Injection')
 
   * Severity: CRITICAL - CVSS_V3 - CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+cvss_v2: 7.5
 cvss_v3: 9.8
+notes: "Never patched"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2014-10075
-    - http://www.vapid.dhs.org/advisories/karo-2.3.8.html
     - http://www.vapidlabs.com/advisory.php?v=63
-    - http://osvdb.org/show/osvdb/108573
-    - https://github.com/advisories/GHSA-qf67-vmxx-gp4jGHSA-qfwq-chf4-jvwg.json
     - https://github.com/rahult/karo
     - https://github.com/rahult/karo/blob/master/CHANGELOG.md
+    - https://github.com/advisories/GHSA-qfwq-chf4-jvwg


### PR DESCRIPTION
Some misc cleanup work
  * Upgraded activesupport gem to 8.0.x
  * Added "e.g" (example) text to README for framework: field.
  * Updated CVE-2014-10075 advisory to current standards. Removed dead links.