### PR TITLE
Add a rspec lint check to check title: and description:line lengths.

### DIFF
--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -3,6 +3,9 @@ require 'versions_example'
 
 require 'yaml'
 
+MAX_DESC_LEN  = 80
+MAX_TITLE_LEN = 154
+
 shared_examples_for 'Advisory' do |path|
   advisory = YAML.safe_load_file(path, permitted_classes: [Date])
 
@@ -106,6 +109,18 @@ shared_examples_for 'Advisory' do |path|
       it { expect(subject).to be_kind_of(String) }
       it { expect(subject).to_not match(%r{\Ahttp(s)?://osvdb\.org}) }
       it { expect(subject).not_to be_empty }
+
+      it "has a filename that matches the root of the url field" do
+        url = advisory["url"]
+
+        filename_root = File.basename(path, ".yml")
+
+        # 5/24/2026: May 9, 2026 is earliest start date with no failed checks.
+        start_date = Date.new(2026, 5, 9)
+        if advisory["date"] >= start_date and !filename_root.start_with?("OSVDB")
+          expect(url).to include(filename_root)
+        end
+      end
     end
 
     describe "title" do
@@ -120,6 +135,20 @@ shared_examples_for 'Advisory' do |path|
 
       it "must not start with or end with additional whitespace" do
         expect(subject).to_not match(/\A\s|\s\z/)
+      end
+
+      it "has a title <= #{MAX_TITLE_LEN} characters" do
+        title = advisory["title"]
+        expect(title).to be_a(String)
+
+        filename_root = File.basename(path, ".yml")
+
+        # 5/28/2026: May 8, 2026 is earliest start date with no failed checks.
+        start_date = Date.new(2026, 5, 8)
+        if advisory["date"] >= start_date and !filename_root.start_with?("OSVDB")
+          expect(title.length).to be <= MAX_TITLE_LEN,
+            "Title too long (#{title.length} chars): #{title.inspect}"
+        end
       end
     end
 
@@ -146,6 +175,22 @@ shared_examples_for 'Advisory' do |path|
 
       it { expect(subject).to be_kind_of(String) }
       it { expect(subject).not_to be_empty }
+
+      it "has a description with no line > ${MAX_DESC_LEN} characters" do
+         description = advisory["description"]
+         expect(description).to be_a(String)
+
+        filename_root = File.basename(path, ".yml")
+
+         # 5/28/2026: May 8, 2026 is earliest start date with no failed checks.
+         start_date = Date.new(2026, 5, 8)
+         if advisory["date"] >= start_date and !filename_root.start_with?("OSVDB")
+           long_lines = description.split("\n").select { |line| line.length > MAX_DESC_LEN }
+           expect(long_lines).to be_empty,
+             "Description has lines > #{MAX_DESC_LEN} chars:\n" +
+             long_lines.map { |l| "  #{l.length} chars: #{l.inspect}" }.join("\n")
+          end
+        end
     end
 
     describe "cvss_v2" do


### PR DESCRIPTION
Add a rspec lint check to check `title:` and `description:`line lengths.
 * Initial the maximum `title:`             line length will be 154.
 * Initial the maximum `description:` line length will be 80.
 * Initial start date is May 9, 2026 and it is the earliest start date with no failed checks.
  * Also excluded OSVDB advisory since they are very old.
  
These max numbers are at or close to the minimum to get a clean "rake" run.
