### PR TITLE
New advisory - see Ruby 4.0.5

### DIFF
--- a/rubies/ruby/CVE-2026-46727.yml
+++ b/rubies/ruby/CVE-2026-46727.yml
@@ -21,7 +21,7 @@ description: |
   This issue has been fixed in Ruby 4.0.5. We recommend upgrading Ruby.
 cvss_v3: 8.1
 unaffected_versions:
-  - "<= 3.4"
+  - "< 4.0"
 patched_versions:
   - ">= 4.0.5"
 related:

--- a/rubies/ruby/CVE-2026-46727.yml
+++ b/rubies/ruby/CVE-2026-46727.yml
@@ -1,0 +1,35 @@
+---
+engine: ruby
+cve: 2026-46727
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-46727
+title: CVE-2026-46727 - Use-after-free in pthread-based getaddrinfo timeout handler
+date: 2026-05-20
+description: |
+  ## SUMMARY
+
+  A race condition leading to a use-after-free in the pthread-based
+  getaddrinfo timeout handler (rb_getaddrinfo in ext/socket/raddrinfo.c)
+  allows a remote attacker who can delay DNS responses near the
+  user-specified timeout to crash a Ruby process that calls
+  Addrinfo.getaddrinfo(..., timeout:) or Socket.tcp(..., resolv_timeout:).
+  Memory-corruption-based exploitation is theoretically possible. The
+  attack could, for example, be carried out through a crafted
+  authoritative DNS server or recursive resolver.
+
+  This vulnerability has been assigned the CVE identifier CVE-2026-46727.
+
+  This issue has been fixed in Ruby 4.0.5. We recommend upgrading Ruby.
+cvss_v3: 8.1
+unaffected_versions:
+  - "<= 3.4"
+patched_versions:
+  - ">= 4.0.5"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-46727
+    - https://www.ruby-lang.org/en/news/2026/05/20/ruby-4-0-5-released
+    - https://github.com/ruby/ruby/releases/tag/v4.0.5
+    - https://www.ruby-lang.org/en/news/2026/05/20/getaddrinfo-cve-2026-46727
+    - https://hackerone.com/reports/3607434
+notes: |
+  - "Ruby 3.4 series and earlier are not affected." in ruby-lang post.


### PR DESCRIPTION
New advisory - see Ruby 4.0.5
 * rubies/ruby/CVE-2026-46727.yml
