### PR TITLE
One new advisory, 1 refs to spina and zlib advisories and lots of ignore notes

### DIFF
--- a/gems/action_text-trix/GHSA-53g2-mvcc-q9x3.yml
+++ b/gems/action_text-trix/GHSA-53g2-mvcc-q9x3.yml
@@ -1,0 +1,50 @@
+---
+gem: action_text-trix
+ghsa: 53g2-mvcc-q9x3
+url: https://github.com/basecamp/trix/security/advisories/GHSA-53g2-mvcc-q9x3
+title: Stored XSS via HTMLParser attribute injection on paste
+date: 2026-03-26
+description: |
+  ## Impact
+
+  The Trix editor, in versions prior to 2.1.18, is vulnerable to XSS
+  when crafted HTML is pasted into the editor. The HTMLParser processed
+  a mock attachment, a <span> carrying an empty data-trix-attachment="{}".
+  The empty attachment object caused the element to bypass attachment
+  handling, so its data-trix-attributes were applied to a plain string
+  piece. The pre-2.1.18 StringPiece.fromJSON accepted the href without
+  validation, so an attacker-supplied javascript: URI was carried into
+  the document model and emitted verbatim into the serialized HTML,
+  executing when the content was rendered and clicked.
+
+  This is a stored XSS in any application that accepts untrusted rich
+  text through Trix and renders the serialized output to other users.
+  Applications that apply server-side HTML sanitization, such as the
+  Rails built-in sanitizer, are additionally protected because the
+  payload is neutralized on save.
+
+  This vulnerability shares its fix with GHSA-53p3-c7vp-4mcc.
+  Both are resolved by the StringPiece.fromJSON sanitization added
+  in 2.1.18. This advisory covers the paste and HTMLParser entry
+  vector, while GHSA-53p3-c7vp-4mcc covers the drag-and-drop path
+  through the fallback Level0InputController.
+
+  ## References
+
+  The vulnerability was responsibly reported by HackerOne
+  researcher newbiefromcoma.
+cvss_v3: 4.6
+patched_versions:
+  - ">= 2.1.18"
+related:
+  url:
+    - https://rubygems.org/gems/action_text-trix/versions/2.1.18
+    - https://github.com/basecamp/trix/releases/tag/v2.1.18
+    - https://github.com/basecamp/trix/pull/1293
+    - https://github.com/advisories/GHSA-53p3-c7vp-4mcc
+    - https://github.com/basecamp/trix/security/advisories/GHSA-53g2-mvcc-q9x3
+notes: |
+  - No CVE.
+  - cvss_v3 from GHSA
+  - date from gem releases page
+  - Unnknown HackerOne number

--- a/gems/spina/CVE-2015-4619.yml
+++ b/gems/spina/CVE-2015-4619.yml
@@ -14,5 +14,7 @@ patched_versions:
   - ">= 0.6.29"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2015-4619
+    - https://github.com/denkGroot/Spina/commit/bfe44f289e336f80b6593032679300c493735e75
     - https://sca.analysiscenter.veracode.com/vulnerability-database/security/cross-site-request-forgery-csrf/ruby/sid-1686/summary
     - https://github.com/rubysec/ruby-advisory-db/issues/238

--- a/gems/zlib/CVE-2026-27820.yml
+++ b/gems/zlib/CVE-2026-27820.yml
@@ -2,7 +2,7 @@
 gem: zlib
 cve: 2026-27820
 ghsa: g857-hhfv-j68w
-url: https://www.ruby-lang.org/en/news/2026/03/05/buffer-overflow-zlib-cve-2026-27820
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-27820
 title: Buffer overflow vulnerability in Zlib::GzipReader
 date: 2026-03-05
 description: |
@@ -50,3 +50,4 @@ related:
     - https://rubygems.org/gems/zlib/versions/3.2.3
     - https://rubygems.org/gems/zlib/versions/3.1.2
     - https://rubygems.org/gems/zlib/versions/3.0.1
