### PR TITLE
Update httparty CVE-2025-68696 criticality to unknown

### DIFF
--- a/gems/httparty/CVE-2025-68696.yml
+++ b/gems/httparty/CVE-2025-68696.yml
@@ -98,7 +98,7 @@ description: |
   - Leakage of credentials: If an absolute URL is provided, any API keys or credentials configured in httparty may be exposed to unintended third-party hosts.
   - SSRF (Server-Side Request Forgery): Attackers can force the httparty-based program to send requests to other internal hosts within the network where the program is running.
   - Affected users: Any software that uses `base_uri` and does not properly validate the path parameter may be affected by this issue.
-cvss_v4: 8.8
+cvss_v4: unknown
 patched_versions:
   - ">= 0.24.0"
 related:


### PR DESCRIPTION
Updated the criticality from 8.8 to unknown as per the advisory details.