### PR TITLE
Advisories: 2 new and 1 modified/renamed + add ghsa to rubies adv

### DIFF
--- a/gems/commonmarker/CVE-2023-37463.yml
+++ b/gems/commonmarker/CVE-2023-37463.yml
@@ -1,7 +1,8 @@
 ---
 gem: commonmarker
+cve: 2023-37463
 ghsa: 7vh7-fw88-wj87
-url: https://github.com/gjtorikian/commonmarker/security/advisories/GHSA-7vh7-fw88-wj87
+url: https://nvd.nist.gov/vuln/detail/CVE-2023-37463
 title: Several quadratic complexity bugs may lead to
   denial of service in Commonmarker
 date: 2023-08-08
@@ -23,15 +24,17 @@ description: |
 
   Users are advised to upgrade to commonmarker version
   [`0.23.10`](https://rubygems.org/gems/commonmarker/versions/0.23.10).
-
+cvss_v3: 7.5
 patched_versions:
   - ">= 0.23.10"
 related:
   url:
-    - https://github.com/gjtorikian/commonmarker/security/advisories/GHSA-7vh7-fw88-wj87
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-37463
+    - https://rubygems.org/gems/commonmarker/versions/0.23.10
     - https://github.com/github/cmark-gfm/releases/tag/0.29.0.gfm.12
     - https://github.com/gjtorikian/commonmarker/commit/db8cd377b54541f7fd484d168b7682a282a680f7
+    - https://github.com/gjtorikian/commonmarker/security/advisories/GHSA-7vh7-fw88-wj87
     - https://github.com/github/cmark-gfm/security/advisories/GHSA-w4qg-3vf7-m9x5
-    - https://rubygems.org/gems/commonmarker/versions/0.23.10
     - https://github.com/advisories/GHSA-7vh7-fw88-wj87
-notes: "No CVE number, no cvss_v2, no cvss_v3"
+notes: |
+  - cvss_v3 came from nvd.nist.gov URL.

--- a/gems/mongoid/CVE-2026-2302.yml
+++ b/gems/mongoid/CVE-2026-2302.yml
@@ -1,0 +1,42 @@
+---
+gem: mongoid
+cve: 2026-2302
+ghsa: 68xj-h57p-gg5j
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-2302
+title: Mongoid::Criteria.from_hash method allows arbitrary method calls
+date: 2026-02-27
+description: |
+  Under specific conditions when processing a maliciously crafted
+  value of type Hash r, Mongoid::Criteria.from_hash may allow for
+  executing arbitrary Ruby code.
+cvss_v3: 6.5
+cvss_v4: 6.9
+patched_versions:
+  - "~> 7.6.1"
+  - "~> 8.0.12"
+  - "~> 8.1.12"
+  - ">= 9.0.10"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-2302
+    - https://github.com/mongodb/mongoid/releases/tag/v9.0.10
+    - https://github.com/mongodb/mongoid/pull/6099
+    - https://rubygems.org/gems/mongoid/versions/8.1.12
+      - https://github.com/mongodb/mongoid/releases/tag/v8.1.12
+        - https://github.com/mongodb/mongoid/pull/6100
+    - https://rubygems.org/gems/mongoid/versions/8.0.12
+      - https://github.com/mongodb/mongoid/releases/tag/v8.0.12
+        - https://github.com/mongodb/mongoid/pull/6101
+    - https://rubygems.org/gems/mongoid/versions/7.6.1
+      - https://github.com/mongodb/mongoid/releases/tag/v7.6.1
+        - https://github.com/mongodb/mongoid/pull/6102
+    - https://github.com/mongodb/mongoid/pull/6087
+    - https://github.com/mongodb/mongoid/pull/6086
+    - https://github.com/mongodb/mongoid/pull/6085
+    - https://github.com/mongodb/mongoid/pull/6084
+    - https://github.com/mongodb/mongoid/pull/6083
+    - https://jira.mongodb.org/browse/MONGOID-5919
+    - https://github.com/advisories/GHSA-68xj-h57p-gg5j
+notes: |
+  - GHSA is unreviewed.
+  - date from nvd.nist.gov URL.

--- a/gems/webrick/CVE-2026-38969.yml
+++ b/gems/webrick/CVE-2026-38969.yml
@@ -1,0 +1,24 @@
+---
+gem: webrick
+cve: 2026-38969
+ghsa: h4w6-wx8r-p68v
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-38969
+title: ruby webrick through v1.9.2 WEBrick reparses trailer
+date: 2026-07-02
+description: |
+  ruby webrick through v1.9.2 WEBrick reparses trailer Content-Length
+  into canonical request state, enabling request smuggling.
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-38969
+    - https://github.com/ruby/webrick/pull/199
+    - https://github.com/ruby/webrick/issues/198
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-7519
+    - https://github.com/advisories/GHSA-h4w6-wx8r-p68v
+notes: |
+
+  - Not patched (last release was 1.9.2)
+    - https://rubygems.org/gems/webrick/versions/1.9.2
+    - https://github.com/ruby/webrick/releases/tag/v1.9.2
+  - No CVSS value in nvd.nist.gov URL.
+  - GHSA is unreviewed.

--- a/rubies/ruby/CVE-2026-46727.yml
+++ b/rubies/ruby/CVE-2026-46727.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2026-46727
+ghsa: jfc8-2xw7-c79m
 url: https://nvd.nist.gov/vuln/detail/CVE-2026-46727
 title: CVE-2026-46727 - Use-after-free in pthread-based getaddrinfo timeout handler
 date: 2026-05-20
@@ -31,5 +32,6 @@ related:
     - https://github.com/ruby/ruby/releases/tag/v4.0.5
     - https://www.ruby-lang.org/en/news/2026/05/20/getaddrinfo-cve-2026-46727
     - https://hackerone.com/reports/3607434
+    - https://github.com/advisories/GHSA-jfc8-2xw7-c79m
 notes: |
   - "Ruby 3.4 series and earlier are not affected." in ruby-lang post.


### PR DESCRIPTION
Advisories: 2 new and 1 modified/renamed + add ghsa to rubies adv
 * modified and renamed:   gems/commonmarker/CVE-2023-37463.yml
 * New
   * gems/mongoid/
   * gems/webrick/CVE-2026-38969.yml
 * Added ghsa field/value
   * rubies/ruby/CVE-2026-46727.yml
