### PR TITLE
Added description: line length max check plus fixed existing files

### DIFF
--- a/gems/actionpack/CVE-2012-1099.yml
+++ b/gems/actionpack/CVE-2012-1099.yml
@@ -8,10 +8,12 @@ url: https://nvd.nist.gov/vuln/detail/CVE-2012-1099
 title: "CVE-2012-1099 rubygem-actionpack: XSS in the \"select\" helper"
 date: 2012-03-01
 description: |
-  Cross-site scripting (XSS) vulnerability in actionpack/lib/action_view/helpers/form_options_helper.rb
-  in the select helper in Ruby on Rails 3.0.x before 3.0.12, 3.1.x before 3.1.4, and
-  3.2.x before 3.2.2 allows remote attackers to inject arbitrary web script or HTML
-  via vectors involving certain generation of OPTION elements within SELECT elements.
+  Cross-site scripting (XSS) vulnerability in
+  actionpack/lib/action_view/helpers/form_options_helper.rb in the select
+  helper in Ruby on Rails 3.0.x before 3.0.12, 3.1.x before 3.1.4, and
+  3.2.x before 3.2.2 allows remote attackers to inject arbitrary web
+  script or HTML via vectors involving certain generation of OPTION
+  elements within SELECT elements.
 cvss_v2: 4.3
 patched_versions:
   - "~> 3.0.12"

--- a/gems/addressable/CVE-2021-32740.yml
+++ b/gems/addressable/CVE-2021-32740.yml
@@ -6,10 +6,13 @@ url: https://github.com/advisories/GHSA-jxhc-q857-3j6g
 date: 2021-07-12
 title: Regular Expression Denial of Service in Addressable templates
 description: |
-  Within the URI template implementation in Addressable, a maliciously crafted template may result in uncontrolled resource consumption,
-  leading to denial of service when matched against a URI. In typical usage, templates would not normally be read from untrusted user input,
-  but nonetheless, no previous security advisory for Addressable has cautioned against doing this.
-  Users of the parsing capabilities in Addressable but not the URI template capabilities are unaffected.
+  Within the URI template implementation in Addressable, a maliciously
+  crafted template may result in uncontrolled resource consumption,
+  leading to denial of service when matched against a URI. In typical
+  usage, templates would not normally be read from untrusted user input,
+  but nonetheless, no previous security advisory for Addressable has
+  cautioned against doing this. Users of the parsing capabilities in
+  Addressable but not the URI template capabilities are unaffected.
 cvss_v3: 7.5
 unaffected_versions:
   - "< 2.3.0"

--- a/gems/fat_free_crm/CVE-2018-20975.yml
+++ b/gems/fat_free_crm/CVE-2018-20975.yml
@@ -6,7 +6,8 @@ url: https://github.com/fatfreecrm/fat_free_crm/commit/6d60bc8ed010c4eda05d6645c
 date: 2019-08-21
 title: fat_free_crm XSS via query parameter of tags_helper method
 description: |
-  Fat Free CRM before 0.18.1 has XSS in the tags_helper in app/helpers/tags_helper.rb.
+  Fat Free CRM before 0.18.1 has XSS in the tags_helper in
+  app/helpers/tags_helper.rb.
 cvss_v3: 6.1
 patched_versions:
   - ">= 0.18.1"

--- a/gems/http/CVE-2015-1828.yml
+++ b/gems/http/CVE-2015-1828.yml
@@ -7,8 +7,9 @@ url: https://groups.google.com/forum/#!topic/httprb/jkb4oxwZjkU
 title: HTTPS MitM vulnerability in http.rb
 date: 2015-03-24
 description: |
-  http.rb failed to call the OpenSSL::SSL::SSLSocket#post_connection_check method to perform hostname verification.
-  Because of this, an attacker with a valid certificate but with a mismatched subject can perform a MitM attack.
+  http.rb failed to call the OpenSSL::SSL::SSLSocket#post_connection_check
+  method to perform hostname verification. Because of this, an attacker with
+  a valid certificate but with a mismatched subject can perform a MitM attack.
 cvss_v2: 5.0
 cvss_v3: 5.9
 patched_versions:

--- a/gems/nokogiri/CVE-2019-13118.yml
+++ b/gems/nokogiri/CVE-2019-13118.yml
@@ -6,9 +6,14 @@ url: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15069
 title: libxslt Type Confusion vulnerability that affects Nokogiri
 date: 2022-05-24
 description: |
-  In `numbers.c` in libxslt 1.1.33, a type holding grouping characters of an `xsl:number` instruction was too narrow and an invalid character/length combination could be passed to `xsltNumberFormatDecimal`, leading to a read of uninitialized stack data.
+  In `numbers.c` in libxslt 1.1.33, a type holding grouping characters of
+  an `xsl:number` instruction was too narrow and an invalid character/length
+  combination could be passed to `xsltNumberFormatDecimal`, leading to
+  a read of uninitialized stack data.
 
