### PR TITLE
update patched_versions for GHSA-mjgf-xj26-9qf9

### DIFF
--- a/gems/pay/GHSA-mjgf-xj26-9qf9.yml
+++ b/gems/pay/GHSA-mjgf-xj26-9qf9.yml
@@ -38,15 +38,16 @@ description: |
 
   - Credit - Reported by tonghuaroot (https://github.com/tonghuaroot)
 cvss_v3: 7.4
+patched_versions:
+  - ">= 11.6.2"
 related:
   url:
     - https://advisories.gitlab.com/gem/pay/GHSA-mjgf-xj26-9qf9
     - https://github.com/pay-rails/pay/security/advisories/GHSA-mjgf-xj26-9qf9
     - https://github.com/advisories/GHSA-mjgf-xj26-9qf9
 notes: |
-  - Latest (unpatched) release as of 7/2/2026 is 11.6.1
-    - `pay` (rubygem) ≤ v11.6.1 (latest release as of 2026-05-27).
-    - https://github.com/pay-rails/pay/releases/tag/v11.6.1
-    - https://rubygems.org/gems/pay/versions/11.6.1
+  - Fixed in 11.6.2.
+    - https://github.com/pay-rails/pay/releases/tag/v11.6.2
+    - https://rubygems.org/gems/pay/versions/11.6.2
   - cvss_v3 value comes from project advisory.
   - No cve value, so missing cvss_v2 and cvss_v4 values.


### PR DESCRIPTION
﻿Add patched_versions for GHSA-mjgf-xj26-9qf9 (pay)

Sets patched_versions: [">= 11.6.2"] on the pay advisory for the non-constant-time HMAC comparison in the Paddle Billing webhook signature verifier.

When this advisory was first added, no fixed release existed yet — 11.6.1 was the latest (unpatched) version. pay 11.6.2 has since shipped with the fix, so this PR records the patched version and updates the notes accordingly.

References

- Upstream issue: https://github.com/pay-rails/pay/issues/1232
- Fix commit: https://github.com/pay-rails/pay/commit/ba64941
- Advisory: https://github.com/advisories/GHSA-mjgf-xj26-9qf9
