### PR TITLE
Update GitHub Actions setup to use pinned SHAs, limited permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,9 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Linter
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.8
       - name: Install yamllint
@@ -23,7 +25,7 @@ jobs:
       - name: Lint YAML files
         run: yamllint gems rubies
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: 3.4
       - name: Install ruby dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ['**']
 
+permissions: {}
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,6 +9,23 @@ on:
 permissions: {}
 
 jobs:
+  lint-actions:
+    name: GitHub Actions audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+
   tests:
     runs-on: ubuntu-latest
     name: Linter

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Repository Dispatch event
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: rubysec/rubysec.github.io

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ master ]
 
+permissions: {}
+
 jobs:
   notify:
     if: github.repository_owner == 'rubysec'


### PR DESCRIPTION
Hello! This PR pins all the GitHub Actions used in the repo to specific SHA hashes to prevent supply chain attacks like [the one last week with actions-cool being taken over](https://www.stepsecurity.io/blog/actions-cool-issues-helper-github-action-compromised-all-tags-point-to-imposter-commit-that-exfiltrates-ci-cd-credentials).

This also updates the actions to their latest versions, limits the permissions of both jobs to no-permissions, and ensures that credentials are not persisted with the checkout action just to be safe. I used [zizmor](https://github.com/zizmorcore/zizmor) to audit and fix all of these.

I think this is especially important to do given that an attacker managing to push to master on this repo would result in anyone running `bundler-audit update` on their machine getting potentially malicious code. Though I admittedly don't think that's particularly likely to lead to much (bundler-audit just parses YAML files as far as I know, it wouldn't result in anything being executed), I'd rather just be careful.

Generally speaking I'd recommend pinning these to SHA hashes yourselves to make sure I can't supply malicious SHA hashes here, and you can use [zizmor](https://github.com/zizmorcore/zizmor) or [pinact](https://github.com/suzuki-shunsuke/pinact) if you want to do it yourself instead and close this PR. (Obviously I didn't do that, but figured I'd mention it for the sake of security)

Updating these actions will also be necessary in a few months anyway, since the Node version used by GitHub Actions is getting bumped to Node 24.