### PR TITLE
Fixed linting for CVE-2021-2671

### DIFF
--- a/gems/ckeditor/CVE-2021-26271.yml
+++ b/gems/ckeditor/CVE-2021-26271.yml
@@ -36,5 +36,5 @@ patched_versions:
 cvss_v3: 6.5
 related:
   url:
-  - https://github.com/ckeditor/ckeditor4/blob/major/CHANGES.md#ckeditor-416
-  - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-f6rf-9m92-x2hh
+    - https://github.com/ckeditor/ckeditor4/blob/major/CHANGES.md#ckeditor-416
+    - https://github.com/ckeditor/ckeditor4/security/advisories/GHSA-f6rf-9m92-x2hh


### PR DESCRIPTION
Fixed indentation of the `related: url:` for CVE-2021-2671.