### PR TITLE
Added GHSA and NVD.NIST.GOV URLs to 13 existing advisories; Added to ignore file

### DIFF
--- a/gems/addressable/CVE-2021-32740.yml
+++ b/gems/addressable/CVE-2021-32740.yml
@@ -18,3 +18,7 @@ unaffected_versions:
   - "< 2.3.0"
 patched_versions:
   - ">= 2.8.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-32740
+    - https://github.com/sporkmonger/addressable/security/advisories/GHSA-jxhc-q857-3j6g

--- a/gems/devise-two-factor/CVE-2021-43177.yml
+++ b/gems/devise-two-factor/CVE-2021-43177.yml
@@ -24,4 +24,6 @@ related:
   cve:
     - 2015-7225
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2021-43177
     - https://github.com/tinfoil/devise-two-factor/issues/106
+    - https://github.com/devise-two-factor/devise-two-factor/security/advisories/GHSA-jm35-h8q2-73mp

--- a/gems/doorkeeper/CVE-2023-34246.yml
+++ b/gems/doorkeeper/CVE-2023-34246.yml
@@ -32,4 +32,5 @@ related:
     - https://github.com/doorkeeper-gem/doorkeeper/pull/1646
     - https://github.com/doorkeeper-gem/doorkeeper/issues/1589
     - https://www.rfc-editor.org/rfc/rfc8252#section-8.6
+    - https://github.com/doorkeeper-gem/doorkeeper/security/advisories/GHSA-7w2c-w47h-789w
     - https://github.com/advisories/GHSA-7w2c-w47h-789w

--- a/gems/jquery-rails/CVE-2020-11023.yml
+++ b/gems/jquery-rails/CVE-2020-11023.yml
@@ -23,4 +23,6 @@ patched_versions:
   - ">= 4.4.0"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2020-11023
     - https://github.com/rails/jquery-rails/blob/master/CHANGELOG.md#440
+    - https://github.com/jquery/jquery/security/advisories/GHSA-jpcq-cgw6-v4j6

--- a/gems/phlex/CVE-2024-28199.yml
+++ b/gems/phlex/CVE-2024-28199.yml
@@ -82,4 +82,5 @@ related:
     - https://github.com/phlex-ruby/phlex/commit/aa50c604cdee1d0ce7ef068a4c66cbd5d43f96a1
     - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
     - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#unsafe-inline
+    - https://github.com/yippee-fun/phlex/security/advisories/GHSA-242p-4v39-2v8g
     - https://github.com/advisories/GHSA-242p-4v39-2v8g

--- a/gems/phlex/CVE-2024-32463.yml
+++ b/gems/phlex/CVE-2024-32463.yml
@@ -52,4 +52,5 @@ related:
     - https://github.com/phlex-ruby/phlex/commit/9e3f5b980655817993682e409cbda72956d865cb
     - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
     - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#unsafe-inline
+    - https://github.com/yippee-fun/phlex/security/advisories/GHSA-g7xq-xv8c-h98c
     - https://github.com/advisories/GHSA-g7xq-xv8c-h98c

--- a/gems/phlex/CVE-2024-32970.yml
+++ b/gems/phlex/CVE-2024-32970.yml
@@ -72,4 +72,5 @@ related:
     - https://github.com/payloadbox/xss-payload-list
     - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
     - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#unsafe-inline
+    - https://github.com/yippee-fun/phlex/security/advisories/GHSA-9p57-h987-4vgx
     - https://github.com/advisories/GHSA-9p57-h987-4vgx

--- a/gems/rexml/CVE-2024-41123.yml
+++ b/gems/rexml/CVE-2024-41123.yml
@@ -34,4 +34,6 @@ patched_versions:
   - ">= 3.3.3"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-41123
     - https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123
+    - https://github.com/ruby/rexml/security/advisories/GHSA-r55c-59qm-vjw6

--- a/gems/rexml/CVE-2024-41946.yml
+++ b/gems/rexml/CVE-2024-41946.yml
@@ -34,4 +34,6 @@ patched_versions:
   - ">= 3.3.3"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-41946
     - https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41946
+    - https://github.com/ruby/rexml/security/advisories/GHSA-5866-49gr-22v4

--- a/gems/sanitize/CVE-2023-36823.yml
+++ b/gems/sanitize/CVE-2023-36823.yml
@@ -45,4 +45,5 @@ related:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-36823
     - https://github.com/rgrove/sanitize/releases/tag/v6.0.2
     - https://github.com/rgrove/sanitize/commit/76ed46e6dc70820f38efe27de8dabd54dddb5220
+    - https://github.com/rgrove/sanitize/security/advisories/GHSA-f5ww-cq3m-q3g7
     - https://github.com/advisories/GHSA-f5ww-cq3m-q3g7

--- a/gems/secure_headers/CVE-2020-5216.yml
+++ b/gems/secure_headers/CVE-2020-5216.yml
@@ -48,3 +48,7 @@ patched_versions:
   - "~> 3.9"
   - "~> 5.2"
   - ">= 6.3.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/cve-2020-5216
+    - https://github.com/github/secure_headers/security/advisories/GHSA-w978-rmpf-qmwg

--- a/gems/secure_headers/CVE-2020-5217.yml
+++ b/gems/secure_headers/CVE-2020-5217.yml
@@ -38,3 +38,7 @@ patched_versions:
   - "~> 3.8"
   - "~> 5.1"
   - ">= 6.2.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/cve-2020-5217
+    - https://github.com/github/secure_headers/security/advisories/GHSA-xq52-rv6w-397c

--- a/gems/view_component/CVE-2022-24722.yml
+++ b/gems/view_component/CVE-2022-24722.yml
@@ -23,4 +23,6 @@ patched_versions:
   - "~> 2.31.2"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2022-24722
     - https://github.com/github/view_component/commit/3f82a6e62578ff6f361aba24a1feb2caccf83ff9
+    - https://github.com/ViewComponent/view_component/security/advisories/GHSA-cm9w-c4rj-r2cf

--- a/lib/rad-ignores.sh
+++ b/lib/rad-ignores.sh
@@ -11,6 +11,17 @@ else
 fi
 
 # 10/26/2024, 5/25/2026: Autolab is not a Rubygem so remove it.
+# 7/13/2026: Found 10 more so added them here.
+#https://github.com/autolab/Autolab/security/advisories/GHSA-v46j-h43h-rwrm
+#https://github.com/autolab/Autolab/security/advisories/GHSA-84qc-7773-2gg3
+#https://github.com/autolab/Autolab/security/advisories/GHSA-8qhp-jhhw-45r2
+#https://github.com/autolab/Autolab/security/advisories/GHSA-962r-m9fj-3hj9
+#https://github.com/autolab/Autolab/security/advisories/GHSA-cqxx-pfmh-h43g
+#https://github.com/autolab/Autolab/security/advisories/GHSA-g7x7-mgrv-f24x
+#https://github.com/autolab/Autolab/security/advisories/GHSA-h8g5-vhm4-wx6g
+#https://github.com/autolab/Autolab/security/advisories/GHSA-h8wq-ghfq-5hfx
+#https://github.com/autolab/Autolab/security/advisories/GHSA-rjg4-cf66-x6gr
+#https://github.com/autolab/Autolab/security/advisories/GHSA-x9hj-r9q4-832c
 rm -f gems/Autolab/CVE-2024-49376.yml
 
 # 1/29/2026, 5/25/2026: rails is not a Rubygem so remove it.


### PR DESCRIPTION
Added GHSA and NVD.NIST.GOV URLs to existing advisories. Added to ignore file.
Needed for upstream automation.
See below for details.