### PR TITLE
Four more new oj gem advisories

### DIFF
--- a/gems/oj/CVE-2026-54896.yml
+++ b/gems/oj/CVE-2026-54896.yml
@@ -1,0 +1,30 @@
+---
+gem: oj
+cve: 2026-54896
+ghsa: 35w3-pjm6-wj95
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54896
+title: Oj - Heap Buffer Overflow in Oj.dump Exception Serialization
+  via Large Indent
+date: 2026-06-19
+description: |
+  ### Summary
+
+  `Oj.dump` in object mode is vulnerable to a heap buffer overflow when
+  serializing Exception objects with a large `:indent` value. The
+  serializer allocates a buffer sized for the object's attributes but
+  does not account for the indent bytes added on each write. With
+  `indent: 5000`, the accumulation of 5,000-byte indent strings overflows
+  the 13,150-byte heap allocation, corrupting adjacent heap memory.
+cvss_v4: 8.7
+patched_versions:
+  - ">= 3.17.3"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54896
+    - https://rubygems.org/gems/oj/versions/3.17.3
+    - https://github.com/ohler55/oj/blob/master/CHANGELOG.md#3173---2026-06-04
+    - https://github.com/ohler55/oj/pull/1015
+    - https://github.com/ohler55/oj/security/advisories/GHSA-35w3-pjm6-wj95
+    - https://github.com/advisories/GHSA-35w3-pjm6-wj95
+notes: |
+  - CVE is reserved, but published so no cvss_v2 or cvss_v3 values.

--- a/gems/oj/CVE-2026-54897.yml
+++ b/gems/oj/CVE-2026-54897.yml
@@ -1,0 +1,29 @@
+---
+gem: oj
+cve: 2026-54897
+ghsa: 9ppp-w3g4-fh4q
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54897
+title: Oj - Use-After-Free in Oj::Doc Iterators via Reentrant Close
+date: 2026-06-19
+description: |
+  ### Summary
+
+  `Oj::Doc` iterators (`each_value`, `each_child`, `each_leaf`) are
+  vulnerable to a heap use-after-free. When a Ruby block yielded during
+  iteration calls `doc.close` or `d.close`, the document's heap memory
+  is freed while the C iterator is still running. When control returns
+  from the block, the iterator reads from the freed region, producing
+  a use-after-free accessible from pure Ruby.
+cvss_v4: 8.7
+patched_versions:
+  - ">= 3.17.3"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54897
+    - https://rubygems.org/gems/oj/versions/3.17.3
+    - https://github.com/ohler55/oj/blob/master/CHANGELOG.md#3173---2026-06-04
+    - https://github.com/ohler55/oj/pull/1015
+    - https://github.com/ohler55/oj/security/advisories/GHSA-9ppp-w3g4-fh4q
+    - https://github.com/advisories/GHSA-9ppp-w3g4-fh4q
+notes: |
+  - CVE is reserved, but published so no cvss_v2 or cvss_v3 values.

--- a/gems/oj/CVE-2026-54898.yml
+++ b/gems/oj/CVE-2026-54898.yml
@@ -3,7 +3,7 @@ gem: oj
 cve: 2026-54898
 ghsa: q2gm-54r6-8fwm
 url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54898
-title: Oj - Use-After-Free in Oj::Parser SAJ Callback via Input Mutation'
+title: Oj - Use-After-Free in Oj::Parser SAJ Callback via Input Mutation
 date: 2026-06-19
 description: |
   ### Summary

--- a/gems/oj/CVE-2026-54898.yml
+++ b/gems/oj/CVE-2026-54898.yml
@@ -1,0 +1,31 @@
+---
+gem: oj
+cve: 2026-54898
+ghsa: q2gm-54r6-8fwm
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54898
+title: Oj - Use-After-Free in Oj::Parser SAJ Callback via Input Mutation'
+date: 2026-06-19
+description: |
+  ### Summary
+
+  `Oj::Parser#parse` is vulnerable to a heap use-after-free when a
+  SAJ/SAJ2 callback mutates the input JSON string during parsing.
+  The C engine holds a raw `const byte *` pointer into the Ruby string's
+  internal buffer. If a callback (e.g. `hash_start`) resizes the
+  string — for example by calling `String#replace` with a longer
+  value — Ruby reallocates the string buffer and frees the old one. The
+  C parser's pointer is left dangling; the next character read
+  at `parser.c:607` is a use-after-free.
+cvss_v4: 8.7
+patched_versions:
+  - ">= 3.17.3"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54898
+    - https://rubygems.org/gems/oj/versions/3.17.3
+    - https://github.com/ohler55/oj/blob/master/CHANGELOG.md#3173---2026-06-04
+    - https://github.com/ohler55/oj/pull/1015
+    - https://github.com/ohler55/oj/security/advisories/GHSA-q2gm-54r6-8fwm
+    - https://github.com/advisories/GHSA-q2gm-54r6-8fwm
+notes: |
+  - CVE is reserved, but published so no cvss_v2 or cvss_v3 values.

--- a/gems/oj/CVE-2026-54899.yml
+++ b/gems/oj/CVE-2026-54899.yml
@@ -1,0 +1,28 @@
+---
+gem: oj
+cve: 2026-54899
+ghsa: 2cw7-v8ff-p88r
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54899
+title: Oj - Use-After-Free in Oj::Parser Symbol Key Cache Toggle
+date: 2026-06-19
+description: |
+  ### Summary
+
+  Disabling `symbol_keys` on a reused `Oj::Parser` instance triggers a
+  heap use-after-free. When `symbol_keys` is toggled from `true` to
+  `false`, `opt_symbol_keys_set` frees the internal key cache (`cache_free`)
+  but does not clear the pointer. The next `parse` call reads from
+  the freed cache via `cache_intern`, producing a use-after-free.
+cvss_v4: 8.7
+patched_versions:
+  - ">= 3.17.3"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54899
+    - https://rubygems.org/gems/oj/versions/3.17.3
+    - https://github.com/ohler55/oj/blob/master/CHANGELOG.md#3173---2026-06-04
+    - https://github.com/ohler55/oj/pull/1015
+    - https://github.com/ohler55/oj/security/advisories/GHSA-2cw7-v8ff-p88r
+    - https://github.com/advisories/GHSA-2cw7-v8ff-p88r
+notes: |
+  - CVE is reserved, but published so no cvss_v2 or cvss_v3 values.


### PR DESCRIPTION
Four more new oj gem advisories
 * gems/oj/CVE-2026-54896.yml
 * gems/oj/CVE-2026-54897.yml
 * gems/oj/CVE-2026-54898.yml
 * gems/oj/CVE-2026-54899.yml
