### PR TITLE
Update CVE-2025-27221 advisory

### DIFF
--- a/gems/uri/CVE-2025-27221.yml
+++ b/gems/uri/CVE-2025-27221.yml
@@ -41,5 +41,4 @@ related:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-27221
     - https://www.cve.org/CVERecord?id=CVE-2025-27221
     - https://www.ruby-lang.org/en/news/2025/02/26/security-advisories
-    - https://github.com/rubysec/ruby-advisory-db/issues/932
     - https://github.com/advisories/GHSA-22h5-pq3x-2gf2


### PR DESCRIPTION
Update CVE-2025-27221 advisory** in response to issue [932](https://github.com/rubysec/ruby-advisory-db/issues/932).
Fixed  [932](https://github.com/rubysec/ruby-advisory-db/issues/932).