### PR TITLE
Add patched_version data to 2 rubies advs

### DIFF
--- a/rubies/mruby/CVE-2025-7207.yml
+++ b/rubies/mruby/CVE-2025-7207.yml
@@ -17,12 +17,13 @@ description: |
 cvss_v2: 1.7
 cvss_v3: 5.5
 cvss_v4: 4.4
-notes: |
-  - Not patched - mruby 3.5.0 has not been released as of 2026/02/07.
-  - Found Issue #6509 listed in **unreleased** mruby 3.5 file listed below.
+patched_versions:
+  - ">= 4.0.0"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-7207
+    - https://mruby.org/releases/2026/04/20/mruby-4.0.0-released.html
+    - https://github.com/mruby/mruby/blob/master/NEWS.md#user-visible-changes-in-mruby40-from-mruby34
     - https://github.com/mruby/mruby/blob/6f321251785c2396cb7e6a576ac2080c1adb4491/NEWS.md
     - https://github.com/mruby/mruby/commit/1fdd96104180cc0fb5d3cb086b05ab6458911bb9.patch
     - https://github.com/mruby/mruby/commit/1fdd96104180cc0fb5d3cb086b05ab6458911bb9
@@ -33,3 +34,8 @@ related:
     - https://vuldb.com/?submit.607683
     - https://www.wiz.io/vulnerability-database/cve/cve-2025-7207
     - https://github.com/advisories/GHSA-48pr-6hvf-39v3
+notes: |
+  - Older notes
+    - Not patched - mruby 3.5.0 has not been released as of 2026/02/07.
+    - Found Issue #6509 listed in **unreleased** mruby 3.5 file listed below.
+  - Picked release 4.0.0 instead of rc's.

--- a/rubies/mrubyc/CVE-2025-13397.yml
+++ b/rubies/mrubyc/CVE-2025-13397.yml
@@ -10,22 +10,24 @@ description: |
   This impacts the function mrbc_raw_realloc of the file src/alloc.c.
   Such manipulation of the argument ptr leads to null pointer
   dereference. An attack has to be approached locally.
-  The name of the patch is 009111904807b8567262036bf45297c3da8f1c87.
-  It is advisable to implement a patch to correct this issue.
-
-  ## RELEASE INFO
-  - Release 3.4 commit stopped on 6/26/2025 and ommit 0091119 was
-    on 10/14/2025 so not in 3.4. Do not see any CHANGELOG or NEWS files.
 cvss_v2: .17
 cvss_v3: 5.5
 cvss_v4: 4.8
-notes: "Never patched"
+patched_versions:
+  - ">= 3.4.1"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2025-13397
+    - https://github.com/mrubyc/mrubyc/releases/tag/release3.4.1
     - https://github.com/mrubyc/mrubyc/commit/009111904807b8567262036bf45297c3da8f1c87
     - https://github.com/mrubyc/mrubyc/issues/244
     - https://vuldb.com/?ctiid.332925
     - https://vuldb.com/?id.332925
     - https://vuldb.com/?submit.692130
     - https://github.com/advisories/GHSA-99jr-qh2r-jwfm
+notes: |
+  - PATCH/RELEASE INFO
+    - The name of the patch is 009111904807b8567262036bf45297c3da8f1c87.
+      It is advisable to implement a patch to correct this issue.
+    - Release 3.4 commit stopped on 6/26/2025 and commit 0091119 was
+      on 10/14/2025 so not in 3.4. Do not see any CHANGELOG or NEWS files.


### PR DESCRIPTION
Add patched_version data to 2 rubies advs
 * rubies/mruby/CVE-2025-7207.yml
 * rubies/mrubyc/CVE-2025-13397.yml
 
 NOTE: These are the **only 2 rubies** advisories without "patched_versions" values.
