### PR TITLE
Fix CVSS v3 and v4 parsing/output in GitHub advisory sync.

### DIFF
--- a/gems/action_text-trix/GHSA-53p3-c7vp-4mcc.yml
+++ b/gems/action_text-trix/GHSA-53p3-c7vp-4mcc.yml
@@ -34,6 +34,7 @@ description: |
 
   The XSS vulnerability was responsibly reported by Hackerone
   researcher [newbiefromcoma](https://hackerone.com/newbiefromcoma).
+cvss_v4: 2.1
 patched_versions:
   - ">= 2.1.18"
 related:

--- a/gems/actionmailer/CVE-2024-47889.yml
+++ b/gems/actionmailer/CVE-2024-47889.yml
@@ -34,6 +34,7 @@ description: |
   ##Credits
 
   Thanks to [ooooooo_q](https://hackerone.com/ooooooo_q) for the report!
+cvss_v4: 6.6
 unaffected_versions:
   - "< 3.0.0"
 patched_versions:

--- a/gems/actionpack/CVE-2024-47887.yml
+++ b/gems/actionpack/CVE-2024-47887.yml
@@ -36,6 +36,7 @@ description: |
   ## Credits
 
   Thanks to [scyoon](https://hackerone.com/scyoon) for reporting
+cvss_v4: 6.6
 unaffected_versions:
   - "< 4.0.0"
 patched_versions:

--- a/gems/actionpack/CVE-2026-33167.yml
+++ b/gems/actionpack/CVE-2026-33167.yml
@@ -15,6 +15,7 @@ description: |
 
   ### Releases
   The fixed releases are available at the normal locations.
+cvss_v4: 1.3
 unaffected_versions:
   - "< 8.1.0"
 patched_versions:

--- a/gems/actiontext/CVE-2024-32464.yml
+++ b/gems/actiontext/CVE-2024-32464.yml
@@ -46,6 +46,7 @@ description: |
 
   Thank you [ooooooo_q](https://hackerone.com/ooooooo_q) for reporting this!
 cvss_v3: 6.1
+cvss_v4: 5.1
 unaffected_versions:
   - "< 7.1.0"
 patched_versions:

--- a/gems/actiontext/CVE-2024-47888.yml
+++ b/gems/actiontext/CVE-2024-47888.yml
@@ -35,6 +35,7 @@ description: |
   ## Credits
 
   Thanks to [ooooooo_q](https://hackerone.com/ooooooo_q) for the report!
+cvss_v4: 6.6
 unaffected_versions:
   - "< 6.0.0"
 patched_versions:

--- a/gems/actionview/CVE-2026-33168.yml
+++ b/gems/actionview/CVE-2026-33168.yml
@@ -15,6 +15,7 @@ description: |
 
   ### Releases
   The fixed releases are available at the normal locations.
+cvss_v4: 2.3
 patched_versions:
   - "~> 7.2.3, >= 7.2.3.1"
   - "~> 8.0.4, >= 8.0.4.1"

--- a/gems/activejob/GHSA-mpwp-4h2m-765c.yml
+++ b/gems/activejob/GHSA-mpwp-4h2m-765c.yml
@@ -15,6 +15,7 @@ description: |
     We also fixed an Active Job bug that allowed String
     arguments to be deserialized as if they were Global IDs,
     an object injection security vulnerability.
+cvss_v4: 6.6
 patched_versions:
   - ">= 4.2.0.beta2"
 related:

--- a/gems/activerecord-jdbc-adapter/GHSA-5qw5-wf2q-f538.yml
+++ b/gems/activerecord-jdbc-adapter/GHSA-5qw5-wf2q-f538.yml
@@ -14,6 +14,7 @@ description: |
   using it in SQL queries. This may allow a remote attacker to inject or
   manipulate SQL queries in the back-end database, allowing for the
   manipulation or disclosure of arbitrary data.
+cvss_v4: 8.8
 unaffected_versions:
   - "< 1.2.6"
 patched_versions:

--- a/gems/activerecord/CVE-2013-3221.yml
+++ b/gems/activerecord/CVE-2013-3221.yml
@@ -21,6 +21,7 @@ description: |
     But "Indeed the vector is completely fixed as of Rails 4.2 almost
     two years after the original advisory."
 cvss_v2: 6.4
+cvss_v4: 9.3
 patched_versions:
   - ">= 4.2.0"
 related:

--- a/gems/activerecord/CVE-2025-55193.yml
+++ b/gems/activerecord/CVE-2025-55193.yml
@@ -23,6 +23,7 @@ description: |
 
   Thanks to [lio346](https://hackerone.com/lio346) for reporting
   this vulnerability.
+cvss_v4: 5.3
 patched_versions:
   - "~> 7.1.5, >= 7.1.5.2"
   - "~> 7.2.2, >= 7.2.2.2"

--- a/gems/activestorage/CVE-2025-24293.yml
+++ b/gems/activestorage/CVE-2025-24293.yml
@@ -56,6 +56,7 @@ description: |
   ## Credits
 
   Thank you [lio346](https://hackerone.com/lio346) for reporting this!
+cvss_v4: 9.2
 unaffected_versions:
   - "< 5.20"
 patched_versions:

--- a/gems/activestorage/CVE-2026-33173.yml
+++ b/gems/activestorage/CVE-2026-33173.yml
@@ -15,6 +15,7 @@ description: |
 
   ### Releases
   The fixed releases are available at the normal locations.
+cvss_v4: 5.3
 patched_versions:
   - "~> 7.2.3, >= 7.2.3.1"
   - "~> 8.0.4, >= 8.0.4.1"

--- a/gems/activestorage/CVE-2026-33174.yml
+++ b/gems/activestorage/CVE-2026-33174.yml
@@ -16,6 +16,7 @@ description: |
 
   ### Releases
   The fixed releases are available at the normal locations.
+cvss_v4: 6.6
 patched_versions:
   - "~> 7.2.3, >= 7.2.3.1"
   - "~> 8.0.4, >= 8.0.4.1"

--- a/gems/activestorage/CVE-2026-33195.yml
+++ b/gems/activestorage/CVE-2026-33195.yml
@@ -17,6 +17,7 @@ description: |
 
   ### Releases
   The fixed releases are available at the normal locations.
+cvss_v4: 8.0
 patched_versions:
   - "~> 7.2.3, >= 7.2.3.1"
   - "~> 8.0.4, >= 8.0.4.1"

--- a/gems/activestorage/CVE-2026-33202.yml
+++ b/gems/activestorage/CVE-2026-33202.yml
@@ -14,6 +14,7 @@ description: |
 
   ### Releases
   The fixed releases are available at the normal locations.
+cvss_v4: 6.6
 patched_versions:
   - "~> 7.2.3, >= 7.2.3.1"
   - "~> 8.0.4, >= 8.0.4.1"

--- a/gems/activesupport/CVE-2026-33169.yml
+++ b/gems/activesupport/CVE-2026-33169.yml
@@ -13,6 +13,7 @@ description: |
 
   ### Releases
   The fixed releases are available at the normal locations.
+cvss_v4: 6.9
 patched_versions:
   - "~> 7.2.3, >= 7.2.3.1"
   - "~> 8.0.4, >= 8.0.4.1"

--- a/gems/activesupport/CVE-2026-33170.yml
+++ b/gems/activesupport/CVE-2026-33170.yml
@@ -14,6 +14,7 @@ description: |
 
   ### Releases
   The fixed releases are available at the normal locations.
+cvss_v4: 5.3
 patched_versions:
   - "~> 7.2.3, >= 7.2.3.1"
   - "~> 8.0.4, >= 8.0.4.1"

--- a/gems/activesupport/CVE-2026-33176.yml
+++ b/gems/activesupport/CVE-2026-33176.yml
@@ -15,6 +15,7 @@ description: |
 
   ### Releases
   The fixed releases are available at the normal locations.
+cvss_v4: 6.6
 patched_versions:
   - "~> 7.2.3, >= 7.2.3.1"
   - "~> 8.0.4, >= 8.0.4.1"

--- a/gems/bcrypt/CVE-2026-33306.yml
+++ b/gems/bcrypt/CVE-2026-33306.yml
@@ -34,6 +34,7 @@ description: |
   ### Workarounds
 
   Set the cost to something less than 31.
+cvss_v4: 4.5
 patched_versions:
   - ">= 3.1.22"
 related:

--- a/gems/bindata/CVE-2021-32823.yml
+++ b/gems/bindata/CVE-2021-32823.yml
@@ -13,5 +13,6 @@ description: |
   for a CPU-based DoS. In version 2.4.10, bindata improved the creation time of Bits
   and Integers.
 cvss_v3: 3.7
+cvss_v4: 6.3
 patched_versions:
   - ">= 2.4.10"

--- a/gems/bitcoinrb/GHSA-q66h-m87m-j2q6.yml
+++ b/gems/bitcoinrb/GHSA-q66h-m87m-j2q6.yml
@@ -35,6 +35,7 @@ description: |
     in `RequestHandler`.
 
   - Fixed in version 1.12.0.
+cvss_v4: 2.0
 patched_versions:
   - ">= 1.12.0"
 related:

--- a/gems/camaleon_cms/CVE-2024-46986.yml
+++ b/gems/camaleon_cms/CVE-2024-46986.yml
@@ -88,6 +88,7 @@ description: |
   [CodeQL: Uncontrolled data used in path expression](https://codeql.github.com/codeql-query-help/ruby/rb-path-injection/)
   [OWASP: Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
 cvss_v3: 9.9
+cvss_v4: 8.7
 unaffected_versions:
   - "< 2.8.0"
 patched_versions:

--- a/gems/camaleon_cms/CVE-2024-46987.yml
+++ b/gems/camaleon_cms/CVE-2024-46987.yml
@@ -65,6 +65,7 @@ description: |
   * [CodeQL: Uncontrolled data used in path expression](https://codeql.github.com/codeql-query-help/ruby/rb-path-injection/)
   * [OWASP: Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
 cvss_v3: 7.7
+cvss_v4: 7.1
 patched_versions:
   - ">= 2.8.1"
 related:

--- a/gems/camaleon_cms/CVE-2024-48652.yml
+++ b/gems/camaleon_cms/CVE-2024-48652.yml
@@ -10,6 +10,7 @@ description: |
   remote attacker to execute arbitrary code via the content group
   name field.
 cvss_v3: 4.8
+cvss_v4: 4.8
 notes: |
   Never patched
 

--- a/gems/camaleon_cms/GHSA-75j2-9gmc-m855.yml
+++ b/gems/camaleon_cms/GHSA-75j2-9gmc-m855.yml
@@ -43,6 +43,7 @@ description: |
   could make sense to use the authentication provided by Ruby on Rails,
   so that stolen tokens cannot be used anymore after some time.
 cvss_v3: 5.4
+cvss_v4: 4.8
 unaffected_versions:
   - "< 2.8.0"
 patched_versions:

--- a/gems/camaleon_cms/GHSA-7x4w-cj9r-h4v9.yml
+++ b/gems/camaleon_cms/GHSA-7x4w-cj9r-h4v9.yml
@@ -72,6 +72,7 @@ description: |
   [CodeQL: Uncontrolled data used in path expression](https://codeql.github.com/codeql-query-help/ruby/rb-path-injection/)
   [OWASP: Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
 cvss_v3: 7.2
+cvss_v4: 8.6
 patched_versions:
   - ">= 2.8.1"
 related:

--- a/gems/camaleon_cms/GHSA-8fx8-3rg2-79xw.yml
+++ b/gems/camaleon_cms/GHSA-8fx8-3rg2-79xw.yml
@@ -43,6 +43,7 @@ description: |
   Ruby on Rails, so that stolen tokens cannot be used anymore
   after some time.
 cvss_v3: 5.4
+cvss_v4: 4.8
 patched_versions:
   - ">= 2.8.1"
 related:

--- a/gems/camaleon_cms/GHSA-r9cr-qmfw-pmrc.yml
+++ b/gems/camaleon_cms/GHSA-r9cr-qmfw-pmrc.yml
@@ -43,6 +43,7 @@ description: |
   Ruby on Rails, so that stolen tokens cannot be used anymore
   after some time.
 cvss_v3: 5.4
+cvss_v4: 4.8
 patched_versions:
   - ">= 2.8.1"
 related:

--- a/gems/cgi/CVE-2025-27219.yml
+++ b/gems/cgi/CVE-2025-27219.yml
@@ -27,6 +27,7 @@ description: |
   Thanks to lio346 for discovering this issue.
   Also thanks to mame for fixing this vulnerability.
 cvss_v3: 5.8
+cvss_v4: 6.3
 patched_versions:
   - "~> 0.3.5.1"
   - "~> 0.3.7"

--- a/gems/cgi/CVE-2025-27220.yml
+++ b/gems/cgi/CVE-2025-27220.yml
@@ -28,6 +28,7 @@ description: |
   Thanks to svalkanov for discovering this issue.
   Also thanks to nobu for fixing this vulnerability.
 cvss_v3: 4.0
+cvss_v4: 6.3
 patched_versions:
   - "~> 0.3.5.1"
   - "~> 0.3.7"

--- a/gems/decidim-admin/CVE-2024-27095.yml
+++ b/gems/decidim-admin/CVE-2024-27095.yml
@@ -30,6 +30,7 @@ description: |
 
   OWASP ASVS v4.0.3-5.1.3
 cvss_v3: 5.4
+cvss_v4: 6.8
 patched_versions:
   - "~> 0.27.6"
   - ">= 0.28.1"

--- a/gems/decidim-admin/CVE-2024-32034.yml
+++ b/gems/decidim-admin/CVE-2024-32034.yml
@@ -23,6 +23,7 @@ description: |
   ### References
   OWASP ASVS v4.0.3-5.1.3
 cvss_v3: 6.8
+cvss_v4: 6.0
 patched_versions:
   - "~> 0.27.7"
   - ">= 0.28.2"

--- a/gems/decidim-decidim_awesome/CVE-2024-43415.yml
+++ b/gems/decidim-decidim_awesome/CVE-2024-43415.yml
@@ -53,6 +53,7 @@ description: |
   https://pentest.ait.ac.at/security-advisory/decidim-awesome-sql-injection-in-adminaccountability
   https://portswigger.net/web-security/sql-injection
 cvss_v3: 9.0
+cvss_v4: 8.5
 unaffected_versions:
   - "< 0.11.0"
 patched_versions:

--- a/gems/decidim-meetings/CVE-2024-45594.yml
+++ b/gems/decidim-meetings/CVE-2024-45594.yml
@@ -26,6 +26,7 @@ description: |
   Partizipationsbüro against Decidim. The security audit was implemented
   by the Austrian Institute of Technology.
 cvss_v3: 7.7
+cvss_v4: 5.1
 unaffected_versions:
   - "< 0.28.0"
 patched_versions:

--- a/gems/decidim/CVE-2024-27090.yml
+++ b/gems/decidim/CVE-2024-27090.yml
@@ -22,6 +22,7 @@ description: |
 
   Disallow access through your web server to the URLs finished with `/embed.html`
 cvss_v3: 5.3
+cvss_v4: 6.9
 patched_versions:
   - ">= 0.27.6"
 related:

--- a/gems/decidim/CVE-2024-32469.yml
+++ b/gems/decidim/CVE-2024-32469.yml
@@ -28,6 +28,7 @@ description: |
   done during April 2024. The security audit was implemented by
   [AIT Austrian Institute of Technology GmbH](https://www.ait.ac.at/),
 cvss_v3: 7.1
+cvss_v4: 6.3
 patched_versions:
   - "~> 0.27.6"
   - ">= 0.28.1"

--- a/gems/decidim/CVE-2024-39910.yml
+++ b/gems/decidim/CVE-2024-39910.yml
@@ -29,6 +29,7 @@ description: |
   ### References
   OWASP ASVS v4.0.3-5.1.3
 cvss_v3: 5.4
+cvss_v4: 5.9
 patched_versions:
   - ">= 0.27.7"
 related:

--- a/gems/decidim/CVE-2024-41673.yml
+++ b/gems/decidim/CVE-2024-41673.yml
@@ -25,6 +25,7 @@ description: |
   [Open Source Politics](https://opensourcepolitics.eu/)
   against Decidim done during July 2025.
 cvss_v3: 7.1
+cvss_v4: 7.1
 patched_versions:
   - ">= 0.27.8"
 related:

--- a/gems/devise/CVE-2026-32700.yml
+++ b/gems/devise/CVE-2026-32700.yml
@@ -47,6 +47,7 @@ description: |
   change, so you might have to implement a workaround similar to
   Devise by setting changed_attributes["unconfirmed_email"] = nil as well.
 cvss_v3: 5.3
+cvss_v4: 6.0
 patched_versions:
   - ">= 5.0.3"
 related:

--- a/gems/doorkeeper-openid_connect/CVE-2026-44476.yml
+++ b/gems/doorkeeper-openid_connect/CVE-2026-44476.yml
@@ -40,6 +40,7 @@ description: |
   Upgrade existing applications created with a Dynamic Client registration
   to have `confidential: true`
 cvss_v3: 6.3
+cvss_v4: 6.3
 unaffected_versions:
   - "< 1.9.0"
 patched_versions:

--- a/gems/fat_free_crm/GHSA-9pm8-vwc5-w2hm.yml
+++ b/gems/fat_free_crm/GHSA-9pm8-vwc5-w2hm.yml
@@ -22,6 +22,7 @@ description: |
 
   Disable use of email dropbox.
 cvss_v3: 2.1
+cvss_v4: 2.1
 patched_versions:
   - ">= 0.26.0"
 related:

--- a/gems/fugit/CVE-2024-43380.yml
+++ b/gems/fugit/CVE-2024-43380.yml
@@ -31,6 +31,7 @@ description: |
   In fewer words, making sure those fugit methods are not fed
   unvetted input strings.
 cvss_v3: 5.3
+cvss_v4: 5.3
 patched_versions:
   - ">= 1.11.1"
 related:

--- a/gems/jquery-rails/CVE-2020-7656.yml
+++ b/gems/jquery-rails/CVE-2020-7656.yml
@@ -14,6 +14,7 @@ description: |
   allows attackers to execute arbitrary JavaScript in a victim's browser.
 cvss_v2: 4.3
 cvss_v3: 6.1
+cvss_v4: 5.3
 patched_versions:
   - ">= 2.1.4"
 related:

--- a/gems/json/CVE-2026-33210.yml
+++ b/gems/json/CVE-2026-33210.yml
@@ -23,6 +23,7 @@ description: |
 
   The issue can be avoided by not using the `allow_duplicate_key: false`
   parsing option.
+cvss_v4: 8.3
 unaffected_versions:
   - "< 2.14.0"
 patched_versions:

--- a/gems/logstash/CVE-2014-4326.yml
+++ b/gems/logstash/CVE-2014-4326.yml
@@ -10,6 +10,7 @@ description: |
   remote attackers to execute arbitrary commands via a crafted
   event in (1) `zabbix.rb` or (2) `nagios_nsca.rb` in `outputs/`.
 cvss_v2: 7.5
+cvss_v4: 8.1
 unaffected_versions:
   - "< 1.0.14"
 patched_versions:

--- a/gems/loofah/GHSA-46fp-8f5p-pf2m.yml
+++ b/gems/loofah/GHSA-46fp-8f5p-pf2m.yml
@@ -41,6 +41,7 @@ description: |
   ## Credit
 
   Responsibly reported by HackOne user `@smlee`.
+cvss_v4: 2.7
 unaffected_versions:
   - "< 2.25.0"
 patched_versions:

--- a/gems/mcp/CVE-2026-33946.yml
+++ b/gems/mcp/CVE-2026-33946.yml
@@ -37,6 +37,7 @@ description: |
   belonging to the victim. The tool responses can be sensitive
   confidential data.
 cvss_v3: 8.2
+cvss_v4: 8.2
 patched_versions:
   - ">= 0.9.2"
 related:

--- a/gems/measured/GHSA-29g5-m8v7-v564.yml
+++ b/gems/measured/GHSA-29g5-m8v7-v564.yml
@@ -16,6 +16,7 @@ description: |
   ### Patches
 
   Users should update to the latest version.
+cvss_v4: 4.9
 patched_versions:
   - ">= 3.2.1"
 related:

--- a/gems/mpxj/CVE-2024-49771.yml
+++ b/gems/mpxj/CVE-2024-49771.yml
@@ -24,6 +24,7 @@ description: |
   ### References
   N/A
 cvss_v3: 5.3
+cvss_v4: 5.3
 unaffected_versions:
   - "< 8.3.5"
 patched_versions:

--- a/gems/net-imap/CVE-2025-25186.yml
+++ b/gems/net-imap/CVE-2025-25186.yml
@@ -141,6 +141,7 @@ description: |
   end
   ```
 cvss_v3: 6.5
+cvss_v4: 6.0
 unaffected_versions:
   - "< 0.3.2"
 patched_versions:

--- a/gems/net-imap/CVE-2026-47240.yml
+++ b/gems/net-imap/CVE-2026-47240.yml
@@ -70,6 +70,7 @@ description: |
     or `IMAP4rev2` capabilities before using untrusted string inputs
     for the affected "raw data" arguments.
 cvss_v3: 5.8
+cvss_v4: 5.8
 patched_versions:
   - "~> 0.5.15"
   - ">= 0.6.4.1"

--- a/gems/net-imap/CVE-2026-47241.yml
+++ b/gems/net-imap/CVE-2026-47241.yml
@@ -88,6 +88,7 @@ description: |
   and user code will often need to wait for state changing commands to successfully
   complete before issuing commands that rely on that state change.
 cvss_v3: 2.1
+cvss_v4: 2.1
 patched_versions:
   - "~> 0.5.15"
   - ">= 0.6.4.1"

--- a/gems/net-imap/CVE-2026-47242.yml
+++ b/gems/net-imap/CVE-2026-47242.yml
@@ -59,6 +59,7 @@ description: |
   * or add validation that client ID field values must not contain
     any CR or LF bytes.
 cvss_v3: 4.3
+cvss_v4: 5.8
 patched_versions:
   - "~> 0.5.15"
   - ">= 0.6.4.1"

--- a/gems/puma/CVE-2024-45614.yml
+++ b/gems/puma/CVE-2024-45614.yml
@@ -30,6 +30,7 @@ description: |
   for security or availability should immediately cease doing so
   until upgraded to the fixed versions.
 cvss_v3: 5.4
+cvss_v4: 6.3
 patched_versions:
   - "~> 5.6.9"
   - ">= 6.4.3"

--- a/gems/pwpush/CVE-2024-52796.yml
+++ b/gems/pwpush/CVE-2024-52796.yml
@@ -37,6 +37,7 @@ description: |
   [v1.49.0]: https://github.com/pglombardo/PasswordPusher/releases/tag/v1.49.0
   [1]: https://docs.pwpush.com/docs/proxies/#trusted-proxies
 cvss_v3: 5.3
+cvss_v4: 2.7
 patched_versions:
   - ">= 1.49.0"
 related:

--- a/gems/rack-ssl/CVE-2014-2538.yml
+++ b/gems/rack-ssl/CVE-2014-2538.yml
@@ -12,5 +12,6 @@ description: |
   or HTML via a URI, which might not be properly handled by third-party adapters such
   as JRuby-Rack.
 cvss_v2: 4.3
+cvss_v4: 5.3
 patched_versions:
   - ">= 1.3.4"

--- a/gems/rails_admin/CVE-2024-39308.yml
+++ b/gems/rails_admin/CVE-2024-39308.yml
@@ -32,6 +32,7 @@ description: |
   https://owasp.org/www-community/attacks/xss/
   https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-strip_tags
 cvss_v3: 6.8
+cvss_v4: 6.1
 patched_versions:
   - "~> 2.3.0"
   - ">= 3.1.3"

--- a/gems/rdoc/CVE-2024-27281.yml
+++ b/gems/rdoc/CVE-2024-27281.yml
@@ -30,6 +30,7 @@ description: |
   Note: 6.3.4, 6.4.1, 6.5.1 and 6.6.3 have a incorrect fix. We recommend to
   upgrade 6.3.4.1, 6.4.1.1, 6.5.1.1 and 6.6.3.1 instead of them.
 cvss_v3: 4.5
+cvss_v4: 2.3
 patched_versions:
   - "~> 6.3.4, >= 6.3.4.1"
   - "~> 6.4.1, >= 6.4.1.1"

--- a/gems/red-arrow/CVE-2019-12408.yml
+++ b/gems/red-arrow/CVE-2019-12408.yml
@@ -13,6 +13,7 @@ description: |
   over the wire (for instance with Flight) or persisted in the streaming IPC and file
   formats.
 cvss_v3: 7.5
+cvss_v4: 8.7
 unaffected_versions:
   - "< 0.14.0"
 patched_versions:

--- a/gems/red-arrow/CVE-2019-12410.yml
+++ b/gems/red-arrow/CVE-2019-12410.yml
@@ -13,6 +13,7 @@ description: |
   if are transmitted over the wire (for instance with Flight) or persisted in the
   streaming IPC and file formats.
 cvss_v3: 7.5
+cvss_v4: 8.7
 unaffected_versions:
   - "< 0.12.0"
 patched_versions:

--- a/gems/request_store/CVE-2024-43791.yml
+++ b/gems/request_store/CVE-2024-43791.yml
@@ -27,6 +27,7 @@ description: |
 
   You could chmod the files yourself, I guess.
 cvss_v3: 7.8
+cvss_v4: 5.9
 unaffected_versions:
   - "< 1.3.2"
 patched_versions:

--- a/gems/resolv/CVE-2025-24294.yml
+++ b/gems/resolv/CVE-2025-24294.yml
@@ -37,6 +37,7 @@ description: |
   ## History
   Originally published at 2025-07-08 07:00:00 (UTC)
 cvss_v3: 7.5
+cvss_v4: 6.6
 patched_versions:
   - "~> 0.2.2"
   - "~> 0.3.0"

--- a/gems/rexml/CVE-2024-39908.yml
+++ b/gems/rexml/CVE-2024-39908.yml
@@ -29,6 +29,7 @@ description: |
 
   Originally published at 2024-07-16 03:00:00 (UTC)
 cvss_v3: 4.3
+cvss_v4: 6.9
 patched_versions:
   - ">= 3.3.2"
 related:

--- a/gems/rexml/CVE-2024-41123.yml
+++ b/gems/rexml/CVE-2024-41123.yml
@@ -29,6 +29,7 @@ description: |
 
   Originally published at 2024-08-01 03:00:00 (UTC)
 cvss_v3: 5.3
+cvss_v4: 6.9
 patched_versions:
   - ">= 3.3.3"
 related:

--- a/gems/rexml/CVE-2024-41946.yml
+++ b/gems/rexml/CVE-2024-41946.yml
@@ -29,6 +29,7 @@ description: |
 
   Originally published at 2024-08-01 03:00:00 (UTC)
 cvss_v3: 5.3
+cvss_v4: 6.9
 patched_versions:
   - ">= 3.3.3"
 related:

--- a/gems/rexml/CVE-2024-43398.yml
+++ b/gems/rexml/CVE-2024-43398.yml
@@ -40,6 +40,7 @@ description: |
 
   Originally published at 2024-08-22 03:00:00 (UTC)
 cvss_v3: 5.9
+cvss_v4: 8.2
 patched_versions:
   - ">= 3.3.6"
 related:

--- a/gems/ruby-saml/CVE-2024-45409.yml
+++ b/gems/ruby-saml/CVE-2024-45409.yml
@@ -11,6 +11,7 @@ description: |
   Response/Assertion with arbitrary contents. This would allow the attacker to log in as arbitrary user within
   the vulnerable system.
 cvss_v3: 10.0
+cvss_v4: 9.9
 patched_versions:
   - "~> 1.12.3"
   - ">= 1.17.0"

--- a/gems/sequenceserver/CVE-2024-42360.yml
+++ b/gems/sequenceserver/CVE-2024-42360.yml
@@ -20,6 +20,7 @@ description: |
 
   No known workarounds
 cvss_v3: 9.8
+cvss_v4: 9.3
 patched_versions:
   - ">= 3.1.2"
 related:

--- a/gems/sidekiq-unique-jobs/CVE-2023-46950.yml
+++ b/gems/sidekiq-unique-jobs/CVE-2023-46950.yml
@@ -10,6 +10,7 @@ description: |
   allows a remote attacker to obtain sensitive information via a
   crafted URL to the filter functions.
 cvss_v3: 6.1
+cvss_v4: 5.1
 patched_versions:
   - "~> 7.1.33"
   - ">= 8.0.7"

--- a/gems/sinatra/CVE-2024-21510.yml
+++ b/gems/sinatra/CVE-2024-21510.yml
@@ -17,6 +17,7 @@ description: |
   handling the X-Forwarded-Host header, attackers can potentially
   exploit Cache Poisoning or Routing-based SSRF.
 cvss_v3: 5.4
+cvss_v4: 5.3
 patched_versions:
   - ">= 4.1.0"
 related:

--- a/gems/sinatra/CVE-2025-61921.yml
+++ b/gems/sinatra/CVE-2025-61921.yml
@@ -27,6 +27,7 @@ description: |
   * https://github.com/sinatra/sinatra/pull/2121 (fix)
   * https://github.com/sinatra/sinatra/pull/1823 (older ReDoS vulnerability)
   * https://bugs.ruby-lang.org/issues/19104 (fix in Ruby >= 3.2)
+cvss_v4: 2.7
 patched_versions:
   - ">= 4.2.0"
 related:

--- a/gems/spree/GHSA-xf4v-w5x5-pv79.yml
+++ b/gems/spree/GHSA-xf4v-w5x5-pv79.yml
@@ -23,6 +23,7 @@ description: |
   software are the direct victims. Administrative accounts have
   access to all store data, payment method configurations, customer
   PII, and full order history.
+cvss_v4: 5.2
 unaffected_versions:
   - "< 5.2.0"
 patched_versions:

--- a/gems/sqlite-vec/CVE-2024-46488.yml
+++ b/gems/sqlite-vec/CVE-2024-46488.yml
@@ -12,6 +12,7 @@ description: |
 
   Workaround for CVE in release 0.1.3.
 cvss_v3: 9.1
+cvss_v4: 8.8
 patched_versions:
   - ">= 0.1.3"
 related:

--- a/gems/stringio/CVE-2024-27280.yml
+++ b/gems/stringio/CVE-2024-27280.yml
@@ -25,5 +25,6 @@ description: |
   You can use `gem update stringio` to update it. If you are using bundler,
   please add `gem "stringio", ">= 3.0.1.2"` to your `Gemfile`.
 cvss_v3: 9.8
+cvss_v4: 9.3
 patched_versions:
   - ">= 3.0.1.1"

--- a/gems/uri/CVE-2025-27221.yml
+++ b/gems/uri/CVE-2025-27221.yml
@@ -31,6 +31,7 @@ description: |
   Thanks to Tsubasa Irisawa (lambdasawa) for discovering this issue.
   Also thanks to nobu for additional fixes of this vulnerability.
 cvss_v3: 5.3
+cvss_v4: 2.1
 patched_versions:
   - "~> 0.11.3"
   - "~> 0.12.4"

--- a/gems/zlib/CVE-2026-27820.yml
+++ b/gems/zlib/CVE-2026-27820.yml
@@ -38,6 +38,7 @@ description: |
   Thanks to calysteon for reporting this issue. Also thanks to
   nobu for creating the patch.
 cvss_v3: 9.8
+cvss_v4: 5.9
 patched_versions:
   - "~> 3.0.1"
   - "~> 3.1.2"

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -152,9 +152,15 @@ module GitHub
                 summary
                 description
                 severity
-                cvss {
-                  score
-                  vectorString
+                cvssSeverities {
+                  cvssV3 {
+                    score
+                    vectorString
+                  }
+                  cvssV4 {
+                    score
+                    vectorString
+                  }
                 }
                 references {
                   url
@@ -356,10 +362,19 @@ module GitHub
       !advisory["withdrawnAt"].nil?
     end
 
-    def cvss
-      return if advisory["cvss"]["vectorString"].nil?
+    def cvss_v3
+      cvss_score("cvssV3")
+    end
 
-      advisory["cvss"]["score"].to_f
+    def cvss_v4
+      cvss_score("cvssV4")
+    end
+
+    def cvss_score(version)
+      severity = advisory.dig("cvssSeverities", version)
+      return if severity.nil? || severity["vectorString"].nil?
+
+      severity["score"].to_f
     end
 
     def external_reference
@@ -384,7 +399,8 @@ module GitHub
         "url"         => external_reference,
         "title"       => advisory["summary"],
         "description" => advisory["description"],
-        "cvss_v3"     => cvss,
+        "cvss_v3"     => cvss_v3,
+        "cvss_v4"     => cvss_v4,
       }.compact
     end
 
@@ -472,7 +488,11 @@ module GitHub
       filename_to_write = package.filename
 
       new_data = package.merge_data(
-        "cvss_v3" => (cvss if cvss) # Used value if have one else no field.
+        # Include each score only if we have one, else no field.
+        {
+          "cvss_v3" => cvss_v3,
+          "cvss_v4" => cvss_v4,
+        }.compact
       )
 
       if (unaffected_versions = unaffected_versions_for(package))


### PR DESCRIPTION
Disclaimer: This change was generated using Claude Code, but fully reviewed, tested, and validated by me. This PR description was written by me.

I noticed that generating the YML files for the recent nokogiri security advisories resulted in no CVSS score when the GHSA only had a CVSS v4 score. After investigating, I discovered that we were using a deprecated field in the GraphQL query on the GitHub API, and it did not return any v4 scores. This fixes that problem by updating the GraphQL query in the sync task and then the code for extracting the scores accordingly.

I can add further tests here if desired, the current tests for this file are fairly sparse so I wasn't sure what the project preferences were.

Fixes #1128.