### PR TITLE
Five new mcp gem advisories

### DIFF
--- a/gems/mcp/GHSA-52jp-gj8w-j6xh.yml
+++ b/gems/mcp/GHSA-52jp-gj8w-j6xh.yml
@@ -1,0 +1,28 @@
+---
+gem: mcp
+ghsa: 52jp-gj8w-j6xh
+url: https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-52jp-gj8w-j6xh
+title: Unbounded session retention in StreamableHTTPTransport allows
+  memory exhaustion via initialize flood
+date: 2026-07-07
+description: |
+  ## Summary
+
+  In its default configuration, MCP::Server::Transports::StreamableHTTPTransport
+  never expires sessions. Every successful initialize request stores a
+  new ServerSession and a session record under a fresh UUID, and the
+  only path that removes them is an explicit client-issued HTTP DELETE.
+  An unauthenticated attacker can repeatedly initialize new sessions
+  and immediately disconnect, forcing the server to retain an unbounded
+  number of ServerSession objects until memory is exhausted.
+cvss_v3: 5.3
+patched_versions:
+  - ">= 0.23.0"
+related:
+  url:
+    - https://rubygems.org/gems/mcp/versions/0.23.0
+    - https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v0.23.0
+    - https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-52jp-gj8w-j6xh
+notes: |
+  - cvss_v3 came from GHSA.
+  - date from gem release

--- a/gems/mcp/GHSA-5p9g-j988-pcwv.yml
+++ b/gems/mcp/GHSA-5p9g-j988-pcwv.yml
@@ -1,0 +1,24 @@
+---
+gem: mcp
+ghsa: 5p9g-j988-pcwv
+url: https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-5p9g-j988-pcwv
+title: Ruby SSE Session Poisoning
+date: 2026-07-07
+description: |
+  ## Summary
+
+  Vulnerability: Missing Session Ownership Validation in the Ruby MCP
+  SDK's Streamable and SSE HTTP transport implementation. Any attacker
+  with a stolen session ID can execute tools with the victim's session.
+  This is a silent attack - the victim's session is compromised and
+  being used for unauthorized actions, but it is hard to know for the victim.
+patched_versions:
+  - ">= 0.23.0"
+related:
+  url:
+    - https://rubygems.org/gems/mcp/versions/0.23.0
+    - https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v0.23.0
+    - https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-5p9g-j988-pcwv
+notes: |
+  - Project GHSA has high severity.
+  - date from gem release

--- a/gems/mcp/GHSA-7683-3w9x-ch42.yml
+++ b/gems/mcp/GHSA-7683-3w9x-ch42.yml
@@ -1,0 +1,30 @@
+---
+gem: mcp
+ghsa: 7683-3w9x-ch42
+url: https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-7683-3w9x-ch42
+title: Unbounded line buffer in stdio transports leads to memory
+  exhaustion (DoS)
+date: 2026-07-07
+description: |
+  ## Summary
+
+  The stdio transports in MCP::Server::Transports::StdioTransport and
+  MCP::Client::Stdio read newline-delimited JSON-RPC frames using
+  IO#gets with no limit argument. CRuby's IO#gets with no limit reads
+  from the current position until the next separator (\n) with no upper
+  bound on the returned string length. A peer that streams bytes without
+  ever emitting a newline causes gets to accumulate the entire stream
+  in a single Ruby String until the process is killed by the
+  operating-system OOM killer.
+cvss_v3: 6.2
+patched_versions:
+  - ">= 0.23.0"
+related:
+  url:
+    - https://rubygems.org/gems/mcp/versions/0.23.0
+    - https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v0.23.0
+    - https://docs.ruby-lang.org/en/3.3/IO.html#method-i-gets
+    - https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-7683-3w9x-ch42
+notes: |
+  - cvss_v3 came from GHSA.
+  - date from gem release

