### PR TITLE
Four websocket-driver advisories

### DIFF
--- a/gems/websocket-driver/CVE-2026-54463.yml
+++ b/gems/websocket-driver/CVE-2026-54463.yml
@@ -1,0 +1,37 @@
+---
+gem: websocket-driver
+cve: 2026-54463
+ghsa: ghhp-3qvg-889p
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54463
+title: Memory exhaustion via abuse of protocol length headers
+date: 2026-06-04
+description: |
+  ## Impact
+
+  The frame format in draft versions of the WebSocket protocol includes
+  a length header that allows an arbitrarily large integer to be encoded
+  as a sequence of bytes with the high bit set. By sending an indefinite
+  sequence of bytes with values 0x80 or above, a server or client can
+  make the other peer parse these bytes into an ever-growing integer.
+  Since Ruby integers are arbitrary precision, this can be used to make
+  a WebSocket connection consume an unbounded amount of memory and
+  lead to the host process running out of memory.
+
+  ## Acknowledgements
+
+  This issue was discovered and reported by Pranjali Thakur,
+  DepthFirst Security Research Team.
+cvss_v4: 6.9
+patched_versions:
+  - ">= 0.8.1"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54463
+    - https://rubygems.org/gems/websocket-driver/versions/0.8.1
+    - https://github.com/faye/websocket-driver-ruby/blob/main/CHANGELOG.md#081--2026-06-04
+    - https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-ghhp-3qvg-889p
+notes: |
+  - NOTE: Gem name is websocket-driver but repo name is websocket-driver-ruby.
+  - date value from CHANGELOG URL.
+  - cvss_v4 value came from GHSA.
+  - CVE is reserved, but not published.

--- a/gems/websocket-driver/CVE-2026-54464.yml
+++ b/gems/websocket-driver/CVE-2026-54464.yml
@@ -1,0 +1,36 @@
+---
+gem: websocket-driver
+cve: 2026-54464
+ghsa: 33ph-fccm-39pj
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54464
+title: Resource limit bypass via message compression
+date: 2026-06-04
+description: |
+  ## Impact
+
+  If this library is used in tandem with the permessage-deflate extension,
+  a WebSocket server or client can be made to accept messages that are
+  larger than the configured maximum message size. This is because this
+  limit is checked against the message frames' length headers, which
+  give the size of the compressed data, not the size after decompression.
+  This can lead to applications accepting larger messages than expected
+  and exceeding their intended resource usage.
+
+  ## Acknowledgements
+
+  This issue was discovered and reported by Pranjali Thakur,
+  DepthFirst Security Research Team.
+cvss_v4: 6.3
+patched_versions:
+  - ">= 0.8.1"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54464
+    - https://rubygems.org/gems/websocket-driver/versions/0.8.1
+    - https://github.com/faye/websocket-driver-ruby/blob/main/CHANGELOG.md#081--2026-06-04
+    - https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-33ph-fccm-39pj
+notes: |
+  - NOTE: Gem name is websocket-driver but repo name is websocket-driver-ruby.
+  - date value from CHANGELOG URL.
+  - cvss_v4 value came from GHSA.
+  - CVE is reserved, but not published.

--- a/gems/websocket-driver/CVE-2026-54465.yml
+++ b/gems/websocket-driver/CVE-2026-54465.yml
@@ -1,0 +1,36 @@
+---
+gem: websocket-driver
+cve: 2026-54465
+ghsa: 8j3g-f24p-4mpw
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54465
+title: Memory exhaustion in HTTP header parser
+date: 2026-06-04
+description: |
+  ## Impact
+
+  If this library is used to implement a WebSocket server on top of a
+  TCP server (rather than an HTTP server or framework) using the
+  WebSocket::Driver.server() method, or, if it is used to complement
+  a WebSocket client, then a peer can make a single connection consume
+  an unbounded amount of memory by sending an HTTP request or response
+  with a never-ending list of headers. This can lead to the receiving
+  process running out of memory.
+
+  ## Acknowledgements
+
+  This issue was discovered and reported by Pranjali Thakur,
+  DepthFirst Security Research Team.
+cvss_v4: 8.3
+patched_versions:
+  - ">= 0.8.1"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54465
+    - https://rubygems.org/gems/websocket-driver/versions/0.8.1
+    - https://github.com/faye/websocket-driver-ruby/blob/main/CHANGELOG.md#081--2026-06-04
+    - https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-8j3g-f24p-4mpw
+notes: |
+  - NOTE: Gem name is websocket-driver but repo name is websocket-driver-ruby.
+  - date value from CHANGELOG URL.
+  - cvss_v4 value came from GHSA.
+  - CVE is reserved, but not published.

--- a/gems/websocket-driver/GHSA-2x63-gw47-w4mm.yml
+++ b/gems/websocket-driver/GHSA-2x63-gw47-w4mm.yml
@@ -1,0 +1,34 @@
+---
+gem: websocket-driver
+ghsa: 2x63-gw47-w4mm
+url: https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-2x63-gw47-w4mm
+title: Denial of service via malformed Host header
+date: 2026-06-23
+description: |
+  ## Impact
+
+  If this library is used to implement a WebSocket server on top of a
+  TCP server, by using the WebSocket::Driver.server() method, then a
+  client can cause the server to crash by sending a Host header that
+  is not a valid host[:port] string. When this happens, a URI::InvalidURIError
+  exception is raised which is not caught, and this can cause the server
+  process to crash if the application does not catch the error from
+   the parse() method itself.
+
+  ## Acknowledgements
+
+  This issue was discovered and reported by Pranjali Thakur,
+  DepthFirst Security Research Team.
+cvss_v4: 8.9
+patched_versions:
+  - ">= 0.8.2"
+related:
+  url:
+    - https://rubygems.org/gems/websocket-driver/versions/0.8.2
+    - https://github.com/faye/websocket-driver-ruby/blob/main/CHANGELOG.md#082--2026-06-23
+    - https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-2x63-gw47-w4mm
+notes: |
+  - NOTE: Gem name is websocket-driver but repo name is websocket-driver-ruby.
+  - date value from CHANGELOG URL.
+  - cvss_v4 value came from GHSA.
+  - No CVE, so no non-GHSA cvss values.


### PR DESCRIPTION
Four websocket-driver advisories
 * gems/websocket-driver/CVE-2026-54464.yml
 * gems/websocket-driver/CVE-2026-54465.yml
 * gems/websocket-driver/GHSA-2x63-gw47-w4mm.yml
 * gems/websocket-driver/CVE-2026-54463.yml
