### PR TITLE
Combined and renamed 3 decidem advisories (s/GHSA/CVE/)

### DIFF
--- a/gems/decidim-api/CVE-2026-40870.yml
+++ b/gems/decidim-api/CVE-2026-40870.yml
@@ -1,5 +1,6 @@
 ---
-gem: decidim-comments
+gem: decidim-api
+cve: 2026-40870
 ghsa: ghmh-q25g-gxxx
 url: https://github.com/decidim/decidim/security/advisories/GHSA-ghmh-q25g-gxxx
 title: Decidim's comments API allows access to all commentable resources
@@ -54,10 +55,10 @@ description: |
   vulnerability. This may be sufficient for some installations,
   but not for all.
 
-  Another workaround is to limit the availability of the `/api`
-  endpoint to only trusted ranges of IPs that need to access the
-  API. The following Nginx configuration would help limiting the
-  API access to only specific IPs:
+  Another workaround is to limit the availability of the `/api` endpoint
+  to only trusted ranges of IPs that need to access the API. The
+  following Nginx configuration would help limiting the API access
+  to only specific IPs:
 
   ```
   location /api {
@@ -90,5 +91,6 @@ patched_versions:
   - ">= 0.31.1"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40870
     - https://github.com/decidim/decidim/security/advisories/GHSA-ghmh-q25g-gxxx
     - https://github.com/advisories/GHSA-ghmh-q25g-gxxx

--- a/gems/decidim-comments/CVE-2026-40870.yml
+++ b/gems/decidim-comments/CVE-2026-40870.yml
@@ -1,5 +1,6 @@
 ---
-gem: decidim-api
+gem: decidim-comments
+cve: 2026-40870
 ghsa: ghmh-q25g-gxxx
 url: https://github.com/decidim/decidim/security/advisories/GHSA-ghmh-q25g-gxxx
 title: Decidim's comments API allows access to all commentable resources
@@ -54,10 +55,10 @@ description: |
   vulnerability. This may be sufficient for some installations,
   but not for all.
 
-  Another workaround is to limit the availability of the `/api` endpoint
-  to only trusted ranges of IPs that need to access the API. The
-  following Nginx configuration would help limiting the API access
-  to only specific IPs:
+  Another workaround is to limit the availability of the `/api`
+  endpoint to only trusted ranges of IPs that need to access the
+  API. The following Nginx configuration would help limiting the
+  API access to only specific IPs:
 
   ```
   location /api {
@@ -90,5 +91,6 @@ patched_versions:
   - ">= 0.31.1"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40870
     - https://github.com/decidim/decidim/security/advisories/GHSA-ghmh-q25g-gxxx
     - https://github.com/advisories/GHSA-ghmh-q25g-gxxx

--- a/gems/decidim-core/CVE-2026-40869.yml
+++ b/gems/decidim-core/CVE-2026-40869.yml
@@ -1,5 +1,6 @@
 ---
 gem: decidim-core
+cve: 2026-40869
 ghsa: w5xj-99cg-rccm
 url: https://github.com/decidim/decidim/security/advisories/GHSA-w5xj-99cg-rccm
 title: Decidim amendments can be accepted or rejected by anyone
@@ -37,6 +38,7 @@ patched_versions:
   - ">= 0.31.1"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-40869
     - https://github.com/decidim/decidim/security/advisories/GHSA-w5xj-99cg-rccm
     - https://github.com/decidim/decidim/commit/1b99136a1c7aa02616a0b54a6ab88d12907a57a9
     - https://github.com/advisories/GHSA-w5xj-99cg-rccm


### PR DESCRIPTION
Combined and renamed 3 decidem advisories (s/GHSA/CVE/)
 * Combined then replaced
   * gems/decidim-core/GHSA-w5xj-99cg-rccm.yml with gems/decidim-core/CVE-2026-40869.yml
 * Combined then replaced
   * gems/decidim-api/GHSA-ghmh-q25g-gxxx with gems/decidim-api/CVE-2026-40870.yml .
 * Combined then replaced
   * gems/decidim-comments/GHSA-ghmh-q25g-gxxx with gems/decidim-comments/CVE-2026-40870.yml .
 * See PR #1047 for context.

 * **NOTE:** CVE prefix advisory/filenames are used if available.
