### PR TITLE
GHSA sync script fixes

### DIFF
--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -414,7 +414,7 @@ module GitHub
 
       # populate the related information
       new_data["related"] = {
-        "url" => advisory["references"]
+        "url" => advisory["references"].map { |reference| reference['url'] }.reject(&:empty?)
       }
 
       FileUtils.mkdir_p(File.dirname(filename_to_write))

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -184,6 +184,11 @@ module GitHub
 
   class GitHubAdvisory
     class Package
+      NORMALISED_NAMES = {
+        "arabic-prawn"  => "Arabic-Prawn",
+        "redcloth"      => "RedCloth",
+      }
+
       attr_reader :name
 
       def initialize(advisory, name)
@@ -196,7 +201,11 @@ module GitHub
       end
 
       def filename
-        File.join("gems", name, "#{@advisory.primary_id}.yml")
+        # These packages appear to have been named differently in the past
+        # This 'corrects' them so updates don't affect existing vulnerabilities
+        package_name = NORMALISED_NAMES.fetch(name, name)
+
+        File.join("gems", package_name, "#{@advisory.primary_id}.yml")
       end
 
       def framework


### PR DESCRIPTION
Just made two amendments to the GHSA sync script to fix issues I noticed when using it recently:

1. Correct the generation of the vulnerabilities references

    Currently the references nest an additional `url:` key inside them, which causes the RSpec tests to fail

2. Translate two package names that appear to have been renamed at some point

    `arabic-prawn` and `redcloth` apparently previously used camel-cased names (`Arabic-Prawn` and `RedCloth`) which is how they're stored in the repository. The sync script creates 'new' vulnerabilities because of these changes, so I've translated these package names back to avoid this.