### PR TITLE
Added .ruby-version to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /Gemfile.lock
+.ruby-version
 .bundle
 .DS_Store
 /vendor


### PR DESCRIPTION
Added .ruby-version to .gitignore file because Gemfile.lock was already in it.