### PR TITLE
Adding  new rake CVE's (2026-25500 and 206-22860)

### DIFF
--- a/gems/rack/CVE-2026-22860.yml
+++ b/gems/rack/CVE-2026-22860.yml
@@ -4,7 +4,7 @@ cve: 2026-22860
 ghsa: mxw3-3hh2-x2mh
 url: https://github.com/rack/rack/security/advisories/GHSA-mxw3-3hh2-x2mh
 title: Rack::Directory vulnerable to path traversal when serving files
-date: 2026-01-16
+date: 2026-02-16
 description: |
   ## Summary
 
@@ -20,8 +20,8 @@ description: |
   Affected versions:
 
   - `< 2.2.22`
-  - `>= 3.0.0.beta1, < 3.1.20`
-  - `>= 3.2.0.beta1, < 3.2.5`
+  - `>= 3.0.0, < 3.1.20`
+  - `>= 3.2.0, < 3.2.5`
 
   ## Impact
 
@@ -33,9 +33,10 @@ description: |
 
   - Upgrade to a patched version of Rack.
   - Avoid exposing `Rack::Directory` to untrusted paths.
+cvss_v3: 7.5
 patched_versions:
-  - ">= 2.2.22"
-  - ">= 3.1.20"
+  - "~> 2.2.22"
+  - "~> 3.1.20"
   - ">= 3.2.5"
 related:
   url:

--- a/gems/rack/CVE-2026-25500.yml
+++ b/gems/rack/CVE-2026-25500.yml
@@ -4,7 +4,7 @@ cve: 2026-25500
 ghsa: whrj-4476-wvmp
 url: https://github.com/advisories/GHSA-whrj-4476-wvmp
 title: Rack::Directory vulnerable to reflected XSS in directory listings
-date: 2026-01-16
+date: 2026-02-16
 description: |
   ## Summary
 
@@ -21,7 +21,7 @@ description: |
 
   - `< 2.2.22`
   - `>= 3.0.0.beta1, < 3.1.20`
-  - `>= 3.2.0.beta1, < 3.2.5`
+  - `>= 3.2.0, < 3.2.5`
 
   ## Impact
 
@@ -33,9 +33,10 @@ description: |
 
   - Upgrade to a patched version of Rack.
   - Avoid exposing `Rack::Directory` listings to untrusted users.
+cvss_v3: 5.4
 patched_versions:
-  - ">= 2.2.22"
-  - ">= 3.1.20"
+  - "~> 2.2.22"
+  - "~> 3.1.20"
   - ">= 3.2.5"
 related:
   url:


### PR DESCRIPTION
This is a draft PR, feel free to adjust it or close it if is not usefull anymore.


## What Changed?

Non Functional Changes:
- Added missing Rack advisories:
  - `gems/rack/CVE-2026-22860.yml` (Directory Traversal in `Rack::Directory`)
  - `gems/rack/CVE-2026-25500.yml` (Reflected XSS in `Rack::Directory`)
  
  Relevant References:
  
  https://www.tenable.com/cve/CVE-2026-22860
  https://www.tenable.com/cve/CVE-2026-25500
  
  
  
  
  
  