### PR TITLE
Updated/renamed existing iodine advisory

### DIFF
--- a/gems/iodine/CVE-2026-41146.yml
+++ b/gems/iodine/CVE-2026-41146.yml
@@ -2,7 +2,7 @@
 gem: iodine
 cve: 2026-41146
 ghsa: 2x79-gwq3-vxxm
-url: https://github.com/advisories/GHSA-2x79-gwq3-vxxm
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-41146
 title: Uncontrolled resource consumption and loop with unreachable
   exit condition in facil.io and downstream iodine ruby gem
 date: 2026-04-14
@@ -268,4 +268,4 @@ related:
     - https://github.com/advisories/GHSA-2x79-gwq3-vxxm
 notes: |
   - FYI: iodine commit above contains the unreleased patch.
-  - Found GHSA's `patched_versions:` field is "0.7.59" but never released.
+  - Found GHSA's`patched_versions:`field is "0.7.59" but never released.

--- a/gems/iodine/CVE-2026-41146.yml
+++ b/gems/iodine/CVE-2026-41146.yml
@@ -261,7 +261,6 @@ cvss_v4: 8.7
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-41146
-
     - https://github.com/boazsegev/iodine/releases/tag/v0.7.58
     - https://github.com/boazsegev/iodine/commit/0855989d74098d838b972520835cfc256bc479bc
     - https://github.com/boazsegev/facil.io/commit/5128747363055201d3ecf0e29bf0a961703c9fa0

--- a/gems/iodine/CVE-2026-41146.yml
+++ b/gems/iodine/CVE-2026-41146.yml
@@ -268,4 +268,4 @@ related:
     - https://github.com/advisories/GHSA-2x79-gwq3-vxxm
 notes: |
   - FYI: iodine commit above contains the unreleased patch.
-  - Found GHSA's`patched_versions:`field is "0.7.59" but never released.
+  - Found GHSA's `patched_versions:` field is "0.7.59" but never released.

--- a/gems/iodine/CVE-2026-41146.yml
+++ b/gems/iodine/CVE-2026-41146.yml
@@ -1,7 +1,8 @@
 ---
 gem: iodine
+cve: 2026-41146
 ghsa: 2x79-gwq3-vxxm
-url: https://github.com/boazsegev/facil.io/security/advisories/GHSA-2x79-gwq3-vxxm
+url: https://github.com/advisories/GHSA-2x79-gwq3-vxxm
 title: Uncontrolled resource consumption and loop with unreachable
   exit condition in facil.io and downstream iodine ruby gem
 date: 2026-04-14
@@ -11,8 +12,10 @@ description: |
   `fio_json_parse` can enter an infinite loop when it encounters a
   nested JSON value starting with `i` or `I`. The process spins in
   user space and pegs one CPU core at ~100 instead of returning a
-  parse error. Because `iodine` vendors the same parser code, the
-  issue also affects `iodine` when it parses attacker-controlled JSON.
+  parse error.
+
+  Because `iodine` gem vendors the same parser code, the issue also
+  affects `iodine` gem when it parses attacker-controlled JSON.
 
   The smallest reproducer found is `[i`. The quoted-value form that
   originally exposed the issue, `[""i`, reaches the same bug because
@@ -254,8 +257,16 @@ description: |
     - Verified on tag / gem version `v0.7.58`
     - The gem vendors a copy of the vulnerable parser in
       `ext/iodine/fio_json_parser.h`
+cvss_v4: 8.7
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41146
+
     - https://github.com/boazsegev/iodine/releases/tag/v0.7.58
+    - https://github.com/boazsegev/iodine/commit/0855989d74098d838b972520835cfc256bc479bc
+    - https://github.com/boazsegev/facil.io/commit/5128747363055201d3ecf0e29bf0a961703c9fa0
     - https://github.com/boazsegev/facil.io/security/advisories/GHSA-2x79-gwq3-vxxm
     - https://github.com/advisories/GHSA-2x79-gwq3-vxxm
+notes: |
+  - FYI: iodine commit above contains the unreleased patch.
+  - Found GHSA's `patched_versions:` field is "0.7.59" but never released.


### PR DESCRIPTION
Updated/renamed existing iodine advisory
   * Add more iodine gem related information into advisory.
   * Renamed it from GHSA-2x79-gwq3-vxxm.yml to CVE-2026-41146.yml since we have CVE info now.

   