### PR TITLE
Add patched version for CVE-2018-18307 in alchemy_cms

### DIFF
--- a/gems/alchemy_cms/CVE-2018-18307.yml
+++ b/gems/alchemy_cms/CVE-2018-18307.yml
@@ -11,7 +11,8 @@ description: |
 cvss_v3: 5.9
 unaffected_versions:
 - "< 4.1.0"
-notes: Never patched
+patched_versions:
+- ">= 7.4.10"
 related:
   url:
   - https://nvd.nist.gov/vuln/detail/CVE-2018-18307
@@ -19,4 +20,6 @@ related:
   - https://github.com/AlchemyCMS/alchemy_cms/blob/4.1-stable/app/controllers/alchemy/admin/base_controller.rb#L15
   - https://github.com/AlchemyCMS/alchemy_cms/blob/4.1-stable/app/controllers/alchemy/admin/pictures_controller.rb#L5
   - https://github.com/AlchemyCMS/alchemy_cms/blob/4.1-stable/app/controllers/alchemy/admin/resources_controller.rb#L21
+  - https://github.com/AlchemyCMS/alchemy_cms/pull/3375
+  - https://github.com/AlchemyCMS/alchemy_cms/releases/tag/v7.4.10
   - https://github.com/advisories/GHSA-7mj4-2984-955f


### PR DESCRIPTION
This PR adds the patched version information for CVE-2018-18307 in AlchemyCMS.

## Summary

The stored XSS vulnerability (CVE-2018-18307) via the /admin/pictures image filename field has been fixed in AlchemyCMS v7.4.10.

## Changes

- Added `patched_versions: [">= 7.4.10"]` to the advisory
- Removed `notes: Never patched` as it's now patched
- Added references to the fixing PR and release

## References

- Fix PR: https://github.com/AlchemyCMS/alchemy_cms/pull/3375
- Release: https://github.com/AlchemyCMS/alchemy_cms/releases/tag/v7.4.10

The fix sanitizes filenames during upload to prevent malicious content from being stored and executed.