-  Nokogiri prior to version 1.10.5 used a vulnerable version of libxslt. Nokogiri 1.10.5 updated libxslt to version 1.1.34 to address this and other vulnerabilities in libxslt.
+  Nokogiri prior to version 1.10.5 used a vulnerable version of libxslt.
+  Nokogiri 1.10.5 updated libxslt to version 1.1.34 to address this
+  and other vulnerabilities in libxslt.
 cvss_v3: 7.5
 patched_versions:
   - ">= 1.10.5"

--- a/gems/nokogiri/CVE-2021-3517.yml
+++ b/gems/nokogiri/CVE-2021-3517.yml
@@ -6,9 +6,17 @@ url: https://bugzilla.redhat.com/show_bug.cgi?id=1954232
 title: Nokogiri contains libxml Out-of-bounds Write vulnerability
 date: 2022-05-24
 description: |
-  There is a flaw in the xml entity encoding functionality of libxml2 in versions before 2.9.11. An attacker who is able to supply a crafted file to be processed by an application linked with the affected functionality of libxml2 could trigger an out-of-bounds read. The most likely impact of this flaw is to application availability, with some potential impact to confidentiality and integrity if an attacker is able to use memory information to further exploit the application.
+  There is a flaw in the xml entity encoding functionality of libxml2 in
+  versions before 2.9.11. An attacker who is able to supply a crafted
+  file to be processed by an application linked with the affected
+  functionality of libxml2 could trigger an out-of-bounds read. The
+  most likely impact of this flaw is to application availability, with
+  some potential impact to confidentiality and integrity if an attacker
+  is able to use memory information to further exploit the application.
 
-  Nokogiri prior to version 1.11.4 used a vulnerable version of libxml2. Nokogiri 1.11.4 updated libxml2 to version 2.9.11 to address this and other vulnerabilities in libxml2.
+  Nokogiri prior to version 1.11.4 used a vulnerable version of libxml2.
+  Nokogiri 1.11.4 updated libxml2 to version 2.9.11 to address this and
+  other vulnerabilities in libxml2.
 cvss_v3: 8.6
 patched_versions:
   - ">= 1.11.4"

--- a/gems/private_address_check/CVE-2017-0909.yml
+++ b/gems/private_address_check/CVE-2017-0909.yml
@@ -6,8 +6,9 @@ url: https://github.com/jtdowney/private_address_check/pull/3
 title: private_address_check Ruby Gem Blacklist Bypass privilege escalation
 date: 2017-11-09
 description: |
-  The private_address_check ruby gem before 0.4.1 is vulnerable to a bypass due to an incomplete
-  blacklist of common private/local network addresses used to prevent server-side request forgery.
+  The private_address_check ruby gem before 0.4.1 is vulnerable to a bypass
+  due to an incomplete blacklist of common private/local network addresses
+  used to prevent server-side request forgery.
 cvss_v2: 7.5
 cvss_v3: 9.8
 patched_versions:

--- a/gems/web-console/CVE-2015-3224.yml
+++ b/gems/web-console/CVE-2015-3224.yml
@@ -6,12 +6,17 @@ url: https://groups.google.com/forum/#!topic/ruby-security-ann/lzmz9_ijUFw
 title: IP whitelist bypass in Web Console
 date: 2015-06-16
 description: |
-  Specially crafted remote requests can spoof their origin, bypassing the IP whitelist, in any environment where Web Console is enabled (development and test, by default).
+  Specially crafted remote requests can spoof their origin, bypassing the
+  IP whitelist, in any environment where Web Console is enabled
+  (development and test, by default).
 
-  Users whose application is only accessible from localhost (as is the default behaviour in Rails 4.2) are not affected, unless a local proxy is involved.
+  Users whose application is only accessible from localhost (as is the default
+  behaviour in Rails 4.2) are not affected, unless a local proxy is involved.
 
-  All affected users should either upgrade or use one of the work arounds immediately.
+  All affected users should either upgrade or use one of the work arounds
+  immediately.
 
-  To work around this issue, turn off web-console in all environments, by removing/commenting it from the application's Gemfile.
+  To work around this issue, turn off web-console in all environments,
+  by removing/commenting it from the application's Gemfile.
 patched_versions:
   - ">= 2.1.3"

--- a/rubies/ruby/CVE-2021-33621.yml
+++ b/rubies/ruby/CVE-2021-33621.yml
@@ -5,9 +5,15 @@ url: https://www.ruby-lang.org/en/news/2022/11/22/http-response-splitting-in-cgi
 title: HTTP response splitting in CGI
 date: 2022-11-22
 description: |
