### PR TITLE
fix: update CVE-2025-58767 to include Ruby 3.3 and Ruby 3.2

### DIFF
--- a/rubies/ruby/CVE-2025-58767.yml
+++ b/rubies/ruby/CVE-2025-58767.yml
@@ -13,9 +13,9 @@ description: |
   The REXML gem 3.4.2 or later include the patches to fix these vulnerabilities.
 
 patched_versions:
-  - ">= 3.4.8"
-  - "~> 3.3.10"
   - "~> 3.2.10"
+  - "~> 3.3.10"
+  - ">= 3.4.8"
 related:
   url:
     - https://github.com/rubysec/ruby-advisory-db/blob/master/gems/rexml/CVE-2025-58767.yml


### PR DESCRIPTION
It wasn't mentioned in the release notes, but https://github.com/ruby/ruby/commit/f427353653e5488d4f8da1066d07d392a42a00f2 was landed before 3.3.10 came out (https://github.com/ruby/ruby/commit/343ea050023cfc0374fdea6fdf625b2f57b716a4)

Ruby 3.2.10 has also now been released which has the backport (https://github.com/ruby/ruby/commit/d2edfe55e0cebf769c8a343788f56ea406b36286)