### PR TITLE
Update advisory to include new release today

### DIFF
--- a/gems/iodine/CVE-2026-41146.yml
+++ b/gems/iodine/CVE-2026-41146.yml
@@ -258,14 +258,13 @@ description: |
     - The gem vendors a copy of the vulnerable parser in
       `ext/iodine/fio_json_parser.h`
 cvss_v4: 8.7
+patched_versions:
+  - ">= 0.7.59"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-41146
-    - https://github.com/boazsegev/iodine/releases/tag/v0.7.58
+    - https://github.com/boazsegev/iodine/releases/tag/v0.7.59
     - https://github.com/boazsegev/iodine/commit/0855989d74098d838b972520835cfc256bc479bc
     - https://github.com/boazsegev/facil.io/commit/5128747363055201d3ecf0e29bf0a961703c9fa0
     - https://github.com/boazsegev/facil.io/security/advisories/GHSA-2x79-gwq3-vxxm
     - https://github.com/advisories/GHSA-2x79-gwq3-vxxm
-notes: |
-  - FYI: iodine commit above contains the unreleased patch.
-  - Found GHSA's `patched_versions:` field is "0.7.59" but never released.


### PR DESCRIPTION
Update advisory to include new release today
 * gems/iodine/CVE-2026-41146.yml

FYI: https://rubygems.org/gems/iodine