### PR TITLE
Updated advisories with GHSL info

### DIFF
--- a/gems/omniauth-saml/GHSA-hw46-3hmr-x9xv.yml
+++ b/gems/omniauth-saml/GHSA-hw46-3hmr-x9xv.yml
@@ -5,7 +5,7 @@ url: https://github.com/omniauth/omniauth-saml/security/advisories/GHSA-hw46-3hm
 title: omniauth-saml has dependency on ruby-saml version with Signature Wrapping Attack
   issue
 date: 2025-03-12
-description: |-
+description: |
   ### Summary
   There are 2 new Critical Signature Wrapping Vulnerabilities (CVE-2025-25292, CVE-2025-25291) and a potential DDOS Moderated Vulneratiblity (CVE-2025-25293) affecting ruby-saml, a dependency of omniauth-saml.
 
@@ -21,6 +21,9 @@ patched_versions:
   - "~> 2.1.3"
   - ">= 2.2.3"
 related:
+  cve:
+    - 2025-25291
+    - 2025-25292
   url:
     - https://github.com/omniauth/omniauth-saml/security/advisories/GHSA-hw46-3hmr-x9xv
     - https://github.com/omniauth/omniauth-saml/commit/0d5eaa0d808acb2ac96deadf5c750ac1cf2d92b5
@@ -28,4 +31,5 @@ related:
     - https://github.com/omniauth/omniauth-saml/commit/7a348b49083462a566af41a5ae85e9f3af15b985
     - https://github.com/omniauth/omniauth-saml/blob/master/omniauth-saml.gemspec#L16
     - https://rubygems.org/gems/omniauth-saml/versions/2.2.3
+    - https://securitylab.github.com/advisories/GHSL-2024-329_GHSL-2024-330_ruby-saml
     - https://github.com/advisories/GHSA-hw46-3hmr-x9xv

--- a/gems/pay/CVE-2023-30614.yml
+++ b/gems/pay/CVE-2023-30614.yml
@@ -26,4 +26,5 @@ related:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-30614
     - https://github.com/pay-rails/pay/commit/5d6283a24062bd272a524ec48415f536a67ad57f
     - https://github.com/pay-rails/pay/commit/c067771d8c7514acde4b948b474caf054bb0e25d
+    - https://securitylab.github.com/advisories/GHSL-2023-084_Pay
     - https://github.com/advisories/GHSA-cqf3-vpx7-rxhw

--- a/gems/ruby-saml/CVE-2025-25291.yml
+++ b/gems/ruby-saml/CVE-2025-25291.yml
@@ -5,7 +5,7 @@ ghsa: 4vc4-m8qh-g8jm
 url: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-4vc4-m8qh-g8jm
 title: Ruby SAML allows a SAML authentication bypass due to DOCTYPE handling (parser differential)
 date: 2025-03-12
-description: |-
+description: |
   ### Summary
   An authentication bypass vulnerability was found in ruby-saml due to a parser differential.
   ReXML and Nokogiri parse XML differently, the parsers can generate entirely
@@ -30,4 +30,5 @@ related:
     - https://github.blog/security/sign-in-as-anyone-bypassing-saml-sso-authentication-with-parser-differentials
     - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.12.4
     - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.18.0
+    - https://securitylab.github.com/advisories/GHSL-2024-329_GHSL-2024-330_ruby-saml
     - https://github.com/advisories/GHSA-4vc4-m8qh-g8jm

--- a/gems/ruby-saml/CVE-2025-25292.yml
+++ b/gems/ruby-saml/CVE-2025-25292.yml
@@ -5,7 +5,7 @@ ghsa: 754f-8gm6-c4r2
 url: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-754f-8gm6-c4r2
 title: Ruby SAML allows a SAML authentication bypass due to namespace handling (parser differential)
 date: 2025-03-12
-description: |-
+description: |
   ### Summary
   An authentication bypass vulnerability was found in ruby-saml due to a parser differential.
   ReXML and Nokogiri parse XML differently, the parsers can generate entirely
@@ -30,4 +30,5 @@ related:
     - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.18.0
     - https://nvd.nist.gov/vuln/detail/CVE-2025-25292
     - https://github.blog/security/sign-in-as-anyone-bypassing-saml-sso-authentication-with-parser-differentials
+    - https://securitylab.github.com/advisories/GHSL-2024-329_GHSL-2024-330_ruby-saml
     - https://github.com/advisories/GHSA-754f-8gm6-c4r2

--- a/gems/ruby-saml/CVE-2025-25293.yml
+++ b/gems/ruby-saml/CVE-2025-25293.yml
@@ -5,7 +5,7 @@ ghsa: 92rq-c8cf-prrq
 url: https://github.com/SAML-Toolkits/ruby-saml/security/advisories/GHSA-92rq-c8cf-prrq
 title: Ruby SAML allows remote Denial of Service (DoS) with compressed SAML responses
 date: 2025-03-12
-description: |-
+description: |
   ### Summary
   ruby-saml is susceptible to remote Denial of Service (DoS) with compressed SAML responses.
 
@@ -31,4 +31,5 @@ related:
     - https://github.blog/security/sign-in-as-anyone-bypassing-saml-sso-authentication-with-parser-differentials
     - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.12.4
     - https://github.com/SAML-Toolkits/ruby-saml/releases/tag/v1.18.0
+    - https://securitylab.github.com/advisories/GHSL-2024-355_ruby-saml
     - https://github.com/advisories/GHSA-92rq-c8cf-prrq

--- a/lib/rad-ignores.sh
+++ b/lib/rad-ignores.sh
@@ -156,6 +156,11 @@ rm -f gems/bootstrap/CVE-2024-6531.yml
 # * (DISPUTED) https://nvd.nist.gov/vuln/detail/CVE-2018-18307
 rm -f gems/alchemy_cms/CVE-2018-18307.yml
 
+# 7/27/2026: GHSL/Not a gem
+# https://securitylab.github.com/advisories/GHSL-2024-001_GHSL-2024-003_rubygems_org
+# https://github.com/rubygems/rubygems.org/security/advisories/GHSA-4vc5-whwr-7hh2
+# https://nvd.nist.gov/vuln/detail/CVE-2024-35221
+
 exit
 
 # AL>> QUESTION (ruby or jruby)?


### PR DESCRIPTION
Updated advisories with GHSL info
 * gems/omniauth-saml/GHSA-hw46-3hmr-x9xv.yml
 * gems/pay/CVE-2023-30614.yml
 * gems/ruby-saml/CVE-2025-25291.yml
 * gems/ruby-saml/CVE-2025-25292.yml
 * gems/ruby-saml/CVE-2025-25293.yml
 * lib/rad-ignores.sh

Changed "|-" to "-" in above files.