### PR TITLE
Add advisory for where_is_waldo (GHSA-r766-3v88-pfcf)

### DIFF
--- a/gems/where_is_waldo/GHSA-r766-3v88-pfcf.yml
+++ b/gems/where_is_waldo/GHSA-r766-3v88-pfcf.yml
@@ -24,3 +24,5 @@ description: |
   establishes the subject.
 patched_versions:
   - ">= 0.1.6"
+notes: |
+    - A CVE has been requested for this GHSA and can be added once assigned.

--- a/gems/where_is_waldo/GHSA-r766-3v88-pfcf.yml
+++ b/gems/where_is_waldo/GHSA-r766-3v88-pfcf.yml
@@ -1,0 +1,26 @@
+---
+gem: where_is_waldo
+ghsa: r766-3v88-pfcf
+url: https://github.com/byscott-io/where_is_waldo/security/advisories/GHSA-r766-3v88-pfcf
+title: >-
+  where_is_waldo authenticates ActionCable connections from a client-supplied
+  subject_id when no authenticate_proc is configured
+date: 2026-07-25
+description: |
+  WhereIsWaldo::ApplicationCable::Connection (the gem's built-in ActionCable
+  connection) authenticated the connection from `request.params[:subject_id]`
+  whenever no `authenticate_proc` was configured. Because request params are
+  client-controlled, a client could connect with `?subject_id=<any id>` and be
+  authenticated as that subject, enabling impersonation and cross-account
+  presence-roster disclosure (authentication bypass by spoofing, CWE-290).
+
+  Only applications that mount the built-in connection without configuring
+  `authenticate_proc` are affected; applications that supply their own
+  authenticated ActionCable connection (e.g. deriving current_user from a
+  verified JWT) or configure `authenticate_proc` are not.
+
+  Fixed in 0.1.6: the params path is permitted only in local development/test;
+  in production the connection fails closed unless an authenticated source
+  establishes the subject.
+patched_versions:
+  - ">= 0.1.6"


### PR DESCRIPTION
Adds the security advisory for the `where_is_waldo` gem.

- **GHSA:** [GHSA-r766-3v88-pfcf](https://github.com/byscott-io/where_is_waldo/security/advisories/GHSA-r766-3v88-pfcf)
- **Affected:** `< 0.1.6` — **Patched:** `0.1.6`
- **CWE-290** (Authentication Bypass by Spoofing)

The gem's built-in ActionCable connection authenticated from client-supplied `request.params[:subject_id]` when no `authenticate_proc` was configured, allowing subject impersonation / cross-account roster disclosure. Fixed in 0.1.6 by failing closed in production.

(A CVE has been requested for this GHSA and can be added once assigned.)