### PR TITLE
2016 guard-livereload advisory

### DIFF
--- a/gems/guard-livereload/CVE-2016-1000305.yml
+++ b/gems/guard-livereload/CVE-2016-1000305.yml
@@ -1,0 +1,55 @@
+---
+gem: guard-livereload
+cve: 2016-1000305
+url: https://security.snyk.io/vuln/SNYK-RUBY-GUARDLIVERELOAD-20361
+title: Directory traversal vulnerability in guard-livereload
+date: 2016-02-04
+description: |
+  The vulnerability allows remote attackers to read arbitrary files
+  on the server by exploiting improper path validation in the
+  livereload server functionality.
+
+  This vulnerability is related to the handling of file paths in the
+  livereload server component, which could allow an attacker to traverse
+  directories and access files outside the intended web root directory.
+
+  The issue was identified and reported through the DWF (Distributed
+  Weakness Filing) project, which assigns CVE identifiers for
+  security vulnerabilities.
+
+  A directory traversal vulnerability exists in
+  guard-livereload before version 2.5.2.
+cvss_v3: 5.3
+patched_versions:
+  - ">= 2.5.2"
+related:
+  url:
+    - https://security.snyk.io/vuln/SNYK-RUBY-GUARDLIVERELOAD-20361
+    - https://rubygems.org/gems/guard-livereload/versions/2.5.2
+    - https://github.com/guard/guard-livereload/releases/tag/v2.5.2
+    - https://github.com/guard/guard-livereload/pull/158
+    - https://github.com/guard/guard-livereload/pull/158/changes/a24c99e4ce4542d16f5a578df8d47b1275feca46
+    - https://github.com/guard/guard-livereload/issues/159
+    - https://github.com/rubysec/ruby-advisory-db/issues/289
+    - https://github.com/rubysec/ruby-advisory-db/pull/1026
+notes: |
+  - 1/11/2026, 6/8/2026 Notes
+    - 1. Deal with cve-2016-1000305
+         - real, reserved, published?(NONE OF THE ABOVE)
+           - (DEAD) https://cve.report/CVE-2016-1000305 (CVE NOT PUBLISHED)
+    - 2. No GHSA for guard-livereload gem. (checked/fyi)
+    - 3. "date: 2016-02-03" came from gem release date. (fyi)
+    - 4. Pick which description: text to use. (done)
+    - 5. Check "unaffected_versions:" and "patched_versions:" values. (done)
+    - 6. "cvss_v3: 5.3" came from SNYK URL (fyi)
+    - 7. Fill in "related:" URLs. (done)
+  - PR#1026: notes:
+    - DWF: This vulnerability was assigned CVE-2016-1000305 by
+      the DWF (Distributed Weakness Filing) project.
+      - (DWF Info) https://lwn.net/Articles/679441
+        - (DEAD LINK) https://github.com/distributedweaknessfiling/
+          DWF-Database-Artifacts/blob/158c10cf11bc7d6ad728c1a8dd213f
+            523ecfca52/DWF/2016/1000305/CVE-2016-1000305.json
+    - WARNING: The gem has not been released after fixing this
+       vulnerability in version 2.5.2.
+       - Users should consider migrating to rack-livereload as an alternative.


### PR DESCRIPTION
2016 guard-livereload advisory
 * gems/guard-livereload/CVE-2016-1000305.yml

Closes issue #289 and PR #1026 when merged.