### PR TITLE
mruby version of previous advisory

### DIFF
--- a/rubies/mruby/CVE-2017-0898.yml
+++ b/rubies/mruby/CVE-2017-0898.yml
@@ -1,0 +1,29 @@
+---
+engine: mruby
+cve: 2017-0898
+ghsa: wvmx-3rv2-5jgf
+url: https://nvd.nist.gov/vuln/detail/CVE-2017-0898
+title: Buffer underrun vulnerability in Kernel.sprintf
+date: 2017-09-14
+description: |
+  There is a buffer underrun vulnerability in the sprintf
+  method of Kernel module.
+
+  If a malicious format string which contains a precious specifier (*) is
+  passed and a huge minus value is also passed to the specifier, buffer
+  underrun may be caused. In such situation, the result may contains heap,
+  or the Ruby interpreter may crash.
+
+  All users running an affected release should upgrade immediately.
+cvss_v2: 6.4
+cvss_v3: 9.1
+patched_versions:
+  - ">= 1.3.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-0898
+    - https://mruby.org/releases/2017/07/04/mruby-1.3.0-released.html
+    - https://github.com/mruby/mruby/issues/3140
+    - https://github.com/mruby/mruby/issues/3722
+    - https://hackerone.com/reports/212241
+    - https://github.com/advisories/GHSA-wvmx-3rv2-5jgf


### PR DESCRIPTION
mruby version of previous advisory from [PR#978](https://github.com/rubysec/ruby-advisory-db/pull/978)
 * rubies/mruby/CVE-2017-0898.yml
