### PR TITLE
GHSA SYNC: 6 modified advisories

### DIFF
--- a/rubies/ruby/CVE-2008-1891.yml
+++ b/rubies/ruby/CVE-2008-1891.yml
@@ -1,7 +1,8 @@
 ---
 engine: ruby
 cve: 2008-1891
-url: http://aluigi.altervista.org/adv/webrickcgi-adv.txt
+ghsa: rhf2-x48g-5wr7
+url: https://nvd.nist.gov/vuln/detail/CVE-2008-1891
 title: Directory traversal vulnerability in WEBrick
 date: 2008-04-15
 description: |
@@ -19,3 +20,13 @@ patched_versions:
   - "~> 1.8.6.230"
   - "~> 1.8.7.22"
   - ">= 1.9.0.2"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2008-1891
+    - https://github.com/ruby/ruby/blob/ruby_1_9_1/ChangeLog
+    - https://github.com/ruby/ruby/blob/ruby_1_8_7/ChangeLog
+    - https://github.com/ruby/ruby/blob/ruby_1_8_6/ChangeLog
+    - https://github.com/ruby/ruby/blob/ruby_1_8_5/ChangeLog
+    - http://aluigi.altervista.org/adv/webrickcgi-adv.txt
+    - http://lists.opensuse.org/opensuse-security-announce/2008-08/msg00006.html
+    - https://github.com/advisories/GHSA-rhf2-x48g-5wr7

--- a/rubies/ruby/CVE-2009-1904.yml
+++ b/rubies/ruby/CVE-2009-1904.yml
@@ -18,6 +18,7 @@ patched_versions:
 related:
   url:
     - https://www.ruby-lang.org/en/news/2009/06/09/dos-vulnerability-in-bigdecimal
+    - https://www.ruby-forum.com/t/ruby-1-8-6-pl369-released/169912
     - https://nvd.nist.gov/vuln/detail/CVE-2009-1904
     - https://github.com/advisories/GHSA-prwc-wj59-8vwr
     - http://www.osvdb.org/show/osvdb/55031

--- a/rubies/ruby/CVE-2011-3009.yml
+++ b/rubies/ruby/CVE-2011-3009.yml
@@ -1,7 +1,8 @@
 ---
 engine: ruby
 cve: 2011-3009
-url: https://osdir.com/ml/lang-ruby-core/2011-01/msg00917.html
+ghsa: mg6g-jwh6-pwjf
+url: https://nvd.nist.gov/vuln/detail/CVE-2011-3009
 title:
   Ruby Properly initialize the random number generator when forking new process
 date: 2011-07-02
@@ -15,3 +16,11 @@ unaffected_versions:
   - ">= 1.9.2"
 patched_versions:
   - ">= 1.8.6.114"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2011-3009
+    - https://bugzilla.redhat.com/show_bug.cgi?id=722415
+    - http://rhn.redhat.com/errata/RHSA-2012-0070.html
+    - https://security.snyk.io/vuln/SNYK-ORACLE6-RUBYLIBS-2462477
+    - http://www.openwall.com/lists/oss-security/2011/07/20/1
+    - https://github.com/advisories/GHSA-mg6g-jwh6-pwjf

--- a/rubies/ruby/CVE-2015-1855.yml
+++ b/rubies/ruby/CVE-2015-1855.yml
@@ -1,7 +1,8 @@
 ---
 engine: ruby
 cve: 2015-1855
-url: https://www.ruby-lang.org/en/news/2015/04/13/ruby-openssl-hostname-matching-vulnerability/
+ghsa: 4x8v-74xf-h4g3
+url: https://nvd.nist.gov/vuln/detail/CVE-2015-1855
 title: Ruby OpenSSL Hostname Verification
 date: 2015-04-13
 description: |
@@ -11,7 +12,18 @@ description: |
   follows more strict behavior, as recommended by these RFCs. In particular,
   matching of more than one wildcard per subject/SAN is no-longer allowed. As well,
   comparison of these values is now case-insensitive.
+cvss_v2: 4.3
+cvss_v3: 5.9
 patched_versions:
   - "~> 2.0.0.645"
   - "~> 2.1.6"
   - ">= 2.2.2"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-1855
