### PR TITLE
Four enhanced advisories; 1 renamed advisory

### DIFF
--- a/gems/loofah/GHSA-5qhf-9phg-95m2.yml
+++ b/gems/loofah/GHSA-5qhf-9phg-95m2.yml
@@ -30,6 +30,7 @@ description: |
   ## Credit
 
   Responsibly reported by GitHub user @MoonFuji.
+cvss_v4: 2.7
 unaffected_versions:
   - "< 2.25.0"
 patched_versions:
@@ -41,5 +42,5 @@ related:
     - https://github.com/advisories/GHSA-46fp-8f5p-pf2m
     - https://github.com/flavorjones/loofah/security/advisories/GHSA-5qhf-9phg-95m2
 notes: |
-  - "Low" severity from GHSA
+  - cvss_v4 from GHSA
   - No CVE.

--- a/gems/loofah/GHSA-8whx-365g-h9vv.yml
+++ b/gems/loofah/GHSA-8whx-365g-h9vv.yml
@@ -15,6 +15,7 @@ description: |
   This is a bypass of the fix for GHSA-46fp-8f5p-pf2m, which handled
   the equivalent numeric character references (&#9;, &#10;, &#13;) but
   did not cover the named forms.
+cvss_v4: 2.3
 unaffected_versions:
   - "< 2.25.0"
 patched_versions:
@@ -26,5 +27,5 @@ related:
     - https://github.com/advisories/GHSA-46fp-8f5p-pf2m
     - https://github.com/flavorjones/loofah/security/advisories/GHSA-8whx-365g-h9vv
 notes: |
-  - "Low" severity from GHSA
+  - cvss_v4 from project GHSA
   - No CVE.

--- a/gems/net-imap/CVE-2026-42258.yml
+++ b/gems/net-imap/CVE-2026-42258.yml
@@ -59,6 +59,7 @@ description: |
   * For the few IMAP commands which do allow `flag` arguments, it may be
     appropriate to hard-code Symbol arguments or restrict them to an enumerated
     list which is valid for the calling application.
+cvss_v3: 7.1
 cvss_v4: 5.8
 patched_versions:
   - "~> 0.4.24"
@@ -66,6 +67,7 @@ patched_versions:
   - ">= 0.6.4"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-42258
     - https://github.com/ruby/net-imap/security/advisories/GHSA-75xq-5h9v-w6px
     - https://github.com/ruby/net-imap/commit/6bf02aef7e0b5931010c36e377f79a71636b306b
     - https://github.com/ruby/net-imap/commit/9db3e9d60bfb8f3735ea95015bf8a700f4af9cbb
@@ -74,3 +76,6 @@ related:
     - https://github.com/ruby/net-imap/releases/tag/v0.5.14
     - https://github.com/ruby/net-imap/releases/tag/v0.6.4
     - https://github.com/advisories/GHSA-75xq-5h9v-w6px
+notes: |
+  - cvss_v4 from GHSA
+  - cvss_v3 from nvd.nist.gov URL (also had 5.3 too)

--- a/gems/rails-html-sanitizer/GHSA-cj75-f6xr-r4g7.yml
+++ b/gems/rails-html-sanitizer/GHSA-cj75-f6xr-r4g7.yml
@@ -14,6 +14,7 @@ description: |
   SVG reference element such as <use>.
   See related GHSA-9wjq-cp2p-hrgf in Loofah, whose SVG local-reference
   logic rails-html-sanitizer mirrors.
+cvss_v4: 5.1
 unaffected_versions:
   - "< 1.0.3"
 patched_versions:
@@ -27,5 +28,5 @@ related:
     - https://github.com/flavorjones/loofah/security/advisories/GHSA-9wjq-cp2p-hrgf
     - https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-cj75-f6xr-r4g7
 notes: |
-  - "Moderate" severity in GHSA
+  - cvss_v4 from GHSA
   - No CVE.

--- a/gems/websocket-driver/CVE-2026-61666.yml
+++ b/gems/websocket-driver/CVE-2026-61666.yml
@@ -1,7 +1,8 @@
 ---
 gem: websocket-driver
+cve: 2026-61666
 ghsa: 2x63-gw47-w4mm
-url: https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-2x63-gw47-w4mm
+url: https://www.cve.org/CVERecord?id=CVE-2026-61666
 title: Denial of service via malformed Host header
 date: 2026-06-23
 description: |
@@ -19,16 +20,22 @@ description: |
 
   This issue was discovered and reported by Pranjali Thakur,
   DepthFirst Security Research Team.
+cvss_v3: 7.1
 cvss_v4: 8.9
 patched_versions:
   - ">= 0.8.2"
 related:
   url:
+    - https://www.cve.org/CVERecord?id=CVE-2026-61666
     - https://rubygems.org/gems/websocket-driver/versions/0.8.2
     - https://github.com/faye/websocket-driver-ruby/blob/main/CHANGELOG.md#082--2026-06-23
+    - https://github.com/faye/websocket-driver-ruby/compare/0.8.1...0.8.2
+    - https://github.com/faye/websocket-driver-ruby/commit/7d6fd87759a2fdc83590d3b49ffa661dc53fa128
     - https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-2x63-gw47-w4mm
+    - https://github.com/advisories/GHSA-2x63-gw47-w4mm
 notes: |
   - NOTE: Gem name is websocket-driver but repo name is websocket-driver-ruby.
   - date value from CHANGELOG URL.
-  - cvss_v4 value came from GHSA.
+  - cvss_v3 from nvd.nist.gov URL
+  - cvss_v4 from GHSA
   - No CVE, so no non-GHSA cvss values.


### PR DESCRIPTION
Four enhanced advisories; 1 renamed advisory
 * modified:   gems/loofah/GHSA-5qhf-9phg-95m2.yml
 * modified:   gems/loofah/GHSA-8whx-365g-h9vv.yml
 * modified:   gems/net-imap/CVE-2026-42258.yml
 * modified:   gems/rails-html-sanitizer/GHSA-cj75-f6xr-r4g7.yml
 
 * modified:   gems/websocket-driver/CVE-2026-61666.yml and rename from gems/websocket-driver/GHSA-2x63-gw47-w4mm.yml 

