### PR TITLE
GHSA SYNC: cvss_v3 field and value was added

### DIFF
--- a/gems/lodash-rails/CVE-2019-1010266.yml
+++ b/gems/lodash-rails/CVE-2019-1010266.yml
@@ -13,6 +13,7 @@ description: |
   to match using a regular expression.
 
   The fixed version is: 4.7.11.
+cvss_v3: 6.5
 patched_versions:
   - ">= 4.17.11"
 related:


### PR DESCRIPTION

GHSA SYNC: cvss_v3 field and value was added
 * For  gems/lodash-rails/CVE-2019-1010266.yml
