### PR TITLE
GHSA SYNC: 3 brand new advisories

### DIFF
--- a/gems/shakapacker/GHSA-96qw-h329-v5rg.yml
+++ b/gems/shakapacker/GHSA-96qw-h329-v5rg.yml
@@ -1,0 +1,91 @@
+---
+gem: shakapacker
+ghsa: 96qw-h329-v5rg
+url: https://github.com/shakacode/shakapacker/security/advisories/GHSA-96qw-h329-v5rg
+title: Shakapacker has environment variable leak via EnvironmentPlugin
+  that exposes secrets to client-side bundles
+date: 2026-01-08
+description: |
+  ### Summary
+
+  Since 2017, the default webpack plugins have passed the entire
+  `process.env` to `EnvironmentPlugin`. This pattern exposed ALL
+  build environment variables to client-side JavaScript bundles
+  whenever application code (or any dependency) referenced
+  `process.env.VARIABLE_NAME`.
+
+  This is not a regression - the vulnerable code has existed since
+  the original Webpacker implementation. No recent code change
+  in Shakapacker triggered this issue.
+
+  ### Impact
+
+  Any environment variable in the build environment that is referenced
+  in client-side code (including third-party dependencies) is embedded
+  directly into the JavaScript bundle. This includes:
+
+  - `DATABASE_URL` - Database credentials
+  - `AWS_SECRET_ACCESS_KEY` - AWS credentials
+  - `RAILS_MASTER_KEY` - Rails encrypted credentials key
+  - `STRIPE_SECRET_KEY`, `TWILIO_AUTH_TOKEN` - Third-party API keys
+  - Any other secrets present in the build environment
+
+  **Severity**: Critical - secrets are exposed in publicly accessible
+  JavaScript files.
+
+  ### Root Cause
+
+  The original code used:
+  ```javascript
+  new
+  webpack.EnvironmentPlugin(process.env)
+  ```
+
+  This makes every environment variable available for substitution. If
+  any code references `process.env.SECRET_KEY`, that value is embedded
+  in the bundle.
+
+  ### Patches
+
+  Upgrade to version 9.5.0 or later, which uses an allowlist approach
+  that only exposes `NODE_ENV`, `RAILS_ENV`, and `WEBPACK_SERVE` by default.
+
+  ### Workarounds
+
+  If developers cannot upgrade immediately:
+    1. Audit client-side code and dependencies for any `process.env.X`
+       references to sensitive variables
+    2. Remove sensitive variables from the build environment
+    3. Override the default plugins with a custom webpack/rspack
+       config using an explicit allowlist
+
+  ### Migration
+
+  After upgrading, if client-side code needs access to specific environment
+  variables:
+
+  **Option 1: Use the `SHAKAPACKER_PUBLIC_` prefix (recommended)**
+  ```bash
+  # Variables with this prefix are automatically exposed
+  export SHAKAPACKER_PUBLIC_API_URL=\"https://api.example.com\"
+  ```
+
+  **Option 2: Use `SHAKAPACKER_ENV_VARS`**
+  ```bash
+  SHAKAPACKER_ENV_VARS=API_URL,FEATURE_FLAG
+  bundle exec rails assets:precompile
+  ```
+
+  ### Action Required
+
+  After upgrading, **rotate any secrets** that may have been exposed
+  in previously compiled JavaScript bundles.
+cvss_v3: 7.5
+patched_versions:
+  - ">= 9.5.0"
+related:
+  url:
+    - https://github.com/shakacode/shakapacker/security/advisories/GHSA-96qw-h329-v5rg
+    - https://github.com/shakacode/shakapacker/pull/857
+    - https://github.com/shakacode/shakapacker/commit/3e06781b18383c5c2857ed3a722f7b91bdc1bc0e
+    - https://github.com/advisories/GHSA-96qw-h329-v5rg

