### PR TITLE
Two updated advisories; extend sync script to update patched_versions with new data

### DIFF
--- a/gems/concurrent-ruby/CVE-2026-54905.yml
+++ b/gems/concurrent-ruby/CVE-2026-54905.yml
@@ -2,7 +2,7 @@
 gem: concurrent-ruby
 cve: 2026-54905
 ghsa: wv3x-4vxv-whpp
-url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54905
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-54905
 title: Concurrent Ruby - `ReentrantReadWriteLock` read-count overflow
   grants a write lock without exclusivity
 date: 2026-06-19
@@ -33,12 +33,13 @@ description: |
   ### Credit
 
   Pranjali Thakur - depthfirst ([depthfirst.com](<http://depthfirst.com>))
+cvss_v3: 5.5
 cvss_v4: 2.0
 patched_versions:
   - ">= 1.3.7"
 related:
   url:
-    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54905
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54905
     - https://rubygems.org/gems/concurrent-ruby/versions/1.3.7
     - https://github.com/ruby-concurrency/concurrent-ruby/releases/tag/v1.3.7
     - https://advisories.gitlab.com/gem/concurrent-ruby/CVE-2026-54905
@@ -46,5 +47,4 @@ related:
     - https://github.com/advisories/GHSA-wv3x-4vxv-whpp
 notes: |
   - cvss_v4 from GHSA
-  - CVE is reserved, but not published.
-    - Not on nvd.nist.gov so no cvss_v2 or cvss_v3.
+  - cvss_v3 from nvd.nist.gov

--- a/gems/rest-client/CVE-2019-15224.yml
+++ b/gems/rest-client/CVE-2019-15224.yml
@@ -8,8 +8,8 @@ date: 2019-08-19
 description: |
   The rest-client gem 1.6.13 for Ruby, as distributed on RubyGems.org,
   included a code-execution backdoor inserted by a third party.
+cvss_v2: 7.5
 cvss_v3: 9.8
-cvss_v4: 7.5
 unaffected_versions:
   - "<= 1.6.9"
   - ">= 1.6.14"

--- a/gems/rest-client/CVE-2019-15224.yml
+++ b/gems/rest-client/CVE-2019-15224.yml
@@ -2,13 +2,20 @@
 gem: rest-client
 cve: 2019-15224
 ghsa: 333g-rpr4-7hxq
-url: https://github.com/rest-client/rest-client/issues/713
-title: Code execution backdoor in rest-client
+url: https://nvd.nist.gov/vuln/detail/CVE-2019-15224
+title: Code execution backdoor in rest-client (Contains Malicious Code)
 date: 2019-08-19
 description: |
   The rest-client gem 1.6.13 for Ruby, as distributed on RubyGems.org,
   included a code-execution backdoor inserted by a third party.
 cvss_v3: 9.8
+cvss_v4: 7.5
 unaffected_versions:
   - "<= 1.6.9"
   - ">= 1.6.14"
+patched_versions:
+  - ">= 1.7.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2019-15224
+    - https://github.com/advisories/GHSA-333g-rpr4-7hxq

--- a/lib/github_advisory_sync.rb
+++ b/lib/github_advisory_sync.rb
@@ -418,6 +418,11 @@ module GitHub
       saved_data = YAML.safe_load_file(package.filename, permitted_classes: [Date])
       new_data = package.merge_data(saved_data)
 
+      patched = patched_versions_for(package)
+      if patched.any? && (new_data["patched_versions"].nil? || new_data["patched_versions"].empty?)
+        new_data["patched_versions"] = patched
+      end
+
       return if saved_data == new_data
 
       File.open(package.filename, 'w') do |file|


### PR DESCRIPTION
Two updated advisories; extend sync script to update patched_versions with new data
 * gems/concurrent-ruby/CVE-2026-54905.yml
 * gems/rest-client/CVE-2019-15224.yml
 
 Extend sync script to update patched_versions with new data
  * lib/github_advisory_sync.rb
  In other words, if the advisory is missing the "patched_versions:" field/value and
  GHSA gets a value, the script will add the field and the value now.
  This is part of issue #1173.