+    - https://github.com/ruby/zlib/security/advisories/GHSA-g857-hhfv-j68w

--- a/lib/rad-ignores.sh
+++ b/lib/rad-ignores.sh
@@ -88,6 +88,48 @@ rm -f gems/webrick/CVE-2026-38969.yml
 # https://github.com/github/cmark-gfm/security/advisories/GHSA-cgh3-p57x-9q7q
 # are not a Ruby gems, no Ruby code.
 
+# https://github.com/joniles/mpxj/security/advisories/GHSA-jf2p-4gqj-849g
+# does not involve Ruby code.
+
+# https://github.com/devise-two-factor/devise-two-factor/security/advisories/GHSA-chcr-x7hc-8fp8
+# https://github.com/advisories/GHSA-chcr-x7hc-8fp8
+# was never patched and withdrawn on 3/19/2026.
+
+# CVE-2024-43368: https://github.com/basecamp/trix/security/advisories/GHSA-qm2q-9f3q-2vcv
+# CVE-2025-46812: https://github.com/basecamp/trix/security/advisories/GHSA-mcrw-746g-9q8h
+# CVE-2024-53847: https://github.com/basecamp/trix/security/advisories/GHSA-6vx4-v2jw-qwqh
+# CVE-2025-21610: https://github.com/basecamp/trix/security/advisories/GHSA-j386-3444-qgwg
+# all 4 are NPM related, not Ruby.
+
+######################################################################
+# PasswordPusher SUMMARY: Yes, Ruby Fixed, none are gems.
+#.....................................................................
+# https://github.com/pglombardo/PasswordPusher/security/advisories/GHSA-59w3-h5v2-c4xw
+# - https://github.com/pglombardo/PasswordPusher/releases/tag/v2.9.2
+#   - https://rubygems.org/gems/pwpush (https://eu.pwpush.com - 2016)
+# Release 2.9.2; pglombardo/PasswordPusher; RUBY code; Bash Poc; Ruby fix; No CVE
+#...
+# https://github.com/pglombardo/PasswordPusher/security/advisories/GHSA-76c2-66pg-fj2f
+#  - https://github.com/pglombardo/PasswordPusher/releases/tag/v2.8.1
+# Release 2.8.1; pglombardo/PasswordPusher; RUBY code; Bash Poc; Ruby fix; No CVE
+#... 
+# https://github.com/pglombardo/PasswordPusher/security/advisories/GHSA-qfh8-f79c-x86c
+# - https://github.com/pglombardo/PasswordPusher/pull/4381
+#   - https://github.com/pglombardo/PasswordPusher/releases/tag/v2.4.2
+# Release 2:4.2 - Ruby rb code; Unreviewed GHSA
+#... 
+# https://github.com/pglombardo/PasswordPusher/security/advisories/GHSA-4fwj-m62q-pp47
+# Never patched; CVE-2024-56733; Password Pusher; No project references
+#...
+# https://github.com/pglombardo/PasswordPusher/security/advisories/GHSA-ffp2-8p2h-4m5j
+# - https://github.com/pglombardo/PasswordPusher/releases/tag/v1.49.0
+#   - https://github.com/pglombardo/PasswordPusher/pull/2797
+# Release 1.49.0; Password Pusher Application; yml and ruby fixes
+#...
+# https://github.com/pglombardo/PasswordPusher/security/advisories/GHSA-5chg-cq29-gfqf
+# - https://github.com/pglombardo/PasswordPusher/releases/tag/v1.48.1
+# Release 1.48.1; Password Pusher Application; erb file code fix
+
 exit
 
 # AL>> QUESTION (ruby or jruby)?


### PR DESCRIPTION
One new advisory, 1 refs to spina and zlib advisories and lots of ignore notes
 * New: gems/action_text-trix/GHSA-53g2-mvcc-q9x3.yml
  * Added 2 refs to spina advisory.
   * Added 1 reference to zlib advisory.
  *  See below for new rad-ignores.sh notes.