### PR TITLE
Tighten json schema advisory checks

### DIFF
--- a/spec/schemas/gem.json
+++ b/spec/schemas/gem.json
@@ -3,6 +3,10 @@
   "$id": "https://github.com/rubysec/ruby-advisory-db/schemas/gem.json",
   "title": "Ruby gem advisory",
   "type": "object",
+  "properties": {},
+  "patternProperties": {
+    "^(?!engine$).*": {}
+  },
   "additionalProperties": false,
   "required": ["gem", "url", "title", "date", "description"],
   "anyOf": [
@@ -11,20 +15,27 @@
     { "required": ["ghsa"] }
   ],
   "properties": {
+    "engine": {
+      "type": "string",
+      "enum": ["ruby", "jruby", "mruby", "mrubyc", "rbx", "truffleruby"]
+    },
     "gem": {
       "type": "string",
       "minLength": 1
     },
     "library": {
       "type": "string",
+      "pattern": "rubygems",
       "minLength": 1
     },
     "framework": {
       "type": "string",
+      "pattern": "rails",
       "minLength": 1
     },
     "platform": {
       "type": "string",
+      "pattern": "jruby",
       "minLength": 1
     },
     "cve": {
@@ -57,8 +68,8 @@
     "description": {
       "type": "string",
       "minLength": 1,
+      "pattern": "\\n",
       "allOf": [
-        { "pattern": "\\n" },
         { "not": { "pattern": "\\\\n\\\\n" } },
         { "not": { "pattern": "(#+) PoC" } }
       ]

--- a/spec/schemas/gem.json
+++ b/spec/schemas/gem.json
@@ -68,7 +68,7 @@
     "description": {
       "type": "string",
       "minLength": 1,
-      "pattern": "\\n",
+      "pattern": "^(?=.*\\n)(?:[^\\n]{1,150})(?:\\n[^\\n]{1,150})*$",
       "allOf": [
         { "not": { "pattern": "\\\\n\\\\n" } },
         { "not": { "pattern": "(#+) PoC" } }

--- a/spec/schemas/ruby.json
+++ b/spec/schemas/ruby.json
@@ -3,6 +3,12 @@
   "$id": "https://github.com/rubysec/ruby-advisory-db/schemas/ruby.json",
   "title": "Ruby implementation advisory",
   "type": "object",
+  "properties": {},
+  "patternProperties": {
+    "^(?!gem$).*": {},
+    "^(?!library$).*": {},
+    "^(?!framework$).*": {}
+  },
   "additionalProperties": false,
   "required": ["engine", "url", "title", "date", "description"],
   "anyOf": [
@@ -17,6 +23,7 @@
     },
     "platform": {
       "type": "string",
+      "pattern": "jruby",
       "minLength": 1
     },
     "cve": {
@@ -49,8 +56,8 @@
     "description": {
       "type": "string",
       "minLength": 1,
+      "pattern": "\\n",
       "allOf": [
-        { "pattern": "\\n" },
         { "not": { "pattern": "\\\\n\\\\n" } },
         { "not": { "pattern": "(#+) PoC" } }
       ]


### PR DESCRIPTION
Tighten json schema advisory checks
  * Disallow some fields in each JSON schema.
   * Provide enums for some fields.
   * Require 2+ lines in descriptions: field.
  