### PR TITLE
Improve "PoC"/"Proof of Concept" detection to match more variations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ patched_versions:
   vulnerability. It may contain multiple paragraphs.
   * Used `description: |` if it is more than one sentence/line.
   * Line wrap `descriptions:` field at 80.
-  * Do no include "POC" or "PoC" in `description:` field.
+  * Do not include "POC", "PoC", or "Proof of Concept" heading sections
+    (any casing) in the `description:` field.
   * Not use "\n" or "%" in `description:` field.
 * `cvss_v2` \[Float\] (optional): The [CVSSv2] score for the vulnerability.
 * `cvss_v3` \[Float\] (optional): The [CVSSv3] score for the vulnerability.
@@ -183,7 +184,8 @@ patched_versions:
   * Used `description: |` (not `|-`) if it is more than one sentence/line.
   * Line wrap `descriptions:` field at 80.
   * Not use "\n" or "%" in `description:` field.
-  * Do no include "POC" or "PoC" in `description:` field.
+  * Do not include "POC", "PoC", or "Proof of Concept" heading sections
+    (any casing) in the `description:` field.
 * `cvss_v2` \[Float\] (optional): The [CVSSv2] score for the vulnerability.
 * `cvss_v3` \[Float\] (optional): The [CVSSv3] score for the vulnerability.
 * `cvss_v4` \[Float\] (optional): The [CVSSv4] score for the vulnerability.

--- a/gems/bsv-sdk/CVE-2026-40070.yml
+++ b/gems/bsv-sdk/CVE-2026-40070.yml
@@ -120,31 +120,6 @@ description: |
     attacker-controlled data.
   - **A:N** — availability unaffected.
 
-  ## Proof of concept
-
-  ```ruby
-  client = BSV::Wallet::WalletClient.new(key,
-    storage: BSV::Wallet::MemoryStore.new)
-
-  client.acquire_certificate(
-    type: 'age-over-18',
-    acquisition_protocol: 'direct',
-    certifier: claimed_trusted_pubkey_hex,
-    serial_number: 'any-serial',
-    revocation_outpoint: ('00' * 32) + '.0',
-    signature: 'deadbeef' * 16,       # arbitrary bytes — never verified
-    fields: { 'verified' => 'true' },
-    keyring_for_subject: {}
-  )
-
-  client.list_certificates(
-    certifiers: [claimed_trusted_pubkey_hex],
-    types: ['age-over-18']
-  )
-  # => returns the forged record as if it were a real
-  #    certificate from that certifier
-  ```
-
   ## Affected versions
 
   The vulnerable direct-path code was introduced in commit `d14dd19`

--- a/gems/bsv-wallet/CVE-2026-40070.yml
+++ b/gems/bsv-wallet/CVE-2026-40070.yml
@@ -123,31 +123,6 @@ description: |
     attacker-controlled data.
   - **A:N** — availability unaffected.
 
-  ## Proof of concept
-
-  ```ruby
-  client = BSV::Wallet::WalletClient.new(key,
-    storage: BSV::Wallet::MemoryStore.new)
-
-  client.acquire_certificate(
-    type: 'age-over-18',
-    acquisition_protocol: 'direct',
-    certifier: claimed_trusted_pubkey_hex,
-    serial_number: 'any-serial',
-    revocation_outpoint: ('00' * 32) + '.0',
-    signature: 'deadbeef' * 16,       # arbitrary bytes — never verified
-    fields: { 'verified' => 'true' },
-    keyring_for_subject: {}
-  )
-
-  client.list_certificates(
-    certifiers: [claimed_trusted_pubkey_hex],
-    types: ['age-over-18']
-  )
-  # => returns the forged record as if it were a real certificate
-  #    from that certifier
-  ```
-
   ## Affected versions
 
   The vulnerable direct-path code was introduced in commit `d14dd19`

--- a/gems/camaleon_cms/CVE-2024-46987.yml
+++ b/gems/camaleon_cms/CVE-2024-46987.yml
@@ -43,12 +43,6 @@ description: |
 
   [send_file]: https://github.com/owen2345/camaleon-cms/blob/feccb96e542319ed608acd3a16fa5d92f13ede67/app/controllers/camaleon_cms/admin/media_controller.rb#L33-L34
 
-  ## Proof of concept
-
-  An authenticated user can download the /etc/passwd file by visiting an URL such as:
-
-      https://<camaleon-host>/admin/media/download_private_file?file=../../../../../../etc/passwd
-
   ## Impact
 
   This issue may lead to Information Disclosure.

--- a/gems/camaleon_cms/GHSA-7x4w-cj9r-h4v9.yml
+++ b/gems/camaleon_cms/GHSA-7x4w-cj9r-h4v9.yml
@@ -40,22 +40,6 @@ description: |
   Where it is joined in an unchecked manner with the root folder and
   then deleted.
 
-  **Proof of concept**
-  The following request would delete the file README.md in the top
-  folder of the Ruby on Rails application. (The values for auth_token,
-  X-CSRF-Token and _cms_session would also need to be replaced with
-  authenticated values in the curl command below)
-  ```
-  curl --path-as-is -i -s -k -X $'POST' \
-      -H $'X-CSRF-Token: [..]' -H $'User-Agent: Mozilla/5.0' -H $'Content-Type: application/x-www-form-urlencoded; charset=UTF-8' -H $'Accept: */*' -H $'Connection: keep-alive' \
-      -b $'auth_token=[..]; _cms_session=[..]' \
-      --data-binary $'versions=&thumb_size=&formats=&media_formats=&dimension=&private=&folder=..
-  2F..
-  2F..
-  2FREADME.md&media_action=del_file' \
-      $'https://<camaleon-host>/admin/media/actions?actions=true'
-  ```
-
   **Impact**
 
   This issue may lead to a defective CMS or system.

