### PR TITLE
GHSA SYNC: 1 new and 8 modified advisories

### DIFF
--- a/gems/actiontext/CVE-2024-34341.yml
+++ b/gems/actiontext/CVE-2024-34341.yml
@@ -1,5 +1,6 @@
 ---
 gem: actiontext
+framework: rails
 cve: 2024-34341
 ghsa: qjqp-xr96-cj99
 url: https://github.com/advisories/GHSA-qjqp-xr96-cj99
@@ -54,12 +55,12 @@ description: |
   can significantly mitigate the risk of such vulnerabilities.
   Set CSP policies such as script-src 'self' to ensure that only scripts hosted on the same origin
   are executed, and explicitly prohibit inline scripts using script-src-elem.
+cvss_v3: 5.4
 unaffected_versions:
   - "< 7.0.0"
 patched_versions:
   - "~> 7.0.8, >= 7.0.8.3"
   - ">= 7.1.3.3"
-cvss_v3: 5.4
 related:
   url:
     - https://discuss.rubyonrails.org/t/xss-vulnerabilities-in-trix-editor/85803

--- a/gems/activestorage/CVE-2025-24293.yml
+++ b/gems/activestorage/CVE-2025-24293.yml
@@ -1,5 +1,6 @@
 ---
 gem: activestorage
+framework: rails
 cve: 2025-24293
 ghsa: r4mg-4433-c7g3
 url: https://github.com/rails/rails/security/advisories/GHSA-r4mg-4433-c7g3

--- a/gems/jquery-rails/CVE-2011-4969.yml
+++ b/gems/jquery-rails/CVE-2011-4969.yml
@@ -1,5 +1,6 @@
 ---
 gem: jquery-rails
+framework: rails
 cve: 2011-4969
 ghsa: 579v-mp3v-rrw5
 url: http://blog.jquery.com/2011/09/01/jquery-1-6-3-released

--- a/gems/jquery-rails/CVE-2015-1840.yml
+++ b/gems/jquery-rails/CVE-2015-1840.yml
@@ -1,5 +1,6 @@
 ---
 gem: jquery-rails
+framework: rails
 cve: 2015-1840
 ghsa: 4whc-pp4x-9pf3
 url: https://groups.google.com/forum/#!topic/ruby-security-ann/XIZPbobuwaY

--- a/gems/jquery-rails/CVE-2016-10707.yml
+++ b/gems/jquery-rails/CVE-2016-10707.yml
@@ -1,5 +1,6 @@
 ---
 gem: jquery-rails
+framework: rails
 cve: 2016-10707
 ghsa: mhpp-875w-9cpv
 url: https://nvd.nist.gov/vuln/detail/CVE-2016-10707

--- a/gems/jquery-rails/CVE-2020-11022.yml
+++ b/gems/jquery-rails/CVE-2020-11022.yml
@@ -1,5 +1,6 @@
 ---
 gem: jquery-rails
+framework: rails
 cve: 2020-11022
 ghsa: gxr4-xjj5-5px2
 url: https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2

--- a/gems/jquery-rails/CVE-2020-7656.yml
+++ b/gems/jquery-rails/CVE-2020-7656.yml
@@ -1,5 +1,6 @@
 ---
 gem: jquery-rails
+framework: rails
 cve: 2020-7656
 ghsa: q4m3-2j7h-f7xw
 url: https://snyk.io/vuln/SNYK-JS-JQUERY-569619

--- a/gems/openc3/CVE-2025-68271.yml
+++ b/gems/openc3/CVE-2025-68271.yml
@@ -1,0 +1,30 @@
+---
+gem: openc3
+cve: 2025-68271
+ghsa: w757-4qv9-mghp
+url: https://github.com/OpenC3/cosmos/security/advisories/GHSA-w757-4qv9-mghp
+title: openc3-api Vulnerable to Unauthenticated Remote Code Execution
+date: 2026-01-13
+description: |
+  ### Summary
+
+  OpenC3 COSMOS contains a critical remote code execution vulnerability
+  reachable through the JSON-RPC API. When a JSON-RPC request uses the
+  string form of certain APIs, attacker-controlled parameter text is
+  parsed into values using String#convert_to_value. For array-like
+  inputs, convert_to_value executes eval().
+
+  Because the cmd code path parses the command string before calling
+  authorize(), an unauthenticated attacker can trigger Ruby code
+  execution even though the request ultimately fails authorization (401).
+cvss_v3: 10.0
+unaffected_versions:
+  - "< 5.0.6"
+patched_versions:
+  - ">= 6.10.2"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-68271
+    - https://github.com/OpenC3/cosmos/security/advisories/GHSA-w757-4qv9-mghp
+    - https://github.com/OpenC3/cosmos/commit/01e9fbc5e66e9a2500b71a75a44775dd1fc2d1de
+    - https://github.com/advisories/GHSA-w757-4qv9-mghp

--- a/gems/spree/CVE-2011-10019.yml
+++ b/gems/spree/CVE-2011-10019.yml
@@ -13,6 +13,7 @@ description: |
   attackers to execute arbitrary shell commands on the server without
   authentication.
 cvss_v2: 9.0
+cvss_v3: 9.8
 patched_versions:
   - ">= 0.60.2"
 related:


### PR DESCRIPTION
GHSA SYNC: 1 new and 8 modified advisories
NEW
 * gems/openc3/CVE-2025-68271.yml

MODIFIED:
 *  gems/actiontext/CVE-2024-34341.yml
 * gems/activestorage/CVE-2025-24293.yml
 * gems/jquery-rails/CVE-2011-4969.yml
 * gems/jquery-rails/CVE-2015-1840.yml
 * gems/jquery-rails/CVE-2016-10707.yml
  * gems/jquery-rails/CVE-2020-11022.yml
 * gems/jquery-rails/CVE-2020-7656.yml
 * gems/spree/CVE-2011-10019.yml
 
**NOTE: The modifications came from the recent script change.**