-  If an application that generates HTTP responses using the cgi gem with untrusted user input, an attacker can exploit it to inject a malicious HTTP response header and/or body.
+  If an application that generates HTTP responses using the cgi gem with
+  untrusted user input, an attacker can exploit it to inject a malicious
+  HTTP response header and/or body.
 
-  Also, the contents for a CGI::Cookie object were not checked properly. If an application creates a CGI::Cookie object based on user input, an attacker may exploit it to inject invalid attributes in Set-Cookie header. We think such applications are unlikely, but we have included a change to check arguments for CGI::Cookie#initialize preventatively.
+  Also, the contents for a CGI::Cookie object were not checked properly. If
+  an application creates a CGI::Cookie object based on user input, an
+  attacker may exploit it to inject invalid attributes in Set-Cookie header.
+  We think such applications are unlikely, but we have included a change
+  to check arguments for CGI::Cookie#initialize preventatively.
 cvss_v3: 8.8
 patched_versions:
   - "~> 2.7.7"

--- a/rubies/ruby/CVE-2025-24294.yml
+++ b/rubies/ruby/CVE-2025-24294.yml
@@ -5,12 +5,17 @@ url: https://www.ruby-lang.org/en/news/2025/07/08/dos-resolv-cve-2025-24294/
 title: Possible Denial of Service in resolv gem
 date: 2025-07-08
 description: |
-  A denial of service vulnerability has been discovered in the `resolv` gem bundled with Ruby.
+  A denial of service vulnerability has been discovered in the `resolv`
+  gem bundled with Ruby.
 
-  The vulnerability is caused by an insufficient check on the length of a decompressed domain name within a DNS packet.
-  An attacker can craft a malicious DNS packet containing a highly compressed domain name. When the resolv library parses such a packet,
-  the name-decompression process consumes a large amount of CPU resources, as the library does not limit the resulting length of the name.
-  This resource consumption can cause the application thread to become unresponsive, resulting in a Denial of Service condition.
+  The vulnerability is caused by an insufficient check on the length of
+  a decompressed domain name within a DNS packet. An attacker can craft
+  a malicious DNS packet containing a highly compressed domain name.
+  When the resolv library parses such a packet, the name-decompression
+  process consumes a large amount of CPU resources, as the library
+  does not limit the resulting length of the name.
+  This resource consumption can cause the application thread to become
+  unresponsive, resulting in a Denial of Service condition.
 patched_versions:
   - "~> 3.2.9"
   - "~> 3.3.9"

--- a/rubies/ruby/CVE-2025-61594.yml
+++ b/rubies/ruby/CVE-2025-61594.yml
@@ -5,11 +5,13 @@ url: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/
 title: URI Credential Leakage Bypass
 date: 2025-10-07
 description: |
-  A vulnerability in the URI library bundled with Ruby allows sensitive user credentials
-  (such as usernames or passwords) in a URI to be unintentionally leaked when combining
-  URIs using the `+` operator. This issue bypasses the previous fix for CVE-2025-27221.
+  A vulnerability in the URI library bundled with Ruby allows sensitive
+  user credentials (such as usernames or passwords) in a URI to be
+  unintentionally leaked when combining URIs using the `+` operator.
+  This issue bypasses the previous fix for CVE-2025-27221.
 
-  The issue affects Ruby's built-in URI implementation prior to Ruby 3.3.10 and 3.4.7.
+  The issue affects Ruby's built-in URI implementation prior to
+  Ruby 3.3.10 and 3.4.7.
 patched_versions:
   - "~> 3.3.10"
   - ">= 3.4.7"

--- a/spec/schemas/gem.json
+++ b/spec/schemas/gem.json
@@ -57,6 +57,7 @@
     "description": {
       "type": "string",
       "minLength": 1,
+      "pattern": "^(?!.{81,})(?:[^\n]{1,150})(?:\n[^\n]{1,150})*$",
       "allOf": [
         { "pattern": "\\n" },
         { "not": { "pattern": "\\\\n\\\\n" } },

--- a/spec/schemas/ruby.json
+++ b/spec/schemas/ruby.json
@@ -49,6 +49,7 @@
     "description": {
       "type": "string",
       "minLength": 1,
+      "pattern": "^(?!.{81,})(?:[^\n]{1,150})(?:\n[^\n]{1,150})*$",
       "allOf": [
         { "pattern": "\\n" },
         { "not": { "pattern": "\\\\n\\\\n" } },


### PR DESCRIPTION
Added `description:` line length max check plus fixed existing files
  * to both gem.json and ruby.json
   * Fixed 8 gems advisories and 3 rubies advisories.