### PR TITLE
Added CKEditor 4 vulnerabilities

### DIFF
--- a/gems/ckeditor/CVE-2020-27193.yml
+++ b/gems/ckeditor/CVE-2020-27193.yml
@@ -1,0 +1,24 @@
+---
+gem: ckeditor
+cve: 2020-27193
+ghsa: 4m44-5j2g-xf64
+url: https://ckeditor.com/blog/CKEditor-4.15.1-with-a-security-patch-released/
+title: Improper Neutralization of Input During Web Page Generation in CKEditor4
+date: 2022-05-24
+description: |
+  A cross-site scripting (XSS) vulnerability in the Color Dialog plugin
+  for CKEditor 4.15.0 allows remote attackers to run arbitrary web script after persuading
+  a user to copy and paste crafted HTML code into one of editor inputs.
+cvss_v3: 6.1
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2020-27193
+  - https://ckeditor.com/blog/CKEditor-4.15.1-with-a-security-patch-released/
+  - https://ckeditor.com/cke4/release/CKEditor-4.15.1
+  - https://ckeditor.com/ckeditor-4/download/
+  - https://www.oracle.com//security-alerts/cpujul2021.html
+  - https://www.oracle.com/security-alerts/cpuApr2021.html
+  - https://www.oracle.com/security-alerts/cpuoct2021.html
+  - https://github.com/advisories/GHSA-4m44-5j2g-xf64

--- a/gems/ckeditor/CVE-2020-9281.yml
+++ b/gems/ckeditor/CVE-2020-9281.yml
@@ -1,0 +1,27 @@
+---
+gem: ckeditor
+cve: 2020-9281
+ghsa: vcjf-mgcg-jxjq
+url: https://github.com/ckeditor/ckeditor4
+title: CKEditor 4.0 vulnerability in the HTML Data Processor
+date: 2021-05-07
+description: |
+  A cross-site scripting (XSS) vulnerability in the HTML Data Processor
+  for CKEditor 4.0 before 4.14.0 allows remote attackers to inject arbitrary web script
+  through a crafted "protected" comment (with the cke_protected syntax).
+cvss_v3: 6.1
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2020-9281
+  - https://github.com/ckeditor/ckeditor4
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/7OJ4BSS3VEAEXPNSOOUAXX6RDNECGZNO/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/L322YA73LCV3TO7ORY45WQDAFJVNKXBE/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/M4HHYQ6N452XTCIROFMJOTYEUWSB6FR4/
+  - https://www.oracle.com/security-alerts/cpujan2021.html
+  - https://www.oracle.com/security-alerts/cpuoct2020.html
+  - https://www.oracle.com/security-alerts/cpuApr2021.html
+  - https://www.oracle.com/security-alerts/cpuoct2021.html
+  - https://www.oracle.com/security-alerts/cpujan2022.html
+  - https://github.com/advisories/GHSA-vcjf-mgcg-jxjq

