### PR TITLE
Update faraday CVE-2026-54297 for 1.10.6 backport

### DIFF
--- a/gems/faraday/CVE-2026-54297.yml
+++ b/gems/faraday/CVE-2026-54297.yml
@@ -54,11 +54,18 @@ description: |
   This issue does not provide remote code execution, authentication
   bypass, or data disclosure. The confirmed impact is availability loss.
 
+  ## Patched Versions
+
+  The fix was released in Faraday 2.14.3 and backported to the 1.x
+  branch in Faraday 1.10.6, which adds a `param_depth_limit` to
+  `NestedParamsEncoder`.
+
   ## Reporter
 
   Reported by: Emre Koca
 cvss_v3: 7.5
 patched_versions:
+  - "~> 1.10.6"
   - ">= 2.14.3"
 related:
   url:
@@ -66,6 +73,9 @@ related:
     - https://rubygems.org/gems/faraday/versions/2.14.3
     - https://github.com/lostisland/faraday/releases/tag/v2.14.3
     - https://github.com/lostisland/faraday/compare/v2.14.2...v2.14.3
+    - https://rubygems.org/gems/faraday/versions/1.10.6
+    - https://github.com/lostisland/faraday/releases/tag/v1.10.6
+    - https://github.com/lostisland/faraday/compare/v1.10.5...v1.10.6
     - https://test.osv.dev/vulnerability/GHSA-98m9-hrrm-r99r
     - https://advisories.gitlab.com/gem/faraday/CVE-2026-54297
     - https://github.com/lostisland/faraday/security/advisories/GHSA-98m9-hrrm-r99r
@@ -74,3 +84,4 @@ notes: |
   - cvss_v3 from GHSA
   - cve is reserved, but no cve at nvd.nist.gov, so no cvss_v2 or cvss_v4
   - Removed a lot of text from description field. See reference for details.
+  - Fix backported to the 1.x branch in faraday 1.10.6.


### PR DESCRIPTION
The fix for GHSA-98m9-hrrm-r99r was backported to the 1.x branch in [faraday 1.10.6](https://github.com/lostisland/faraday/releases/tag/v1.10.6), which adds a `param_depth_limit` to `NestedParamsEncoder`.

This updates the advisory accordingly:
- Add `~> 1.10.6` to `patched_versions` (alongside the existing `>= 2.14.3`)
- Note the backport in the description and notes
- Add related URLs for the v1.10.6 release

Follow-up to #1136.
