### PR TITLE
Two new puma advisories

### DIFF
--- a/gems/puma/CVE-2026-47736.yml
+++ b/gems/puma/CVE-2026-47736.yml
@@ -1,0 +1,57 @@
+---
+gem: puma
+cve: 2026-47736
+ghsa: qpgp-93vx-g8v8
+url: https://www.cve.org/CVERecord?id=CVE-2026-47736
+title: Puma PROXY Protocol v1 Parser Allows Remote Memory Exhaustion
+date: 2026-05-27
+description: |
+  ## Impact
+
+  PROXY protocol support for Puma was added in version 5.5.0.
+
+  When PROXY protocol v1 support is enabled, Puma reads incoming bytes
+  into an internal buffer. It waits for "\r\n" to determine whether a
+  PROXY v1 line is present. If an attacker opens a TCP connection and
+  continuously sends bytes without CRLF, Puma keeps appending to this
+  pre-parse buffer.
+
+  This can cause unbounded in-process memory growth and additional
+  CPU cost from repeatedly scanning the growing buffer for CRLF.
+  A single, unauthenticated TCP connection can drive significant memory
+  growth and may cause process/container OOM or degraded availability.
+
+   Only Puma servers using the following non-default config are affected:
+
+   set_remote_address proxy_protocol: :v1
+
+  ## Workarounds
+
+  * Disable PROXY protocol v1 parsing if it is not required:
+    # remove/comment this:
+    # set_remote_address proxy_protocol: :v1
+
+  * Restrict direct network access to Puma listeners using PROXY protocol:
+    * Only allow trusted load balancers/reverse proxies to connect.
+    * Block arbitrary client TCP access with firewall/security group rules.
+cvss_v3: 7.5
+unaffected_versions:
+  - "< 5.5.0"
+patched_versions:
+  - "~> 7.2.1"
+  - ">= 8.0.2"
+related:
+  url:
+    - https://www.cve.org/CVERecord?id=CVE-2026-47736
+    - https://rubygems.org/gems/puma/versions/8.0.2
+    - https://github.com/puma/puma/releases/tag/v8.0.2
+    - https://github.com/puma/puma/releases/tag/v7.2.1
+    - https://github.com/puma/puma/blob/main/History.md#802--2026-05-27
+    - https://github.com/puma/puma/blob/main/History.md#721--2026-05-27
+    - https://github.com/puma/puma/pull/2654
+    - https://github.com/puma/puma/issues/2651
+    - https://rubyweekly.com/issues/803
+    - https://github.com/puma/puma/security/advisories/GHSA-qpgp-93vx-g8v8
+notes: |
+  - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-47736 (reserved)
+  - No nvd cvss values

--- a/gems/puma/CVE-2026-47737.yml
+++ b/gems/puma/CVE-2026-47737.yml
@@ -1,0 +1,67 @@
+---
+gem: puma
+cve: 2026-47737
+ghsa: 2vqw-3mp8-cgmx
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-47737
+title: Puma PROXY Protocol v1 Accepts Repeated Protocol Headers on
+  Persistent Connections
+date: 2026-05-27
+description: |
+  ## Impact
+
+  Puma is vulnerable to source IP spoofing when set_remote_address
+  proxy_protocol: :v1 is enabled and persistent connections are used.
+
+  PROXY protocol v1 is a connection-level protocol. Support was added
+  to Puma in v5.5.0. A proxy sends one PROXY header at the beginning
+  of a TCP connection, before any HTTP data. Puma incorrectly re-parsed
+  PROXY protocol headers after each keep-alive request on the same
+  connection. An attacker able to send HTTP requests through a trusted
+  proxy could therefore inject a second PROXY header between HTTP
+  requests. Puma would treat the injected header as authoritative for
+  the next request and overwrite REMOTE_ADDR.
+
+  This can mislead applications or middleware that use REMOTE_ADDR for
+  security decisions, rate limiting, auditing, or allow/deny lists.
+
+  Only deployments that explicitly enable PROXY protocol v1 are affected,
+  and will have set:
+
+    set_remote_address proxy_protocol: :v1
+
+  Puma's default configuration is not affected. Deployments that do
+  not use persistent connections to Puma are also not expected to
+  be affected by this issue.
+
+  ## Workarounds
+
+  * Disable PROXY protocol v1 parsing if it is not required:
+
+    # remove/comment this:
+    # set_remote_address proxy_protocol: :v1
+
+  Users can also disable persistent connections to Puma, for example:
+
+    enable_keep_alives false
+cvss_v3: 7.5
+unaffected_versions:
+  - "< 5.5.0"
+patched_versions:
+  - "~> 7.2.1"
+  - ">= 8.0.2"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-47737
+    - https://rubygems.org/gems/puma/versions/8.0.2
+    - https://github.com/puma/puma/blob/main/History.md#802--2026-05-27
+    - https://github.com/puma/puma/blob/main/History.md#721--2026-05-27
+    - https://github.com/puma/puma/releases/tag/v8.0.2
+    - https://github.com/puma/puma/releases/tag/v7.2.1
+    - https://github.com/puma/puma/pull/2654
+    - https://github.com/phires/go-guerrilla/security/advisories/GHSA-c2c3-pqw5-5p7c
+    - https://github.com/puma/puma/issues/2651
+    - https://rubyweekly.com/issues/803
+    - https://github.com/puma/puma/security/advisories/GHSA-2vqw-3mp8-cgmx
+notes: |
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-47737 (reserved)
+    - No nvd cvss values


### PR DESCRIPTION
Two new puma advisories
  * gems/puma/CVE-2026-47736.yml
   * gems/puma/CVE-2026-47737.yml
   
   NOTES: These are "repository‑level security advisories", not GHSAs.