### PR TITLE
GHSA SYNC: 2 brand new advisories

### DIFF
--- a/gems/mqtt/CVE-2025-12790.yml
+++ b/gems/mqtt/CVE-2025-12790.yml
@@ -1,0 +1,22 @@
+---
+gem: mqtt
+cve: 2025-12790
+ghsa: 9c5q-w6gr-fxcq
+url: https://access.redhat.com/security/cve/CVE-2025-12790
+title: MQTT does not validate hostnames
+date: 2025-11-06
+description: |
+  A flaw was found in Rubygem MQTT. By default, the package used to
+  not have hostname validation, resulting in possible
+  Man-in-the-Middle (MITM) attack.
+cvss_v3: 7.4
+patched_versions:
+  - ">= 0.7.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-12790
+    - https://github.com/njh/ruby-mqtt/releases/tag/v0.7.0
+    - https://github.com/njh/ruby-mqtt/blob/main/NEWS.md#ruby-mqtt-version-070-2025-10-29
+    - https://access.redhat.com/security/cve/CVE-2025-12790
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2413004
+    - https://github.com/advisories/GHSA-9c5q-w6gr-fxcq

--- a/gems/prosemirror_to_html/GHSA-52c5-vh7f-26fx.yml
+++ b/gems/prosemirror_to_html/GHSA-52c5-vh7f-26fx.yml
@@ -1,0 +1,78 @@
+---
+gem: prosemirror_to_html
+ghsa: 52c5-vh7f-26fx
+url: https://github.com/etaminstudio/prosemirror_to_html/security/advisories/GHSA-52c5-vh7f-26fx
+title: Cross-Site Scripting (XSS) vulnerability through unescaped
+  HTML attribute values
+date: 2025-11-06
+description: |
+  ### Impact
+
+  The prosemirror_to_html gem is vulnerable to Cross-Site Scripting
+  (XSS) attacks through malicious HTML attribute values. While tag
+  content is properly escaped, attribute values are not, allowing
+  attackers to inject arbitrary JavaScript code.
+
+  **Who is impacted:**
+
+  - Any application using prosemirror_to_html to convert ProseMirror
+    documents to HTML
+  - Applications that process user-generated ProseMirror content are
+    at highest risk
+  - End users viewing the rendered HTML output could have malicious
+   JavaScript executed in their browsers
+
+  **Attack vectors include:**
+
+  - `href` attributes with `javascript:` protocol:
+    `<a href="javascript:alert(document.cookie)">`
+  - Event handlers: `<div onclick="maliciousCode()">`
+  - `onerror` attributes on images: `<img src=x onerror="alert('XSS')">`
+  - Other HTML attributes that can execute JavaScript
+
+  ### Patches
+
+  A fix is currently in development. Users should upgrade to version
+  **0.2.1** or later once released.
+
+  The patch escapes all HTML attribute values using `CGI.escapeHTML`
+  to prevent injection attacks.
+
+  ### Workarounds
+
+  Until a patched version is available, users can implement one or
+  more of these mitigations:
+
+  1. **Sanitize output**: Pass the HTML output through a sanitization
+     library like [Sanitize](https://github.com/rgrove/sanitize) or
+     [Loofah](https://github.com/flavorjones/loofah):
+
+  ```ruby
+     html = ProsemirrorToHtml.render(document)
+     safe_html = Sanitize.fragment(html, Sanitize::Config::RELAXED)
+  ```
+
+  2. **Implement Content Security Policy (CSP)**: Add strict CSP
+     headers to prevent inline JavaScript execution:
+  ```
+     Content-Security-Policy: default-src 'self'; script-src 'self'
+  ```
+
+  3. **Input validation**: If possible, validate and sanitize
+     ProseMirror documents before conversion to prevent malicious
+     content from entering the system.
+
+  ### References
+
+  - Vulnerable code: https://github.com/etaminstudio/prosemirror_to_html/blob/ea8beb32f6c37f29f042ba4155ccf18504da716e/lib/prosemirror_to_html.rb#L249
+  - [OWASP XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+  - [CWE-79: Improper Neutralization of Input During Web Page Generation](https://cwe.mitre.org/data/definitions/79.html)
+cvss_v3: 7.6
+patched_versions:
+  - ">= 0.2.1"
+related:
+  url:
+    - https://github.com/etaminstudio/prosemirror_to_html/security/advisories/GHSA-52c5-vh7f-26fx
+    - https://github.com/etaminstudio/prosemirror_to_html/releases/tag/v0.2.1
+    - https://github.com/etaminstudio/prosemirror_to_html/commit/4d59f94f550bcabeec30d298791bbdd883298ad8
+    - https://github.com/advisories/GHSA-52c5-vh7f-26fx


### PR DESCRIPTION
GHSA SYNC: 2 brand new advisories:
 * gems/mqtt/CVE-2025-12790.yml
 * gems/prosemirror_to_html/GHSA-52c5-vh7f-26fx.yml