+    - https://www.ruby-lang.org/en/news/2015/04/13/ruby-openssl-hostname-matching-vulnerability
+    - https://bugs.ruby-lang.org/issues/9644
+    - http://www.debian.org/security/2015/dsa-3245
+    - http://www.debian.org/security/2015/dsa-3246
+    - http://www.debian.org/security/2015/dsa-3247
+    - https://github.com/advisories/GHSA-4x8v-74xf-h4g3

--- a/rubies/ruby/CVE-2017-17405.yml
+++ b/rubies/ruby/CVE-2017-17405.yml
@@ -1,7 +1,8 @@
 ---
 engine: ruby
 cve: 2017-17405
-url: https://www.ruby-lang.org/en/news/2017/12/14/net-ftp-command-injection-cve-2017-17405/
+ghsa: https://github.com/advisories/GHSA-q23r-c9rf-97q3
+url: https://nvd.nist.gov/vuln/detail/CVE-2017-17405
 title: Command injection vulnerability in Net::FTP
 date: 2017-12-14
 description: |
@@ -15,8 +16,28 @@ description: |
   command execution.
 
   All users running an affected release should upgrade immediately.
+cvss_v2: 9.3
+cvss_v3: 8.8
 patched_versions:
   - "~> 2.2.9"
   - "~> 2.3.6"
   - "~> 2.4.3"
   - "> 2.5.0.preview.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2017-17405
+    - https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-4-3-released
+    - https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-3-6-released
+    - https://www.ruby-lang.org/en/news/2017/12/14/ruby-2-2-9-released
+    - https://www.ruby-lang.org/en/news/2017/12/14/net-ftp-command-injection-cve-2017-17405
+    - https://www.exploit-db.com/exploits/43381
+    - https://lists.debian.org/debian-security-announce/2018/msg00188.html
+    - https://lists.debian.org/debian-lts-announce/2017/12/msg00024.html
+    - https://lists.debian.org/debian-lts-announce/2017/12/msg00025.html
+    - https://lists.debian.org/debian-lts-announce/2018/07/msg00012.html
+    - https://access.redhat.com/errata/RHSA-2018:0378
+    - https://access.redhat.com/errata/RHSA-2018:0583
+    - https://access.redhat.com/errata/RHSA-2018:0584
+    - https://access.redhat.com/errata/RHSA-2018:0585
+    - https://access.redhat.com/errata/RHSA-2019:2806
+    - https://github.com/advisories/GHSA-q23r-c9rf-97q3

--- a/rubies/ruby/CVE-2020-10933.yml
+++ b/rubies/ruby/CVE-2020-10933.yml
@@ -1,7 +1,8 @@
 ---
 engine: ruby
 cve: 2020-10933
-url: https://www.ruby-lang.org/en/news/2020/03/31/heap-exposure-in-socket-cve-2020-10933/
+ghsa: g5hm-28jr-53fh
+url: https://nvd.nist.gov/vuln/detail/CVE-2020-10933
 title: Heap exposure vulnerability in the socket library
 date: 2020-03-31
 description: |
@@ -17,9 +18,18 @@ description: |
 
   This issue is exploitable only on Linux. This issue had been since Ruby
   2.5.0; 2.4 series is not vulnerable.
+cvss_v2: 5.0
+cvss_v3: 5.3
+unaffected_versions:
+  - "~> 2.4.0"
 patched_versions:
   - "~> 2.5.8"
   - "~> 2.6.6"
   - ">= 2.7.1"
-unaffected_versions:
-  - "~> 2.4.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-10933
+    - https://lists.debian.org/debian-security-announce/2020/msg00126.html
+    - https://security.netapp.com/advisory/ntap-20200625-0001
+    - https://www.ruby-lang.org/en/news/2020/03/31/heap-exposure-in-socket-cve-2020-10933
+    - https://github.com/advisories/GHSA-g5hm-28jr-53fh


### PR DESCRIPTION
GHSA SYNC: 6 modified advisories
 *  rubies/ruby/CVE-2008-1891.yml
 *  rubies/ruby/CVE-2009-1904.yml
 * rubies/ruby/CVE-2011-3009.yml
 * rubies/ruby/CVE-2015-1855.yml
 * rubies/ruby/CVE-2017-17405.yml
 * rubies/ruby/CVE-2020-10933.yml
