### PR TITLE
Add view_component 3.25.0 as patched for CVE-2026-44836 and CVE-2026-44837

### DIFF
--- a/gems/view_component/CVE-2026-44836.yml
+++ b/gems/view_component/CVE-2026-44836.yml
@@ -25,9 +25,11 @@ unaffected_versions:
   - "< 3.0.0"
 patched_versions:
   - ">= 4.9.0"
+  - ">= 3.25.0, < 4.0.0"
 related:
   url:
     - https://viewcomponent.org/CHANGELOG.html#490
     - https://github.com/ViewComponent/view_component/releases/tag/v4.9.0
+    - https://github.com/ViewComponent/view_component/releases/tag/v3.25.0
     - https://github.com/ViewComponent/view_component/security/advisories/GHSA-7f3r-gwc9-2995
     - https://github.com/advisories/GHSA-7f3r-gwc9-2995

--- a/gems/view_component/CVE-2026-44837.yml
+++ b/gems/view_component/CVE-2026-44837.yml
@@ -18,9 +18,11 @@ unaffected_versions:
   - "< 3.0.0"
 patched_versions:
   - ">= 4.9.0"
+  - ">= 3.25.0, < 4.0.0"
 related:
   url:
     - https://viewcomponent.org/CHANGELOG.html#490
     - https://github.com/ViewComponent/view_component/releases/tag/v4.9.0
+    - https://github.com/ViewComponent/view_component/releases/tag/v3.25.0
     - https://github.com/ViewComponent/view_component/security/advisories/GHSA-hg3h-g7xc-f7vp
     - https://github.com/advisories/GHSA-hg3h-g7xc-f7vp


### PR DESCRIPTION
## Summary

v3.25.0 backports both security fixes (CVE-2026-44836, CVE-2026-44837) to the 3.x branch. The maintainer released this as a direct response to a backport request.

- **Backport request**: https://github.com/ViewComponent/view_component/issues/2637
- **Release**: https://github.com/ViewComponent/view_component/releases/tag/v3.25.0

## Changes

- `gems/view_component/CVE-2026-44836.yml` — added `>= 3.25.0, < 4.0.0` to `patched_versions`
- `gems/view_component/CVE-2026-44837.yml` — added `>= 3.25.0, < 4.0.0` to `patched_versions`