### PR TITLE
Fix the framework helper method in the github advisory sync

### DIFF
--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -205,7 +205,9 @@ module GitHub
           "actioncable",  "actionmailbox", "actionmailer",  "actionpack",
           "actiontext",   "actionview",    "activejob",     "activemodel",
           "activerecord", "activestorage", "activesupport", "railties",
-          "rails", "jquery-rails"
+          "jquery-rails"
+          # Mark all of the above to be part of the Rails framework
+          "rails"
         end
       end
 


### PR DESCRIPTION
I was reading the repo's code after a recent contribution (out of curiosity) and I've found one very strange method for the Github Advisory sync process. I wasn't sure what it should do, as it made no sense, it returned `nil` regardless of its (implicit) inputs. So I did a bit more investigation and found that it meant to mark some vulnerabilities to be part of a framework, but it was lost over time. The history of the method looks like this:

* The method was written ages ago.
* #652 did a cosmetic refactor by removing surrounding `%[]` from the case-when conditions
* #681 added a new gem to the condition list - and assumed that there were a missing comma, which turned the returned value (`rails`) to be part of the condition list

Not sure if I need to re-run anything to backfill the framework data or anything like that, but I'm happy to do that if it helps, just let me know.