### PR TITLE
GHSA SYNC: 1 brand new advisory

### DIFF
--- a/gems/Autolab/CVE-2024-49376.yml
+++ b/gems/Autolab/CVE-2024-49376.yml
@@ -1,0 +1,33 @@
+---
+gem: Autolab
+cve: 2024-49376
+ghsa: v46j-h43h-rwrm
+url: https://github.com/autolab/Autolab/security/advisories/GHSA-v46j-h43h-rwrm
+title: Autolab Misconfigured Reset Password Permissions
+date: 2024-10-25
+description: |
+  ### Impact
+  For email-based accounts, users with insufficient privileges could reset and theoretically access privileged users' accounts by resetting their passwords.
+
+  ### Patches
+  This is fixed in v3.0.1.
+
+  ### Workarounds
+  No workarounds.
+
+  ### For more information
+  If you have any questions or comments about this advisory:
+
+  Open an issue in https://github.com/autolab/Autolab/
+  Email us at [autolab-dev@andrew.cmu.edu](mailto:autolab-dev@andrew.cmu.edu)
+cvss_v3: 8.8
+unaffected_versions:
+- "< 3.0.0"
+patched_versions:
+- ">= 3.0.1"
+related:
+  url:
+  - https://github.com/autolab/Autolab/security/advisories/GHSA-v46j-h43h-rwrm
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-49376
+  - https://github.com/autolab/Autolab/commit/301689ab5c5e39d13bab47b71eaf8998d04bcc9b
+  - https://github.com/advisories/GHSA-v46j-h43h-rwrm


### PR DESCRIPTION
## Summary
Add 1 brand new security advisory from GitHub Advisory Database.

## Advisory Added

- `Autolab/CVE-2024-49376` - Autolab Misconfigured Reset Password Permissions (CVSS: 8.8)

## Changes Made
- Verified and confirmed 'patched_versions' and 'unaffected_versions'
- Filled in 'cvss_v3' score (8.8)
- Removed GitHub advisory data as per sync manual
- Properly formatted 'related' URLs section
- All rspec tests passing

## Review Feedback Addressed
- Removed all 9 duplicate advisories identified in review
- Confirmed ruby-saml CVE-2025-66567 and CVE-2025-66568 already exist in upstream (added 2024-12-12)
- Only including genuinely new advisory for Autolab gem