### PR TITLE
Add patched version for CVE-2026-25765

### DIFF
--- a/gems/faraday/CVE-2026-25765.yml
+++ b/gems/faraday/CVE-2026-25765.yml
@@ -61,7 +61,7 @@ description: |
   ```
 cvss_v3: 5.8
 patched_versions:
-  - ">= 1.10.5"
+  - "~> 1.10.5"
   - ">= 2.14.1"
 related:
   url:


### PR DESCRIPTION
The fix for this was backported to 1.x versions as well.

See: 
- lostisland/faraday@d0fc049beb
- https://github.com/advisories/GHSA-33mh-2634-fwr2