### PR TITLE
GHSA/SYNC: 5 new openc3 advisories

### DIFF
--- a/gems/openc3/CVE-2026-42084.yml
+++ b/gems/openc3/CVE-2026-42084.yml
@@ -1,0 +1,44 @@
+---
+gem: openc3
+cve: 2026-42084
+ghsa: wgx6-g857-jjf7
+url: https://github.com/OpenC3/cosmos/security/advisories/GHSA-wgx6-g857-jjf7
+title: OpenC3 COSMOS - Hijacked session token can be used to reset
+  password for persistence
+date: 2026-04-22
+description: |
+  ### Summary
+
+  The OpenC3 password change functionality allows a user to change their
+  password without providing the old password, by accepting a valid
+  session token instead. In assumed breach scenarios, this behaviour
+  can be exploited by an attacker who has already obtained a valid
+  session token, to gain persistence in hijacked account (including
+  admin) and prevent legitimate users from accessing the account.
+
+  ### Details
+
+  The design flaw in authentication model ([authentication.rb](https://github.com/OpenC3/cosmos/blob/397abec0d57972881a2e8dc10902d0dce9c27f42/openc3/lib/openc3/utilities/authentication.rb))
+  allows for interchangeable use of password and session tokens for
+  user authentication As old tokens are not revoked upon password
+  reset, an attacker who has obtained a valid session token can
+  continue to authenticate and change the account’s password even
+  after the victim resets it, thereby maintaining persistent control
+  over the compromised account.
+
+  ### Impact
+
+  Persistence of an attacker who obtained valid session token and
+  preventing legitimate users from account access.
+cvss_v3: 8.1
+patched_versions:
+  - "~> 6.10.5"
+  - ">= 7.0.0-rc3"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42084
+    - https://github.com/OpenC3/cosmos/security/advisories/GHSA-wgx6-g857-jjf7
+    - https://github.com/OpenC3/cosmos/releases/tag/v7.0.0-rc3
+    - https://github.com/OpenC3/cosmos/releases/tag/v6.10.5
+    - https://github.com/OpenC3/cosmos/commit/2e623714e3426d5ae81b6f8239d4a2a6937ef776
+    - https://github.com/advisories/GHSA-wgx6-g857-jjf7

--- a/gems/openc3/CVE-2026-42085.yml
+++ b/gems/openc3/CVE-2026-42085.yml
@@ -1,0 +1,44 @@
+---
+gem: openc3
+cve: 2026-42085
+ghsa: 4jvx-93h3-f45h
+url: https://github.com/OpenC3/cosmos/security/advisories/GHSA-4jvx-93h3-f45h
+title: OpenC3 COSMOS allows arbitrary writes to plugins directory
+  via path-traversed config filenames
+date: 2026-04-22
+description: |
+  ### Summary
+
+  OpenC3 COSMOS contains a design flaw in the `save_tool_config()`
+  function that allows saving tool configuration files at arbitrary
+  locations inside the shared `/plugins` directory tree by supplying
+  crafted configuration filenames. Although the implementation
+  sufficiently mitigates standard path traversal attacks, by
+  canonicalizing filename to an absolute path, all plugins share this
+  same root directory. That enables users to create arbitrary file
+  structures and overwrite existing configuration files within the
+  shared `/plugins` directory.
+
+  ### Details
+
+  In function `save_tool_config()` ([local_mode.rb](https://github.com/OpenC3/cosmos/blob/397abec0d57972881a2e8dc10902d0dce9c27f42/openc3/lib/openc3/utilities/local_mode.rb#L452))
+  responsible for saving user-supplied tool configuration, the desired
+  saving directory is not sufficiently enforced, instead allowing
+  writes inside entire `OPENC3_LOCAL_MODE_PATH`.
+
+  ### Impact
+
+  Modifying the data of other plugins.
+cvss_v3: 4.3
+patched_versions:
+  - "~> 6.10.5"
+  - ">= 7.0.0-rc3"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42085
+    - https://github.com/OpenC3/cosmos/security/advisories/GHSA-4jvx-93h3-f45h
+    - https://github.com/OpenC3/cosmos/releases/tag/v7.0.0-rc3
+    - https://github.com/OpenC3/cosmos/releases/tag/v6.10.5
+    - https://github.com/OpenC3/cosmos/commit/9957a9fa460c0c0cf5cdbf6a5931bbdd025246a5
+    - https://github.com/OpenC3/cosmos/commit/e6efccbd148ba0e3361c5891027f2373aa140d42
+    - https://github.com/advisories/GHSA-4jvx-93h3-f45h

--- a/gems/openc3/CVE-2026-42086.yml
+++ b/gems/openc3/CVE-2026-42086.yml
@@ -1,0 +1,35 @@
+---
+gem: openc3
+cve: 2026-42086
+ghsa: ffq5-qpvf-xq7x
+url: https://github.com/OpenC3/cosmos/security/advisories/GHSA-ffq5-qpvf-xq7x
+title: OpenC3 COSMOS is Vulnerable to Self-XSS Through the Command Sender
+date: 2026-04-22
+description: |
+  ### Summary
+
+  The Command Sender UI uses an unsafe `eval()` function on array-like
+  command parameters, which allows a user-supplied payload to execute
+  in the browser when sending a command. This creates a self-XSS risk
+  because an attacker can trigger their own script execution in the
+  victim’s session, if allowed to influence the array parameter input,
+  for example via phishing. If successful, an attacker may read or
+  modify data in the authenticated browser context, including session
+  tokens in local storage.
+
+  ### Details
+
+  The unsafe `eval()`  usage on user-supplied ARRAY parameters happens
+  in `convertToValue` method in [CommandSender.vue](https://github.com/OpenC3/cosmos/blob/main/openc3-cosmos-init/plugins/packages/openc3-cosmos-tool-cmdsender/src/tools/CommandSender/CommandSender.vue)
+
+  ### Impact
+
+  Local JavaScript execution in the user's browser.
+cvss_v3: 4.6
+patched_versions:
+  - ">= 7.0.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42086
+    - https://github.com/OpenC3/cosmos/security/advisories/GHSA-ffq5-qpvf-xq7x
+    - https://github.com/advisories/GHSA-ffq5-qpvf-xq7x

--- a/gems/openc3/CVE-2026-42087.yml
+++ b/gems/openc3/CVE-2026-42087.yml
@@ -1,0 +1,41 @@
+---
+gem: openc3
+cve: 2026-42087
+ghsa: v529-vhwc-wfc5
+url: https://github.com/OpenC3/cosmos/security/advisories/GHSA-v529-vhwc-wfc5
+title: OpenC3 COSMOS has SQL Injection in QuestDB Time-Series Database
+date: 2026-04-23
+description: |
+  Vulnerability Type: CWE-89: Improper Neutralization of Special Elements
+  used in an SQL Command ('SQL Injection')
+
+  Attack type: Authenticated remote
+
+  Impact: Telemetry data disclosure and deletion
+
+  Affected components: openc3-tsdb (QuestDB)
+
+  A SQL injection vulnerability exists in the Time-Series Database (TSDB)
+  component of COSMOS. The `tsdb_lookup` function in the `cvt_model.rb`
+  file directly places user-supplied input into a SQL query without
+  sanitizing the input. As a result, a user can break out of the initial
+  SQL statement and execute arbitrary SQL commands, including deleting data.
+
+  ## Recommendations
+
+  * Sanitize all user-supplied input before executing it.
+  * Use prepared statements with parameterized queries when
+    executing SQL statements.
+cvss_v3: 9.6
+unaffected_versions:
+  - "< 6.7.0"
+patched_versions:
+  - ">= 7.0.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42087
+    - https://rubygems.org/gems/openc3/versions/7.0.0
+    - https://github.com/OpenC3/cosmos/releases/tag/v7.0.0
+    - https://github.com/OpenC3/cosmos/security/advisories/GHSA-v529-vhwc-wfc5
+    - https://github.com/OpenC3/cosmos/commit/9ba60c09c8836a37a2e4ea67ab35fe403e041415
+    - https://github.com/advisories/GHSA-v529-vhwc-wfc5

--- a/gems/openc3/GHSA-2wvh-87g2-89hr.yml
+++ b/gems/openc3/GHSA-2wvh-87g2-89hr.yml
@@ -1,0 +1,44 @@
+---
+gem: openc3
+ghsa: 2wvh-87g2-89hr
+url: https://github.com/OpenC3/cosmos/security/advisories/GHSA-2wvh-87g2-89hr
+title: OpenC3 COSMOS - Permissions Bypass Provides User Access to
+  Unassigned Administrative Actions via Script Runner Tool
+date: 2026-04-23
+description: |
+  Vulnerability Type: Execution with Unnecessary Privileges Attack
+  type: Authenticated remote
+
+  Impact: Data disclosure/manipulation, privilege escalation
+
+  Affected components:
+
+  * The following docker images: Openc3inc/openc3-COSMOS-script-runner-api
+
+  The Script Runner widget allows users to execute Python and Ruby
+  scripts directly from the openc3-COSMOS-script-runner-api container.
+  Because all the docker containers share a network, users can execute
+  specially crafted scripts to bypass the API permissions check and
+  perform administrative actions, including reading and modifying data
+  inside the Redis database, which can be used to read secrets and
+  change COSMOS settings, as well as read and write to the buckets
+  service, which holds configuration, log,and plugin files. These
+  actions are normally only available from the Admin Console or with
+  administrative privileges. Any user with permission to create and
+  run scripts can connect to any service in the docker network.
+
+  ## Recommendations
+
+  * Limit the permissions of the script runner API to prevent lower
+    level users from performing administrative actions.
+cvss_v3: 9.6
+patched_versions:
+  - ">= 7.0.0"
+related:
+  url:
+    - https://github.com/OpenC3/cosmos/security/advisories/GHSA-2wvh-87g2-89hr
+    - https://rubygems.org/gems/openc3/versions/7.0.0
+    - https://github.com/OpenC3/cosmos/releases/tag/v7.0.0
+    - https://www.linkedin.com/posts/vulert_critical-permissions-bypass-in-openc3-cosmos-activity-7453420840760774656-RMv1
+    - https://www.miggo.io/vulnerability-database/cve/GHSA-2wvh-87g2-89hr
+    - https://github.com/advisories/GHSA-2wvh-87g2-89hr


### PR DESCRIPTION
GHSA/SYNC: 5 new openc3 advisories
 * gems/openc3/CVE-2026-42084.yml
 * gems/openc3/CVE-2026-42085.yml
 * gems/openc3/CVE-2026-42086.yml
 * gems/openc3/CVE-2026-42087.yml
 * gems/openc3/GHSA-2wvh-87g2-89hr.yml
