### PR TITLE
1 brand new advisory

### DIFF
--- a/gems/uri/CVE-2025-61594.yml
+++ b/gems/uri/CVE-2025-61594.yml
@@ -1,0 +1,41 @@
+---
+gem: uri
+cve: 2025-61594
+url: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594
+title: CVE-2025-61594 - URI Credential Leakage Bypass over CVE-2025-27221
+date: 2025-10-07
+description: |
+
+  In affected URI version, a bypass exists for the fix to CVE-2025-27221
+  that can expose user credentials.
+
+  This vulnerability has been assigned the CVE identifier CVE-2025-61594.
+  We recommend upgrading the uri gem.
+
+  ## Details
+
+  When using the + operator to combine URIs, sensitive information
+  like passwords from the original URI can be leaked, violating
+  RFC3986 and making applications vulnerable to credential exposure.
+
+  Please update URI gem to version 0.12.5, 0.13.3, 1.0.4 or later.
+
+  ## Affected versions
+
+  uri gem versions < 0.12.5, 0.13.0 to 0.13.2 and 1.0.0 to 1.0.3.
+
+  ## Credits
+
+  Thanks to junfuchong (chongfujun) for discovering this issue.
+  Also thanks to nobu for additional fixes of this vulnerability.
+patched_versions:
+  - "~> 0.12.5"
+  - "~> 0.13.3"
+  - ">= 1.0.4"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594
+    - https://rubygems.org/gems/uri/versions/1.0.4
+    - https://rubygems.org/gems/uri/versions/0.13.3
+    - https://rubygems.org/gems/uri/versions/0.12.5
+    - https://github.com/ruby/uri


### PR DESCRIPTION
1 brand new advisory: gems/uri/CVE-2025-61594.yml (based on ruby-lang post)