--- a/gems/mcp/GHSA-h669-8m4g-r2hc.yml
+++ b/gems/mcp/GHSA-h669-8m4g-r2hc.yml
@@ -1,0 +1,28 @@
+---
+gem: mcp
+ghsa: h669-8m4g-r2hc
+url: https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-h669-8m4g-r2hc
+title: Unbounded JSON-RPC request body causes uncontrolled memory
+  allocation in StreamableHTTPTransport
+date: 2026-07-07
+description: |
+  ## Summary
+
+  An unauthenticated remote attacker can force any MCP Ruby SDK server
+  using MCP::Server::Transports::StreamableHTTPTransport to allocate
+  gigabytes of memory by sending a single oversized JSON-RPC POST. The
+  transport reads the entire HTTP body into a Ruby String and parses
+  it with JSON.parse(body, symbolize_names: true) with no size limit,
+  no Content-Length pre-check, and no streaming parser, allowing
+  trivial denial of service against the worker process.
+cvss_v3: 7.5
+patched_versions:
+  - ">= 0.23.0"
+related:
+  url:
+    - https://rubygems.org/gems/mcp/versions/0.23.0
+    - https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v0.23.0
+    - https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-h669-8m4g-r2hc
+notes: |
+  - cvss_v3 came from GHSA.
+  - date from gem release

--- a/gems/mcp/GHSA-rjr6-rcgv-9m7m.yml
+++ b/gems/mcp/GHSA-rjr6-rcgv-9m7m.yml
@@ -1,0 +1,45 @@
+---
+gem: mcp
+ghsa: rjr6-rcgv-9m7m
+url: https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-rjr6-rcgv-9m7m
+title: Streamable HTTP transport lacks DNS-rebinding (Host/Origin) protection
+date: 2026-07-07
+description: |
+  ## Summary
+
+  MCP::Server::Transports::StreamableHTTPTransport (the Rack-mountable
+  Streamable HTTP transport in the mcp gem) processes every incoming
+  JSON-RPC request without ever inspecting the HTTP Host or Origin
+  request headers. There is no AllowedHosts/AllowedOrigins allowlist
+  and no DNS-rebinding guard anywhere in the transport. A local MCP
+  server that binds a loopback or LAN HTTP port is therefore reachable
+  by any web origin a victim's browser visits, via a DNS-rebinding
+  attack: a malicious page rebinds its own hostname to 127.0.0.1, then
+  drives the local MCP server cross-origin to enumerate and invoke
+  its tools and exfiltrate their output. This is the standard browser-driven
+  local-service attack that the MCP Streamable HTTP guidance exists to prevent.
+
+  ## Impact
+
+  An attacker who can get a victim to open a web page can reach any MCP
+  server the victim runs locally over the Streamable HTTP transport
+  (e.g. a developer-tools or filesystem MCP server on localhost).
+  Because the transport issues a session and dispatches tools/list/
+  tools/call from a foreign Host/Origin with no rejection, the attacker
+  can drive arbitrary server-exposed tools and read their results,
+  exfiltrating local data (files, secrets, command output) to the
+  attacker's origin.
+  The blast radius is whatever the locally-running MCP server exposes.
+  For MCP servers wired to filesystem, shell, or credential tools,
+  this is sensitive-data disclosure and, depending on the tool set,
+  local action execution.
+patched_versions:
+  - ">= 0.23.0"
+related:
+  url:
+    - https://rubygems.org/gems/mcp/versions/0.23.0
+    - https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v0.23.0
+    - https://github.com/modelcontextprotocol/ruby-sdk/security/advisories/GHSA-rjr6-rcgv-9m7m
+notes: |
+  - "Moderate" severity in GHSA but no values.
+  - date from gem release


### PR DESCRIPTION
Five new mcp gem advisories
 * gems/mcp/GHSA-52jp-gj8w-j6xh.yml
 * gems/mcp/GHSA-5p9g-j988-pcwv.yml
 * gems/mcp/GHSA-7683-3w9x-ch42.yml
 * gems/mcp/GHSA-h669-8m4g-r2hc.yml
 * gems/mcp/GHSA-rjr6-rcgv-9m7m.yml