--- a/gems/spree_api/CVE-2026-22588.yml
+++ b/gems/spree_api/CVE-2026-22588.yml
@@ -1,0 +1,61 @@
+---
+gem: spree_api
+cve: 2026-22588
+ghsa: g268-72p7-9j6j
+url: https://github.com/spree/spree/security/advisories/GHSA-g268-72p7-9j6j
+title: Spree API has Authenticated Insecure Direct Object Reference
+  (IDOR) via Order Modification
+date: 2026-01-08
+description: |
+  ### Summary
+
+  An Authenticated Insecure Direct Object Reference (IDOR)
+  vulnerability was identified that allows an authenticated user to
+  retrieve other users’ address information by modifying an existing order.
+  By editing an order they legitimately own and manipulating address
+  identifiers in the request, the backend server accepts and processes
+  references to addresses belonging to other users, subsequently
+  associating those addresses with the attacker’s order and returning
+  them in the response.
+
+  ### Details
+
+  Affected Component(s)
+
+  - Authenticated user order management
+  - Address association logic
+  - Order update endpoint(s)
+
+  Affected Endpoint(s):
+  - `/api/v2/storefront/checkout`
+
+  The application fails to enforce proper object-level authorization
+  when updating an existing order. While the user is authenticated and
+  authorized to modify their own order, the backend does not verify
+  that the supplied address identifiers belong to the same authenticated user.
+
+  **See reference below for POC.**
+
+  ### Impact
+
+  As a result, an attacker can:
+  - Replace the address identifier with one belonging to another user
+  - Cause the backend to associate and return another user’s address
+    within the attacker’s order"
+cvss_v3: 6.5
+unaffected_versions:
+  - "< 3.7.0"
+patched_versions:
+  - "~> 4.10.2"
+  - "~> 5.0.7"
+  - "~> 5.1.9"
+  - ">= 5.2.5"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-22588
+    - https://github.com/spree/spree/security/advisories/GHSA-g268-72p7-9j6j
+    - https://github.com/spree/spree/commit/02acabdce2c5f14fd687335b068d901a957a7e72
+    - https://github.com/spree/spree/commit/17e78a91b736b49dbea8d1bb1223c284383ee5f3
+    - https://github.com/spree/spree/commit/b409c0fd327e7ce37f63238894670d07079eefe8
+    - https://github.com/spree/spree/commit/d3f961c442e0015661535cbd6eb22475f76d2dc7
+    - https://github.com/advisories/GHSA-g268-72p7-9j6j

--- a/gems/spree_core/CVE-2026-22589.yml
+++ b/gems/spree_core/CVE-2026-22589.yml
@@ -1,0 +1,75 @@
+---
+gem: spree_core
+cve: 2026-22589
+ghsa: 3ghg-3787-w2xr
+url: https://github.com/spree/spree/security/advisories/GHSA-3ghg-3787-w2xr
+title: Spree API has Unauthenticated IDOR - Guest Address
+date: 2026-01-08
+description: |
+  ### Summary
+
+  An Unauthenticated Insecure Direct Object Reference (IDOR)
+  vulnerability was identified that allows an unauthenticated attacker
+  to access guest address information without supplying valid
+  credentials or session cookies.
+
+  ###  Details
+
+  During testing, it was observed that all guest users can make an
+  unauthenticated request to retrieve address data belonging to other
+  guest users by manipulating object identifiers. The attacker would
+  need to know the storefront URL structure to perform this attack
+  (which can be learnt after creating a registered user account).
+
+  Affected Component(s)
+
+  * Address Edit endpoint: `/addresses/{addressId}/edit`
+
+  Root Cause
+  - Faulty authorization check in CanCanCan Ability class:
+
+  ```diff
+  - can :manage,  ::Spree::Address, user_id: user.id
+  + can :manage, ::Spree::Address, user_id: user.id if user.persisted?
+  ```
+
+  the `user` object in `Spree::Ability` class for guest users is
+  a `Spree.user_class.new` object.
+
+  Addresses endpoint to access it is part of the `spree_storefront`
+  gem. **Headless builds using APIs are not affected,** as the
+  Addresses endpoint there is only for registered users, and
+  records are scoped to the currently signed-in user.
+
+  ### Impact
+
+  An unauthenticated attacker can:
+
+  - Enumerate and retrieve guest address information (Addresses
+    associated with User accounts are NOT affected)
+  - Access personally identifiable information (PII) such as:
+  - Full names
+  - Physical addresses
+  - Phone numbers (if present)
+
+  This vulnerability could lead to:
+
+  - Privacy violations
+  - Regulatory compliance issues (e.g., GDPR)
+  - Loss of user trust"
+cvss_v3: 7.5
+unaffected_versions:
+  - "< 4.0.0"
+patched_versions:
+  - "~> 4.10.2"
+  - "~> 5.0.7"
+  - "~> 5.1.9"
+  - ">= 5.2.5"
+related:
+  url:
+    - https://github.com/spree/spree/security/advisories/GHSA-3ghg-3787-w2xr
+    - https://github.com/spree/spree/commit/16067def6de8e0742d55313e83b0fbab6d2fd795
+    - https://github.com/spree/spree/commit/4c2bd62326fba0d846fd9e4bad2c62433829b3ad
+    - https://github.com/spree/spree/commit/d051925778f24436b62fa8e4a6b842c72ca80a67
+    - https://github.com/spree/spree/commit/e1cff4605eb15472904602aebaf8f2d04852d6ad
+    - https://github.com/advisories/GHSA-3ghg-3787-w2xr


### PR DESCRIPTION
GHSA SYNC: 3 brand new advisories:
 * gems/shakapacker/GHSA-96qw-h329-v5rg.yml
 * gems/spree_api/CVE-2026-22588.yml
 *  gems/spree_core/CVE-2026-22589.yml
 
 CC: @postmodern 

