### PR TITLE
Temporarily pin the CI Ruby version to 3.4 for kwalify

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ruby
+          ruby-version: 3.4
       - name: Install ruby dependencies
         run: bundle install --jobs 4 --retry 3
       - name: Validate YAML


### PR DESCRIPTION
kwalify expects `StringScanner#peep` to be defined. `StrinScanner#peep` was apparently removed in Ruby 4.0. Temporarily pin the CI Ruby version to 3.4, until kwalify or `StringScanner` are fixed.