### PR TITLE
GHSA/SYNC: 3 new oj advisories

### DIFF
--- a/gems/oj/CVE-2026-54500.yml
+++ b/gems/oj/CVE-2026-54500.yml
@@ -1,0 +1,51 @@
+---
+gem: oj
+cve: 2026-54500
+ghsa: fm7p-mprw-wjm9
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54500
+title: Oj - intern.c form_attr (uninitialized stack read)
+date: 2026-06-19
+description: |
+  ### Summary
+
+  `Oj.load` in `:object` mode reads uninitialized stack memory (and,
+  for long keys, reads out of bounds) when parsing a JSON object whose
+  key is 254 bytes or longer. The interned bytes can surface to the
+  caller, disclosing process stack memory.
+
+  ### Impact
+
+  Information disclosure of process stack memory to a caller that parses
+  untrusted JSON with `Oj.load(..., mode: :object)`. For keys >= 256
+  bytes it is also an out-of-bounds read (CWE-125).
+
+  Severity is bounded by several preconditions: it requires `:object`
+  mode (which is already discouraged for untrusted input), the leaked
+  bytes are uncontrolled (the attacker cannot choose what is disclosed),
+  and the data only reaches an attacker if the application surfaces the
+  resulting Symbol or `EncodingError` back to them. Scored CVSS 5.3
+  (Medium) on that basis.
+
+  ### Patches
+
+  Fixed in **3.17.3**: `form_attr()` now passes `b` to `rb_intern3` (a
+  one-character change mirroring the earlier `usual.c` fix). Verified on
+  the fixed build: the same payload returns cleanly with no leak across
+  repeated runs.
+
+  ### Credit
+
+  Reported by Zac Wang (@7a6163).
+cvss_v3: 5.3
+patched_versions:
+  - ">= 3.17.3"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54500
+    - https://rubygems.org/gems/oj/versions/3.17.3
+    - https://github.com/ohler55/oj/blob/master/CHANGELOG.md#3173---2026-06-04
+    - https://github.com/ohler55/oj/pull/1015
+    - https://github.com/ohler55/oj/security/advisories/GHSA-fm7p-mprw-wjm9
+    - https://github.com/advisories/GHSA-fm7p-mprw-wjm9
+notes: |
+  - CVE is reserved, but published so no cvss_v2 or cvss_v4 values.

--- a/gems/oj/CVE-2026-54502.yml
+++ b/gems/oj/CVE-2026-54502.yml
@@ -1,0 +1,30 @@
+---
+gem: oj
+cve: 2026-54502
+ghsa: 3v45-f3vh-wg7m
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54502
+title: Oj - Stack Buffer Overflow in Oj.dump via Large Indent
+date: 2026-06-19
+description: |
+  ### Summary
+
+  `Oj.dump` is vulnerable to a stack-based buffer overflow when a large
+  `:indent` value is provided by the developer. `fill_indent` in `dump.h`
+  calls `memset(indent_str, ' ', (size_t)opts->indent)` without validating
+  the size. When `opts->indent` is set to `INT_MAX` (2,147,483,647), the
+  `(size_t)` cast preserves the large value and `memset` writes 2 GB into
+  the stack-allocated `out` buffer (4,184 bytes), corrupting the stack
+  and crashing the process.
+cvss_v4: 8.7
+patched_versions:
+  - ">= 3.17.3"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54502
+    - https://rubygems.org/gems/oj/versions/3.17.3
+    - https://github.com/ohler55/oj/blob/master/CHANGELOG.md#3173---2026-06-04
+    - https://github.com/ohler55/oj/pull/1015
+    - https://github.com/ohler55/oj/security/advisories/GHSA-3v45-f3vh-wg7m
+    - https://github.com/advisories/GHSA-3v45-f3vh-wg7m
+notes: |
+  - CVE is reserved, but published so no cvss_v2 or cvss_v3 values.

--- a/gems/oj/CVE-2026-54592.yml
+++ b/gems/oj/CVE-2026-54592.yml
@@ -44,6 +44,5 @@ related:
     - https://github.com/ohler55/oj/pull/1015
     - https://github.com/ohler55/oj/security/advisories/GHSA-3m6q-jj5j-38c9
     - https://github.com/advisories/GHSA-3m6q-jj5j-38c9
-
 notes: |
   - CVE is reserved, but published so no cvss_v2 or cvss_v4 values.

--- a/gems/oj/CVE-2026-54592.yml
+++ b/gems/oj/CVE-2026-54592.yml
@@ -1,0 +1,49 @@
+---
+gem: oj
+cve: 2026-54592
+ghsa: 3m6q-jj5j-38c9
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54592
+title: Oj - Stack Buffer Overflow in Oj::Doc#each_child via Deeply Nested Input
+date: 2026-06-19
+description: |
+  ### Summary
+
+  `Oj::Doc#each_child`, when invoked recursively over a deeply nested JSON
+  document, overflows a fixed-size stack buffer and aborts the process. This is a
+  denial of service reachable from untrusted JSON.
+
+  ### Impact
+
+  Reliable denial of service: any endpoint that calls
+  `Oj::Doc.open(untrusted) { |d| d.each_child ... }` recursively can be
+  crashed with a small deeply-nested payload. On builds with a stack
+  protector (the default, `-fstack-protector-strong`) the canary aborts
+  the process before the saved return address is used. The Step-1 heap
+  OOB writes into `struct _doc` fields do occur, but are masked in
+  practice because the Step-2 stack overflow crashes first; turning them
+  into anything beyond a crash has not been demonstrated.
+
+  ### Patches
+
+  Fixed in **3.17.3**: `doc_each_child` now bounds-checks before incrementing
+  `doc->where` (raising `Oj::DepthError`) and restores `doc->where` after the
+  loop, matching the existing `each_leaf` pattern. Verified on the fixed build:
+  depth >= 101 raises a clean `Oj::DepthError` instead of aborting.
+
+  ### Credit
+
+  Reported by Zac Wang (@7a6163).
+cvss_v3: 7.5
+patched_versions:
+  - ">= 3.17.3"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54592
+    - https://rubygems.org/gems/oj/versions/3.17.3
+    - https://github.com/ohler55/oj/blob/master/CHANGELOG.md#3173---2026-06-04
+    - https://github.com/ohler55/oj/pull/1015
+    - https://github.com/ohler55/oj/security/advisories/GHSA-3m6q-jj5j-38c9
+    - https://github.com/advisories/GHSA-3m6q-jj5j-38c9
+
+notes: |
+  - CVE is reserved, but published so no cvss_v2 or cvss_v4 values.


### PR DESCRIPTION
GHSA/SYNC: 3 new oj advisories
 * gems/oj/CVE-2026-54592.yml
 * gems/oj/CVE-2026-54500.yml
 * gems/oj/CVE-2026-54502.yml
 
 See extra blank line - I will remove it.