--- a/gems/ckeditor/CVE-2021-26271.yml
+++ b/gems/ckeditor/CVE-2021-26271.yml
@@ -1,0 +1,40 @@
+---
+gem: ckeditor
+cve: 2021-26271
+ghsa: f6rf-9m92-x2hh
+url: https://github.com/ckeditor/ckeditor4/blob/master/CHANGES.md#ckeditor-416
+title: Regular expression Denial of Service in dialog plugin
+date: 2021-01-26
+description: |
+  ## Affected packages
+
+  The vulnerability has been discovered and fixed in the [dialog](https://ckeditor.com/cke4/addon/dialog) plugin. Packages indirectly affected by the issue having dialog plugin dependency:
+
+  - [Link](https://ckeditor.com/cke4/addon/link)
+  - [Image](https://ckeditor.com/cke4/addon/image)
+  - [Enhanced Image](https://ckeditor.com/cke4/addon/image2)
+  - [Code Snippet](https://ckeditor.com/cke4/addon/codesnippet)
+  - [Iframe Dialog](https://ckeditor.com/cke4/addon/iframe)
+
+  ## Impact
+
+  A potential vulnerability has been discovered in CKEditor 4 dialog plugin. The vulnerability allowed to abuse a dialog input validator regular expression, which could cause a significant performance drop resulting in a browser tab freeze. It affects all users using the CKEditor 4 plugins listed above at version < 4.18.0.
+
+  ## Patches
+
+  The problem has been recognized and patched. The fix will be available in version 4.18.0.
+
+  ## For more information
+
+  Email us at security@cksource.com if you have any questions or comments about this advisory.
+
+  ## Acknowledgements
+
+  This issue was discovered by the CKEditor 4 team during our regular security audit.
+patched_versions:
+  - ">= 5.1.2"
+cvss_v3: 6.5
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/blob/major/CHANGES.md#ckeditor-416
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-f6rf-9m92-x2hh

--- a/gems/ckeditor/CVE-2021-26272.yml
+++ b/gems/ckeditor/CVE-2021-26272.yml
@@ -1,0 +1,23 @@
+---
+gem: ckeditor
+cve: 2021-26272
+ghsa: wpvm-wqr4-p7cw
+url: https://ckeditor.com/blog/CKEditor-4.16-with-improved-image-pasting-High-Contrast-support-and-a-new-color-API/#security-comes-first
+title: Inclusion of Functionality from Untrusted Control Sphere in CKEditor 4
+date: 2021-10-13
+description: |
+  It was possible to execute a ReDoS-type attack inside CKEditor 4 before
+  4.16 by persuading a victim to paste crafted URL-like text into the editor, and
+  then press Enter or Space (in the Autolink plugin).
+cvss_v3: 6.5
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-26272
+  - https://ckeditor.com/blog/CKEditor-4.16-with-improved-image-pasting-High-Contrast-support-and-a-new-color-API/#security-comes-first
+  - https://github.com/ckeditor/ckeditor4/blob/major/CHANGES.md#ckeditor-416
+  - https://www.oracle.com//security-alerts/cpujul2021.html
+  - https://www.oracle.com/security-alerts/cpuoct2021.html
+  - https://www.oracle.com/security-alerts/cpujan2022.html
+  - https://github.com/advisories/GHSA-wpvm-wqr4-p7cw

--- a/gems/ckeditor/CVE-2021-32808.yml
+++ b/gems/ckeditor/CVE-2021-32808.yml
@@ -1,0 +1,39 @@
+---
+gem: ckeditor
+cve: 2021-32808
+ghsa: 6226-h7ff-ch6c
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-6226-h7ff-ch6c
+title: Widget feature vulnerability allowing to execute JavaScript code using undo
+  functionality
+date: 2021-08-23
+description: |
+  ### Affected packages
+  The vulnerability has been discovered in [Widget](https://ckeditor.com/cke4/addon/clipboard) plugin if used alongside [Undo](https://ckeditor.com/cke4/addon/undo) feature.
+
+  ### Impact
+  A potential vulnerability has been discovered in CKEditor 4 [Widget](https://ckeditor.com/cke4/addon/widget) package. The vulnerability allowed to abuse undo functionality using malformed widget HTML, which could result in executing JavaScript code. It affects all users using the CKEditor 4 plugins listed above at version >= 4.13.0.
+
+  ### Patches
+  The problem has been recognized and patched. The fix will be available in version 4.16.2.
+
+  ### For more information
+  Email us at security@cksource.com if you have any questions or comments about this advisory.
+
+  ### Acknowledgements
+  The CKEditor 4 team would like to thank Anton Subbotin ([skavans](https://github.com/skavans)) for recognizing and reporting this vulnerability.
+cvss_v3: 7.6
+unaffected_versions:
+- "< 5.1.2"
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-6226-h7ff-ch6c
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-32808
+  - https://github.com/ckeditor/ckeditor4/releases/tag/4.16.2
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/NYA354LJP47KCVJMTUO77ZCX3ZK42G3T/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UVOYN2WKDPLKCNILIGEZM236ABQASLGW/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WAGNWHFIQAVCP537KFFS2A2GDG66J7XD/
+  - https://www.oracle.com/security-alerts/cpuoct2021.html
+  - https://www.oracle.com/security-alerts/cpujan2022.html
+  - https://github.com/advisories/GHSA-6226-h7ff-ch6c

--- a/gems/ckeditor/CVE-2021-32809.yml
+++ b/gems/ckeditor/CVE-2021-32809.yml
@@ -1,0 +1,46 @@
+---
+gem: ckeditor
+cve: 2021-32809
+ghsa: 7889-rm5j-hpgg
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-7889-rm5j-hpgg
+title: Clipboard feature vulnerability allowing to inject arbitrary HTML into the
+  editor using paste functionality
+date: 2021-08-23
+description: |
+  ### Affected packages
+  The vulnerability has been discovered in [clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin. All plugins with [clipboard](https://ckeditor.com/cke4/addon/clipboard) plugin dependency are affected:
+
+  * [clipboard](https://ckeditor.com/cke4/addon/clipboard)
+  * [pastetext](https://ckeditor.com/cke4/addon/pastetext)
+  * [pastetools](https://ckeditor.com/cke4/addon/pastetools)
+  * [widget](https://ckeditor.com/cke4/addon/widget)
+  * [uploadwidget](https://ckeditor.com/cke4/addon/uploadwidget)
+  * [autolink](https://ckeditor.com/cke4/addon/autolink)
+  * [tableselection](https://ckeditor.com/cke4/addon/tableselection)
+
+  ### Impact
+  A potential vulnerability has been discovered in CKEditor 4 [Clipboard](https://ckeditor.com/cke4/addon/clipboard) package. The vulnerability allowed to abuse paste functionality using malformed HTML, which could result in injecting arbitrary HTML into the editor. It affects all users using the CKEditor 4 plugins listed above at version >= 4.5.2.
+
+  ### Patches
+  The problem has been recognized and patched. The fix will be available in version 4.16.2.
+
+  ### For more information
+  Email us at security@cksource.com if you have any questions or comments about this advisory.
+
+  ### Acknowledgements
+  The CKEditor 4 team would like to thank Anton Subbotin ([skavans](https://github.com/skavans)) for recognizing and reporting this vulnerability.
+cvss_v3: 4.6
+unaffected_versions:
+- "< 4.1.2"
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-7889-rm5j-hpgg
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-32809
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/NYA354LJP47KCVJMTUO77ZCX3ZK42G3T/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UVOYN2WKDPLKCNILIGEZM236ABQASLGW/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WAGNWHFIQAVCP537KFFS2A2GDG66J7XD/
+  - https://www.oracle.com/security-alerts/cpuoct2021.html
+  - https://www.oracle.com/security-alerts/cpujan2022.html
+  - https://github.com/advisories/GHSA-7889-rm5j-hpgg

--- a/gems/ckeditor/CVE-2021-33829.yml
+++ b/gems/ckeditor/CVE-2021-33829.yml
@@ -1,0 +1,29 @@
+---
+gem: ckeditor
+cve: 2021-33829
+ghsa: rgx6-rjj4-c388
+url: https://ckeditor.com/blog/ckeditor-4.16.1-with-accessibility-enhancements/#improvements-for-comments-in-html-parser
+title: ckeditor4 vulnerable to cross-site scripting
+date: 2021-06-21
+description: |
+  A cross-site scripting (XSS) vulnerability in the HTML Data Processor
+  in CKEditor 4 4.14.0 through 4.16.x before 4.16.1 allows remote attackers to inject
+  executable JavaScript code through a crafted comment because `--!>` is mishandled.
+cvss_v3: 6.1
+unaffected_versions:
+- "< 5.1.1"
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-33829
+  - https://ckeditor.com/blog/ckeditor-4.16.1-with-accessibility-enhancements/#improvements-for-comments-in-html-parser
+  - https://www.npmjs.com/package/ckeditor4
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/NYA354LJP47KCVJMTUO77ZCX3ZK42G3T/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UVOYN2WKDPLKCNILIGEZM236ABQASLGW/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WAGNWHFIQAVCP537KFFS2A2GDG66J7XD/
+  - https://www.drupal.org/sa-core-2021-003
+  - https://lists.debian.org/debian-lts-announce/2021/11/msg00007.html
+  - https://github.com/FriendsOfPHP/security-advisories/blob/master/drupal/core/CVE-2021-33829.yaml
+  - https://github.com/FriendsOfPHP/security-advisories/blob/master/drupal/drupal/CVE-2021-33829.yaml
+  - https://github.com/advisories/GHSA-rgx6-rjj4-c388

--- a/gems/ckeditor/CVE-2021-37695.yml
+++ b/gems/ckeditor/CVE-2021-37695.yml
@@ -1,0 +1,45 @@
+---
+gem: ckeditor
+cve: 2021-37695
+ghsa: m94c-37g6-cjhc
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-m94c-37g6-cjhc
+title: Fake objects feature vulnerability allowing to execute JavaScript code using
+  malformed HTML.
+date: 2021-08-23
+description: |
+  ### Affected packages
+  The vulnerability has been discovered in [Fake Objects](https://ckeditor.com/cke4/addon/fakeobjects) plugin. All plugins with [Fake Objects](https://ckeditor.com/cke4/addon/fakeobjects) plugin dependency are affected:
+
+  * [Fake Objects](https://ckeditor.com/cke4/addon/fakeobjects)
+  * [Link](https://ckeditor.com/cke4/addon/link)
+  * [Flash](https://ckeditor.com/cke4/addon/flash)
+  * [Iframe](https://ckeditor.com/cke4/addon/iframe)
+  * [Forms](https://ckeditor.com/cke4/addon/forms)
+  * [Page Break](https://ckeditor.com/cke4/addon/pagebreak)
+
+  ### Impact
+  A potential vulnerability has been discovered in CKEditor 4 [Fake Objects](https://ckeditor.com/cke4/addon/fakeobjects) package. The vulnerability allowed to inject malformed Fake Objects HTML, which could result in executing JavaScript code. It affects all users using the CKEditor 4 plugins listed above at version < 4.16.2.
+
+  ### Patches
+  The problem has been recognized and patched. The fix will be available in version 4.16.2.
+
+  ### For more information
+  Email us at security@cksource.com if you have any questions or comments about this advisory.
+
+  ### Acknowledgements
+  The CKEditor 4 team would like to thank Mika Kulmala ([kulmik](https://github.com/kulmik)) for recognizing and reporting this vulnerability.
+cvss_v3: 7.3
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-m94c-37g6-cjhc
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-37695
+  - https://github.com/ckeditor/ckeditor4/commit/de3c001540715f9c3801aaa38a1917de46cfcf58
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/NYA354LJP47KCVJMTUO77ZCX3ZK42G3T/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UVOYN2WKDPLKCNILIGEZM236ABQASLGW/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WAGNWHFIQAVCP537KFFS2A2GDG66J7XD/
+  - https://www.oracle.com/security-alerts/cpuoct2021.html
+  - https://lists.debian.org/debian-lts-announce/2021/11/msg00007.html
+  - https://www.oracle.com/security-alerts/cpujan2022.html
+  - https://github.com/advisories/GHSA-m94c-37g6-cjhc

--- a/gems/ckeditor/CVE-2021-41164.yml
+++ b/gems/ckeditor/CVE-2021-41164.yml
@@ -1,0 +1,38 @@
+---
+gem: ckeditor
+cve: 2021-41164
+ghsa: pvmx-g8h5-cprj
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-pvmx-g8h5-cprj
+title: Advanced Content Filter (ACF) vulnerability allowing to execute JavaScript
+  code using malformed HTML
+date: 2021-11-17
+description: |
+  ### Affected packages
+  The vulnerability has been discovered in the Advanced Content Filter (ACF) module and may affect all plugins used by CKEditor 4.
+
+  ### Impact
+  A potential vulnerability has been discovered in CKEditor 4 Advanced Content Filter (ACF) core module. The vulnerability allowed to inject malformed HTML bypassing content sanitization, which could result in executing JavaScript code. It affects all users using the CKEditor 4 at version < 4.17.0.
+
+  ### Patches
+  The problem has been recognized and patched. The fix will be available in version 4.17.0.
+
+  ### For more information
+  Email us at security@cksource.com if you have any questions or comments about this advisory.
+
+  ### Acknowledgements
+  The CKEditor 4 team would like to thank Maurice Dauer ([laytonctf](https://twitter.com/laytonctf)) for recognizing and reporting this vulnerability.
+cvss_v3: 8.2
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-pvmx-g8h5-cprj
+  - https://github.com/ckeditor/ckeditor4/blob/major/CHANGES.md#ckeditor-417
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-41164
+  - https://www.drupal.org/sa-core-2021-011
+  - https://www.oracle.com/security-alerts/cpujan2022.html
+  - https://www.oracle.com/security-alerts/cpuapr2022.html
+  - https://www.oracle.com/security-alerts/cpujul2022.html
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WOZGMCYDB2OKKULFXZKM6V7JJW4ZZHJP/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VR76VBN5GW5QUBJFHVXRX36UZ6YTCMW6/
+  - https://github.com/advisories/GHSA-pvmx-g8h5-cprj

--- a/gems/ckeditor/CVE-2021-41165.yml
+++ b/gems/ckeditor/CVE-2021-41165.yml
@@ -1,0 +1,35 @@
+---
+gem: ckeditor
+cve: 2021-41165
+ghsa: 7h26-63m7-qhf2
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-7h26-63m7-qhf2
+title: HTML comments vulnerability allowing to execute JavaScript code
+date: 2021-11-17
+description: |
+  ### Affected packages
+  The vulnerability has been discovered in the core HTML processing module and may affect all plugins used by CKEditor 4.
+
+  ### Impact
+  A potential vulnerability has been discovered in CKEditor 4 HTML processing core module. The vulnerability allowed to inject malformed comments HTML bypassing content sanitization, which could result in executing JavaScript code. It affects all users using the CKEditor 4 at version < 4.17.0.
+
+  ### Patches
+  The problem has been recognized and patched. The fix will be available in version 4.17.0.
+
+  ### For more information
+  Email us at security@cksource.com if you have any questions or comments about this advisory.
+
+  ### Acknowledgements
+  The CKEditor 4 team would like to thank William Bowling ([wbowling](https://github.com/wbowling)) for recognizing and reporting this vulnerability.
+cvss_v3: 8.2
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-7h26-63m7-qhf2
+  - https://github.com/ckeditor/ckeditor4/blob/major/CHANGES.md#ckeditor-417
+  - https://nvd.nist.gov/vuln/detail/CVE-2021-41165
+  - https://www.drupal.org/sa-core-2021-011
+  - https://www.oracle.com/security-alerts/cpujan2022.html
+  - https://www.oracle.com/security-alerts/cpuapr2022.html
+  - https://www.oracle.com/security-alerts/cpujul2022.html
+  - https://github.com/advisories/GHSA-7h26-63m7-qhf2

--- a/gems/ckeditor/CVE-2022-24728.yml
+++ b/gems/ckeditor/CVE-2022-24728.yml
@@ -1,0 +1,39 @@
+---
+gem: ckeditor
+cve: 2022-24728
+ghsa: 4fc4-4p5g-6w89
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-4fc4-4p5g-6w89
+title: Cross-site Scripting in CKEditor4
+date: 2022-03-16
+description: |-
+  ### Affected packages
+  The vulnerability has been discovered in the core HTML processing module and may affect all plugins used by CKEditor 4.
+
+  ### Impact
+  A potential vulnerability has been discovered in CKEditor 4 HTML processing core module. The vulnerability allowed to inject malformed HTML bypassing content sanitization, which could result in executing JavaScript code. It affects all users using the CKEditor 4 at version < 4.18.0.
+
+  ### Patches
+  The problem has been recognized and patched. The fix will be available in version 4.18.0.
+
+  ### For more information
+  Email us at security@cksource.com if you have any questions or comments about this advisory.
+
+  ### Acknowledgements
+  The CKEditor 4 team would like to thank GHSL team member Kevin Backhouse ([@kevinbackhouse](https://github.com/kevinbackhouse)) for recognizing and reporting this vulnerability.
+cvss_v3: 5.4
+patched_versions:
+- ">= 5.1.2"
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-4fc4-4p5g-6w89
+  - https://github.com/ckeditor/ckeditor4/commit/d158413449692d920a778503502dcb22881bc949
+  - https://ckeditor.com/cke4/release/CKEditor-4.18.0
+  - https://www.drupal.org/sa-core-2022-005
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-24728
+  - https://securitylab.github.com/advisories/GHSL-2022-009_ckeditor4/
+  - https://www.oracle.com/security-alerts/cpujul2022.html
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WOZGMCYDB2OKKULFXZKM6V7JJW4ZZHJP/
+  - https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VR76VBN5GW5QUBJFHVXRX36UZ6YTCMW6/
+  - https://github.com/advisories/GHSA-4fc4-4p5g-6w89
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above

--- a/gems/ckeditor/CVE-2023-4771.yml
+++ b/gems/ckeditor/CVE-2023-4771.yml
@@ -1,0 +1,31 @@
+---
+gem: ckeditor
+cve: 2023-4771
+ghsa: wh5w-82f3-wrxh
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-wh5w-82f3-wrxh
+title: CKEditor cross-site scripting vulnerability in AJAX sample
+date: 2024-02-07
+description: |-
+  ### Affected packages
+  The vulnerability has been discovered in the AJAX sample available at the `samples/old/ajax.html` file location. All integrators that use that sample in the production code can be affected.
+
+  ### Impact
+
+  A potential vulnerability has been discovered in one of CKEditor's 4 samples that are shipped with production code. The vulnerability allowed to execute JavaScript code by abusing the AJAX sample. It affects all users using the CKEditor 4 at version < 4.24.0-lts where `samples/old/ajax.html` is used in a production environment.
+
+  ### Patches
+  The problem has been recognized and patched. The fix will be available in version 4.24.0-lts.
+
+  ### For more information
+  Email us at [security@cksource.com](mailto:security@cksource.com) if you have any questions or comments about this advisory.
+
+  ### Acknowledgements
+  The CKEditor 4 team would like to thank Rafael Pedrero and INCIBE ([original report](https://www.incibe.es/en/incibe-cert/notices/aviso/cross-site-scripting-vulnerability-cksource-ckeditor)) for recognizing and reporting this vulnerability.
+cvss_v3: 6.1
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-wh5w-82f3-wrxh
+  - https://nvd.nist.gov/vuln/detail/CVE-2023-4771
+  - https://github.com/ckeditor/ckeditor4/commit/8ed1a3c93d0ae5f49f4ecff5738ab8a2972194cb
+  - https://www.incibe.es/en/incibe-cert/notices/aviso/cross-site-scripting-vulnerability-cksource-ckeditor
+  - https://github.com/advisories/GHSA-wh5w-82f3-wrxh

--- a/gems/ckeditor/CVE-2024-24815.yml
+++ b/gems/ckeditor/CVE-2024-24815.yml
@@ -1,0 +1,36 @@
+---
+gem: ckeditor
+cve: 2024-24815
+ghsa: fq6h-4g8v-qqvm
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-fq6h-4g8v-qqvm
+title: CKEditor4 Cross-site Scripting vulnerability caused by incorrect CDATA detection
+date: 2024-02-07
+description: |-
+  ### Affected packages
+  The vulnerability has been discovered in the core HTML parsing module and may affect all editor instances that:
+  * Enabled [full-page editing](https://ckeditor.com/docs/ckeditor4/latest/features/fullpage.html) mode,
+  * or enabled [CDATA](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dtd.html#property-S-cdata) elements in [Advanced Content Filtering](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_advanced_content_filter.html) configuration (defaults to `script` and `style` elements).
+
+  ### Impact
+
+  A potential vulnerability has been discovered in CKEditor 4 HTML processing core module. The vulnerability allowed to inject malformed HTML content bypassing Advanced Content Filtering mechanism, which could result in executing JavaScript code. An attacker could abuse faulty CDATA content detection and use it to prepare an intentional attack on the editor. It affects all users using the CKEditor 4 at version < 4.24.0-lts.
+
+  ### Patches
+  The problem has been recognized and patched. The fix will be available in version 4.24.0-lts.
+
+  ### For more information
+  Email us at [security@cksource.com](mailto:security@cksource.com) if you have any questions or comments about this advisory.
+
+  ### Acknowledgements
+  The CKEditor 4 team would like to thank [Michal Frýba](https://cz.linkedin.com/in/michal-fryba) from [ALEF NULA](https://www.alefnula.com/) for recognizing and reporting this vulnerability.
+cvss_v3: 6.1
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-fq6h-4g8v-qqvm
+  - https://github.com/ckeditor/ckeditor4/commit/8ed1a3c93d0ae5f49f4ecff5738ab8a2972194cb
+  - https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dtd.html#property-S-cdata
+  - https://ckeditor.com/docs/ckeditor4/latest/features/fullpage.html
+  - https://ckeditor.com/docs/ckeditor4/latest/guide/dev_advanced_content_filter.html
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-24815
+  - https://www.drupal.org/sa-contrib-2024-009
+  - https://github.com/advisories/GHSA-fq6h-4g8v-qqvm

--- a/gems/ckeditor/CVE-2024-24816.yml
+++ b/gems/ckeditor/CVE-2024-24816.yml
@@ -1,0 +1,37 @@
+---
+gem: ckeditor
+cve: 2024-24816
+ghsa: mw2c-vx6j-mg76
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-mw2c-vx6j-mg76
+title: CKEditor4 Cross-site Scripting vulnerability in samples with enabled the preview
+  feature
+date: 2024-02-07
+description: |-
+  ### Affected packages
+  The vulnerability has been discovered in the samples that use the [preview](https://ckeditor.com/cke4/addon/preview) feature:
+
+  * `samples/old/**/*.html`
+  * `plugins/[plugin name]/samples/**/*.html`
+
+  All integrators that use these samples in the production code can be affected.
+
+  ### Impact
+
+  A potential vulnerability has been discovered in one of CKEditor's 4 samples that are shipped with production code. The vulnerability allowed to execute JavaScript code by abusing the misconfigured [preview feature](https://ckeditor.com/cke4/addon/preview). It affects all users using the CKEditor 4 at version < 4.24.0-lts with affected samples used in a production environment.
+
+  ### Patches
+  The problem has been recognized and patched. The fix will be available in version 4.24.0-lts.
+
+  ### For more information
+  Email us at [security@cksource.com](mailto:security@cksource.com) if you have any questions or comments about this advisory.
+
+  ### Acknowledgements
+  The CKEditor 4 team would like to thank [Marcin Wyczechowski](https://www.linkedin.com/in/marcin-wyczechowski-0a823795/) & [Michał Majchrowicz](https://www.linkedin.com/in/micha%C5%82-majchrowicz-mwsc/) [AFINE Team](https://afine.com/) for recognizing and reporting this vulnerability.
+cvss_v3: 6.1
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-mw2c-vx6j-mg76
+  - https://github.com/ckeditor/ckeditor4/commit/8ed1a3c93d0ae5f49f4ecff5738ab8a2972194cb
+  - https://ckeditor.com/cke4/addon/preview
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-24816
+  - https://github.com/advisories/GHSA-mw2c-vx6j-mg76

--- a/gems/ckeditor/CVE-2024-43407.yml
+++ b/gems/ckeditor/CVE-2024-43407.yml
@@ -1,0 +1,40 @@
+---
+gem: ckeditor
+cve: 2024-43407
+ghsa: 7r32-vfj5-c2jv
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-7r32-vfj5-c2jv
+title: Code Snippet GeSHi plugin in CKEditor 4 has reflected cross-site scripting
+  (XSS) vulnerability
+date: 2024-08-21
+description: |-
+  ### Affected packages
+  The vulnerability has been discovered in [Code Snippet GeSHi](https://ckeditor.com/cke4/addon/codesnippetgeshi) plugin. All integrators that use [GeSHi syntax highlighter](https://github.com/GeSHi/geshi-1.0) on the backend side can be affected.
+
+  ### Impact
+  A potential vulnerability has been discovered in CKEditor 4 [Code Snippet GeSHi](https://ckeditor.com/cke4/addon/codesnippetgeshi) plugin. The vulnerability allowed a reflected XSS attack by exploiting a flaw in the [GeSHi syntax highlighter library](https://github.com/GeSHi/geshi-1.0) hosted by the victim.
+
+  The GeSHi library was included as a vendor dependency in CKEditor 4 source files. In a specific scenario, an attacker could craft a malicious script that could be executed by sending a request to the GeSHi library hosted on a PHP web server.
+
+  ### Patches
+
+  The [GeSHi library](https://github.com/GeSHi/geshi-1.0) is no longer actively maintained. Due to the lack of ongoing support and updates, potential security vulnerabilities have been identified with its continued use. To mitigate these risks and enhance the overall security of the CKEditor 4, we have decided to completely remove the GeSHi library as a dependency. This change aims to maintain a secure environment and reduce the risk of any security incidents related to outdated or unsupported software.
+
+  To integrators who still want to use the GeSHi syntax highlighter, we recommend manually adding the [GeSHi library](https://github.com/GeSHi/geshi-1.0) . Please be aware of and understand the potential security vulnerabilities associated with its use.
+
+  The fix is be available in version 4.25.0-lts.
+
+  ### Acknowledgements
+
+  The CKEditor 4 team would like to thank [Jiasheng He](https://github.com/Hebing123) from Qihoo 360 for recognizing and reporting this vulnerability.
+
+  ### For more information
+
+  Email us at [security@cksource.com](mailto:security@cksource.com) if you have any questions or comments about this advisory.
+cvss_v3: 6.1
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-7r32-vfj5-c2jv
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-43407
+  - https://github.com/ckeditor/ckeditor4/commit/71072c9f7f263329841bd38e7e5309074c82ef94
+  - https://github.com/ckeditor/ckeditor4/commit/951e7d75fcbcaa2590b0719fb0bb0dd0539ca6fa
+  - https://github.com/advisories/GHSA-7r32-vfj5-c2jv

--- a/gems/ckeditor/CVE-2024-43411.yml
+++ b/gems/ckeditor/CVE-2024-43411.yml
@@ -1,0 +1,33 @@
+---
+gem: ckeditor
+cve: 2024-43411
+ghsa: 6v96-m24v-f58j
+url: https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-6v96-m24v-f58j
+title: CKEditor4 low-risk cross-site scripting (XSS) vulnerability linked to potential
+  domain takeover
+date: 2024-08-21
+description: |-
+  ### Affected Packages
+
+  The issue impacts only editor instances with enabled [version notifications](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-versionCheck).
+
+  Please note that this feature is disabled by default in all CKEditor 4 LTS versions. Therefore, if you use CKEditor 4 LTS, it is highly unlikely that you are affected by this vulnerability. If you are unsure, please [contact us](mailto:security@cksource.com).
+
+  ### Impact
+
+  A theoretical vulnerability has been identified in CKEditor 4.22 (and above). In a highly unlikely scenario where an attacker gains control over the https://cke4.ckeditor.com domain, they could potentially execute an attack on CKEditor 4 instances. Although the vulnerability is purely hypothetical, we have addressed it in CKEditor 4.25.0-lts to ensure compliance with security best practices.
+
+  ### Patches
+
+  The issue has been recognized and patched. The fix is available in version 4.25.0-lts.
+
+  ### For More Information
+
+  If you have any questions or comments about this advisory, please email us at [security@cksource.com](mailto:security@cksource.com).
+cvss_v3: 3.1
+related:
+  url:
+  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-6v96-m24v-f58j
+  - https://github.com/ckeditor/ckeditor4/commit/b5069c9cb769ea22eae1cbd7200f22b1cf2e3a7f
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-43411
+  - https://github.com/advisories/GHSA-6v96-m24v-f58j


### PR DESCRIPTION
Recent security scanning against one of our applications has highlighted a number of CKEditor 4 vulnerabilities we weren't originally aware of because they're not recorded in the advisory database.

I've brought these in by modifying the GitHub sync script slightly to pull in the security vulnerabilities listed on the https://github.com/ckeditor/ckeditor4 repository and then matching them against the gem version in https://github.com/galetahub/ckeditor.

Hopefully these are OK - please let me know if any further changes are required.