### PR TITLE
Updated CVE-2014-10075 advisory to current standards; Removed/replaced dead links

### DIFF
--- a/gems/karo/CVE-2014-10075.yml
+++ b/gems/karo/CVE-2014-10075.yml
@@ -29,5 +29,4 @@ related:
     - https://web.archive.org/web/20250421021935/http://www.vapid.dhs.org/advisories/karo-2.3.8.html
     - http://www.vapidlabs.com/advisory.php?v=63
     - https://www.openwall.com/lists/oss-security/2014/07/07/22
-    - https://rubysec.com/advisories/OSVDB-108573
     - https://github.com/advisories/GHSA-qfwq-chf4-jvwg


### PR DESCRIPTION
Updated CVE-2014-10075 advisory to current standards; Removed/replaced dead links.