--- a/gems/carrierwave/CVE-2021-21305.yml
+++ b/gems/carrierwave/CVE-2021-21305.yml
@@ -15,15 +15,6 @@ description: |
   (But supplying untrusted input to the option itself is dangerous even in absence of this vulnerability, since is prone to
   DoS vulnerability - attackers can try to consume massive amounts of memory by resizing to a very large dimension)
 
-  ### Proof of Concept
-  ```ruby
-  class MyUploader < CarrierWave::Uploader::Base
-    include CarrierWave::RMagick
-  end
-
-  MyUploader.new.manipulate!({ read: { density: "1 }; p 'Hacked'; {" }}) # => shows "Hacked"
-  ```
-
   ### Patches
   Upgrade to [2.1.1](https://rubygems.org/gems/carrierwave/versions/2.1.1) or
   [1.3.2](https://rubygems.org/gems/carrierwave/versions/1.3.2).

--- a/gems/google-protobuf/CVE-2021-22569.yml
+++ b/gems/google-protobuf/CVE-2021-22569.yml
@@ -23,11 +23,6 @@ description: |
   minutes by creating large numbers of short-lived objects that cause frequent,
   repeated GC pauses.
 
-  ## Proof of Concept
-
-  For reproduction details, please refer to the oss-fuzz issue that identifies
-  the specific inputs that exercise this parsing weakness.
-
   ## Remediation and Mitigation
 
   Please update to the latest available versions of the following packages:

--- a/gems/google-protobuf/CVE-2024-7254.yml
+++ b/gems/google-protobuf/CVE-2024-7254.yml
@@ -27,12 +27,6 @@ description: |+
   or against Protobuf map fields, creates unbounded recursions that can
   be abused by an attacker.
 
-  ### Proof of Concept
-  For reproduction details, please refer to the unit tests (Protobuf Java
-  [LiteTest](https://github.com/protocolbuffers/protobuf/blob/a037f28ff81ee45ebe008c64ab632bf5372242ce/java/lite/src/test/java/com/google/protobuf/LiteTest.java)
-  and [CodedInputStreamTest](https://github.com/protocolbuffers/protobuf/blob/a037f28ff81ee45ebe008c64ab632bf5372242ce/java/core/src/test/java/com/google/protobuf/CodedInputStreamTest.java))
-  that identify the specific inputs that exercise this parsing weakness.
-
   ### Remediation and Mitigation
   We have been working diligently to address this issue and have released
   a mitigation that is available now. Please update to the latest

--- a/gems/jquery-rails/CVE-2012-6708.yml
+++ b/gems/jquery-rails/CVE-2012-6708.yml
@@ -13,11 +13,6 @@ description: |
   the regular expression. The result is that `jquery` may interpret HTML
   as selectors when given certain inputs, allowing for client side code
   execution.
-
-  ## Proof of Concept
-  $("#log").html(
-      $("element[attribute='<img src=\"x\" onerror=\"alert(1)\" />']").html()
-  );
 cvss_v2: 4.3
 cvss_v3: 6.1
 patched_versions:

--- a/gems/spree_api/CVE-2026-22588.yml
+++ b/gems/spree_api/CVE-2026-22588.yml
@@ -34,8 +34,6 @@ description: |
   authorized to modify their own order, the backend does not verify
   that the supplied address identifiers belong to the same authenticated user.
 
-  **See reference below for POC.**
-
   ### Impact
 
   As a result, an attacker can:

--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -153,7 +153,7 @@ shared_examples_for 'Advisory' do |path|
       end
 
       it "must not have PoC sections" do
-        expect(subject).to_not include("### PoC")
+        expect(subject).to_not match(/(#+) *(?:poc\b|proof of concept)/i)
       end
 
       it { expect(subject).to be_kind_of(String) }

--- a/spec/schemas/gem.json
+++ b/spec/schemas/gem.json
@@ -58,7 +58,7 @@
       "pattern": "^(?=.{1,80}$)(?=.*\\n)(?:[^\n]{1,80})(?:\n[^\n]{1,80})*$",
       "allOf": [
         { "not": { "pattern": "\\\\n\\\\n" } },
-        { "not": { "pattern": "(#+) PoC" } }
+        { "not": { "pattern": "(?i)(#+) *(poc\\b|proof of concept)" } }
       ]
     },
     "cvss_v2": {

--- a/spec/schemas/ruby.json
+++ b/spec/schemas/ruby.json
@@ -54,7 +54,7 @@
       "pattern": "^(?=.{1,80}$)(?=.*\\n)(?:[^\n]{1,80})(?:\n[^\n]{1,80})*$",
       "allOf": [
         { "not": { "pattern": "\\\\n\\\\n" } },
-        { "not": { "pattern": "(#+) PoC" } }
+        { "not": { "pattern": "(?i)(#+) *(poc\\b|proof of concept)" } }
       ]
     },
     "cvss_v2": {


### PR DESCRIPTION
AI Disclosure: The regex was generated with Claude Code, all changes tested and reviewed manually by me.

This updates the RSpec check and the checks in the JSON Schemas to catch different capitalizations and also the full "Proof of Concept" phrase.

And update YML files that violated the improved rule.

Fixes #1131.