### PR TITLE
GHSA SYNC: 2 brand new advisories

### DIFF
--- a/gems/ruby-jwt/CVE-2025-45765.yml
+++ b/gems/ruby-jwt/CVE-2025-45765.yml
@@ -1,0 +1,33 @@
+---
+gem: ruby-jwt
+cve: 2025-45765
+ghsa: 6ch4-944p-wf7j
+url: https://github.com/advisories/GHSA-6ch4-944p-wf7j
+title: ruby-jwt < v3.0.0.beta1 was discovered to contain weak encryption
+date: 2025-08-07
+description: |
+  ruby-jwt < v3.0.0.beta1 was discovered to contain weak encryption.
+
+  NOTE: the Supplier's perspective is "keysize is not something
+  that is enforced by this library. Currently more recent versions
+  of OpenSSL are enforcing some key sizes and those restrictions
+  apply to the users of this gem also."
+
+  ## BACKGROUND
+
+  We found that the HMAC and RSA key lengths used in your JSON Web
+  Signature (JWS) implementation do not meet recommended security
+  standards (RFC 75180NIST SP800-1170RFC 2437).
+
+  According to CWE-326 (Inadequate Encryption Strength), using keys
+  that are too short can lead to serious vulnerabilities and
+  potential attacks.
+cvss_v3: 9.1
+patched_versions:
+  - ">= 3.0.0.beta1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-45765
+    - https://github.com/advisories/GHSA-6ch4-944p-wf7j
+    - https://github.com/jwt/ruby-jwt/issues/668
+    - https://gist.github.com/ZupeiNie/c621253068ce5b64911629534879e8f9

--- a/gems/spree/CVE-2011-10019.yml
+++ b/gems/spree/CVE-2011-10019.yml
@@ -1,0 +1,26 @@
+---
+gem: spree
+cve: 2011-10019
+ghsa: 97vm-c39p-jr86
+url: https://github.com/advisories/GHSA-97vm-c39p-jr86
+title: Remote Command Execution in Spree search functionality
+date: 2011-02-10
+description: |
+  Spree versions prior to 0.60.2 contain a remote command execution
+  vulnerability in the search functionality. The application fails to
+  properly sanitize input passed via the `search[:send][]` parameter,
+  which is dynamically invoked using Ruby’s `send` method. This allows
+  attackers to execute arbitrary shell commands on the server without
+  authentication.
+cvss_v2: 9.0
+patched_versions:
+  - ">= 0.60.2"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2011-10019
+    - https://raw.githubusercontent.com/rapid7/metasploit-framework/master/modules/exploits/multi/http/spree_search_exec.rb
+    - https://web.archive.org/web/20111009192436/http://spreecommerce.com/blog/2011/10/05/remote-command-product-group
+    - https://www.exploit-db.com/exploits/17941
+    - https://www.vulncheck.com/advisories/spreecommerce-search-parameter-rce
+    - https://github.com/orgs/spree/spree
+    - https://github.com/advisories/GHSA-97vm-c39p-jr86


### PR DESCRIPTION
GHSA SYNC: 2 brand new advisories:
 * gems/ruby-jwt/CVE-2025-45765.yml
 * gems/spree/CVE-2011-10019.yml
 
 I found these while researching the single vulnerability issues yesterday.
