### PR TITLE
Four enhanced advisories

### DIFF
--- a/gems/actionmailer/CVE-2024-47889.yml
+++ b/gems/actionmailer/CVE-2024-47889.yml
@@ -44,4 +44,5 @@ patched_versions:
 related:
   url:
     - https://github.com/rails/rails/security/advisories/GHSA-h47h-mwp9-c6q6
+    - https://discuss.rubyonrails.org/t/cve-2024-47889-possible-redos-vulnerability-in-block-format-in-action-mailer/87695
     - https://github.com/advisories/GHSA-h47h-mwp9-c6q6

--- a/gems/nokogiri/CVE-2019-13117.yml
+++ b/gems/nokogiri/CVE-2019-13117.yml
@@ -65,6 +65,8 @@ description: |
   disclosed.
 
   Patched with commit https://gitlab.gnome.org/GNOME/libxslt/commit/2232473733b7313d67de8836ea3b29eec6e8e285
+cvss_v2: 5.0
+cvss_v3: 5.3
 patched_versions:
   - ">= 1.10.5"
 related:
@@ -72,6 +74,7 @@ related:
     - 2019-13118
     - 2019-18197
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-13117
     - https://groups.google.com/d/msg/ruby-security-ann/-Wq4aouIA3Q/yc76ZHemBgAJ
     - https://usn.ubuntu.com/4164-1/
     - https://gitlab.gnome.org/GNOME/libxslt/commit/c5eb6cf3aba0af048596106ed839b4ae17ecbcb1

--- a/gems/puma/CVE-2026-47736.yml
+++ b/gems/puma/CVE-2026-47736.yml
@@ -51,6 +51,7 @@ related:
     - https://github.com/puma/puma/pull/2654
     - https://github.com/puma/puma/issues/2651
     - https://rubyweekly.com/issues/803
+    - https://advisories.gitlab.com/gem/puma/CVE-2026-47736
     - https://github.com/puma/puma/security/advisories/GHSA-qpgp-93vx-g8v8
 notes: |
   - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-47736 (reserved)

--- a/gems/zlib/CVE-2026-27820.yml
+++ b/gems/zlib/CVE-2026-27820.yml
@@ -37,12 +37,14 @@ description: |
 
   Thanks to calysteon for reporting this issue. Also thanks to
   nobu for creating the patch.
+cvss_v3: 9.8
 patched_versions:
   - "~> 3.0.1"
   - "~> 3.1.2"
   - ">= 3.2.3"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-27820
     - https://www.ruby-lang.org/en/news/2026/03/05/buffer-overflow-zlib-cve-2026-27820
     - https://rubygems.org/gems/zlib/versions/3.2.3
     - https://rubygems.org/gems/zlib/versions/3.1.2


### PR DESCRIPTION
Four enhanced advisories
 * gems/actionmailer/CVE-2024-47889.yml
 * gems/nokogiri/CVE-2019-13117.yml
 * gems/puma/CVE-2026-47736.yml
 * gems/zlib/CVE-2026-27820.yml

NOTE: Some came from GHSA and some from normal recon.