### PR TITLE
Upgraded versions of two GitHub Actions 

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Linter
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Install yamllint


### PR DESCRIPTION
Upgraded versions of two GitHub Actions

Yesterday, I fouund this warning in one of our GHA logs:
```
Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not
work as expected: 
 * actions/checkout@v3,
 * actions/setup-python@v4.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be 
removed from the runner on September 16th, 2026. Please check if updated versions of these actions
are available that support Node.js 24. To opt into Node.js 24 now, set the 
 *FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true
environment variable on the runner or in your workflow file. Once Node.js 24 becomes the
default, you can temporarily opt out by setting
 *  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners]
```
so I found out this
 " actions/checkout@v3"     had a "v4" version and
  " actions/setup-python@v4" had a "v5" version.

**Will monitor GHA for green run.**