### PR TITLE
2nd try at 2016 advisory: CVE-2016-2336

### DIFF
--- a/rubies/ruby/CVE-2016-2336.yml
+++ b/rubies/ruby/CVE-2016-2336.yml
@@ -1,0 +1,38 @@
+---
+engine: ruby
+cve: 2016-2336
+ghsa: f46g-7w88-2qv4
+url: https://nvd.nist.gov/vuln/detail/CVE-2016-2336
+title: Type confusion exists in ole_invoke and ole_query_interface
+  methods of Ruby's WIN32OLE class
+date: 2017-01-06
+description: |
+  Type confusion exists in two methods of Ruby's
+  WIN32OLE class, ole_invoke and ole_query_interface.
+  Attacker passing different type of object than this assumed
+  by developers can cause arbitrary code execution.
+cvss_v2: 7.5
+cvss_v3: 9.8
+unaffected_versions:
+  - "< 2.2.2"
+patched_versions:
+  - ">= 2.3.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2016-2336
+    - https://github.com/ruby/ruby/blob/v2_3_1/ChangeLog
+    - https://github.com/ruby/ruby/commit/a9721a259665149b1b9ff0beabcf5f8dc0136120
+    - https://github.com/ruby/ruby/commit/d40ea2afa6ff5a6e5befcf342fb7b6dc58796b20
+    - https://security.snyk.io/vuln/SNYK-UNMANAGED-RUBY-2370206?utm_source=copilot.com
+    - https://osv.dev/vulnerability/CVE-2016-2336
+    - https://github.com/google/osv.dev/issues/2333
+    - http://www.talosintelligence.com/reports/TALOS-2016-0029
+    - https://app.opencve.io/cve/CVE-2016-2336
+    - https://ubuntu.com/security/CVE-2016-2336
+    - https://github.com/advisories/GHSA-f46g-7w88-2qv4
+notes: |
+  - osv.dev reference has a lot of discussion of CVE's fix.
+    - The 2 commits are mentioned in osv.dev reference.
+  - Appears that ruby-lang project lost data in move from svn to github.
+  - Talo reference says: TESTED VERSIONS are "Ruby 2.3.0 dev Ruby 2.2.2"
+  - 1st win32ole gem release was 12/3/2020: https://rubygems.org/gems/win32ole


### PR DESCRIPTION
2nd try at 2016 advisory: CVE-2016-2336 (previously part of PR#969)
 * rubies/ruby/CVE-2016-2336.yml

Did more research - add more notes - appears that ruby was patched on or before 2.3.1.