### PR TITLE
GHSA/SYNC: (Two new, updated 4, renamed 2, ignored 2) advisories

### DIFF
--- a/gems/activerecord-tenanted/GHSA-pmwx-rm49-xv39.yml
+++ b/gems/activerecord-tenanted/GHSA-pmwx-rm49-xv39.yml
@@ -36,6 +36,7 @@ related:
     - https://github.com/basecamp/activerecord-tenanted/pull/307
     - https://github.com/basecamp/activerecord-tenanted/commit/b242c8ad9bf58bbd7f5a032d153b0f29db54b9ba
     - https://osv.dev/vulnerability/GHSA-pmwx-rm49-xv39
+    - https://advisories.gitlab.com/gem/activerecord-tenanted/GHSA-pmwx-rm49-xv39
     - https://github.com/rails/rails/security/advisories/GHSA-9xrj-h377-fr87
     - https://github.com/advisories/GHSA-pmwx-rm49-xv39
 notes: |

--- a/gems/activerecord-tenanted/GHSA-pmwx-rm49-xv39.yml
+++ b/gems/activerecord-tenanted/GHSA-pmwx-rm49-xv39.yml
@@ -35,6 +35,7 @@ related:
     - https://github.com/basecamp/activerecord-tenanted/releases/tag/v0.7.0
     - https://github.com/basecamp/activerecord-tenanted/pull/307
     - https://github.com/basecamp/activerecord-tenanted/commit/b242c8ad9bf58bbd7f5a032d153b0f29db54b9ba
+    - https://osv.dev/vulnerability/GHSA-pmwx-rm49-xv39
     - https://github.com/rails/rails/security/advisories/GHSA-9xrj-h377-fr87
     - https://github.com/advisories/GHSA-pmwx-rm49-xv39
 notes: |

--- a/gems/activerecord-tenanted/GHSA-pmwx-rm49-xv39.yml
+++ b/gems/activerecord-tenanted/GHSA-pmwx-rm49-xv39.yml
@@ -1,0 +1,41 @@
+---
+gem: activerecord-tenanted
+ghsa: pmwx-rm49-xv39
+url: https://github.com/basecamp/activerecord-tenanted/security/advisories/GHSA-pmwx-rm49-xv39
+title: ActiveRecord::Tenanted::Storage::DiskService#path_for has a
+  possible path traversal
+date: 2026-07-29
+description: |
+  ### Summary
+
+  Active Record Tenanted's override of Active Storage's `DiskService#path_for`
+  does not validate that the resolved filesystem path remains within
+  the storage root directory. If a blob key containing path traversal
+  sequences (e.g. `../`) is used, it could allow reading, writing, or
+  deleting arbitrary files on the server. Blob keys are expected to be
+  trusted strings, but some applications could be passing user input
+  as keys and would be affected.
+
+  ### Mitigation
+
+  Upgrade to Active Record Tenanted v0.7.0 or later.
+
+  As a workaround, do not use untrusted user input as blob keys. Blob
+  keys are expected to be trusted strings.
+
+  ### Credit
+
+  This issue was responsibly reported by @tonghuaroot.
+cvss_v4: 2.3
+patched_versions:
+  - ">= 0.7.0"
+related:
+  url:
+    - https://github.com/basecamp/activerecord-tenanted/security/advisories/GHSA-pmwx-rm49-xv39
+    - https://github.com/basecamp/activerecord-tenanted/releases/tag/v0.7.0
+    - https://github.com/basecamp/activerecord-tenanted/pull/307
+    - https://github.com/basecamp/activerecord-tenanted/commit/b242c8ad9bf58bbd7f5a032d153b0f29db54b9ba
+    - https://github.com/rails/rails/security/advisories/GHSA-9xrj-h377-fr87
+    - https://github.com/advisories/GHSA-pmwx-rm49-xv39
+notes: |
+  - No CVE in GHSA

--- a/gems/oauth/CVE-2026-54605.yml
+++ b/gems/oauth/CVE-2026-54605.yml
@@ -1,7 +1,8 @@
 ---
 gem: oauth
+cve: 2026-54605
 ghsa: prq8-7wvh-44qh
-url: https://github.com/ruby-oauth/oauth/security/advisories/GHSA-prq8-7wvh-44qh
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-54605
 title: Cross-origin OAuth token-request redirects can expose
   signed request metadata
 date: 2026-06-07
@@ -73,12 +74,15 @@ patched_versions:
   - ">= 1.1.6"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54605
     - https://github.com/ruby-oauth/oauth/blob/v1.1.6/CHANGELOG.md
     - https://github.com/ruby-oauth/oauth/releases/tag/v1.1.6
     - https://github.com/ruby-oauth/oauth/commit/d74b767f
+    - https://github.com/ruby-oauth/oauth/commit/d069dc8c4c9631947451215f07460d6cdf0caf3f
+    - https://github.com/ruby-oauth/oauth/commit/d74b767f
     - https://github.com/ruby-oauth/oauth/security/advisories/GHSA-pp92-crg2-gfv9
     - https://github.com/ruby-oauth/oauth/security/advisories/GHSA-prq8-7wvh-44qh
+    - https://github.com/advisories/GHSA-prq8-7wvh-44qh
 notes: |
-  - Not on GHSA.
-  - No CVE value - will add it if it shows up.
-    - No NVD/[cvss_v2, cvss_v4] values - v3 from GHSA.
+  - cvss_v3 from GHSA
+    - pp92-crg2-gfv9

--- a/gems/oauth2/CVE-2026-54603.yml
+++ b/gems/oauth2/CVE-2026-54603.yml
@@ -1,9 +1,10 @@
 ---
 gem: oauth2
+cve: 2026-54603
 ghsa: pp92-crg2-gfv9
-url: https://github.com/ruby-oauth/oauth2/security/advisories/GHSA-pp92-crg2-gfv9
-title: Protocol-relative redirect Location overrides authority in
-  OAuth2::Client#request, leaking bearer Authorization to attacker host
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-54603
+title: 'OAuth2::Client#request: Protocol-relative redirect Location
+  overrides authority, leaking bearer Authorization to attacker host'
 date: 2026-06-07
 description: |
   ## Summary
@@ -75,11 +76,13 @@ patched_versions:
   - ">= 2.0.22"
 related:
   url:
-    - https://github.com/ruby-oauth/oauth2/blob/v2.0.22/CHANGELOG.md
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54603
     - https://github.com/ruby-oauth/oauth2/releases/tag/v2.0.22
+    - https://github.com/ruby-oauth/oauth2/blob/v2.0.22/CHANGELOG.md
+    - https://github.com/ruby-oauth/oauth2/commit/0f0a474f1b38453e119e660c2daca742d4378ce9
     - https://github.com/ruby-oauth/oauth2/commit/442c1609858ebaecbac5eab77f4511bc81ed7383
+    - https://advisories.gitlab.com/gem/oauth2/CVE-2026-54603
     - https://github.com/ruby-oauth/oauth2/security/advisories/GHSA-pp92-crg2-gfv9
+    - https://github.com/advisories/GHSA-pp92-crg2-gfv9
 notes: |
-  - Not on GHSA.
-  - No CVE value - will add it if it shows up.
-    - No NVD/[cvss_v2, cvss_v4] values - v3 from GHSA.
+  - cvss_v3 from GHSA

--- a/gems/pagy/CVE-2026-54659.yml
+++ b/gems/pagy/CVE-2026-54659.yml
@@ -1,0 +1,42 @@
+---
+gem: pagy
+cve: 2026-54659
+ghsa: 2xmw-f8j8-wfxc
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54659
+title: Pagy I18n locale option is not validated before being used in a file path
+date: 2026-07-28
+description: |
+  ### Summary
+
+  `Pagy::I18n.locale=` did not validate its argument before using it as a
+  path component to load the matching dictionary file (`<locale>.yml`). An
+  application that assigns untrusted input to the locale — e.g. the common
+  pattern `Pagy::I18n.locale = params[:locale]` — let that input influence
+  which file Pagy attempted to load.
+
+  ### Impact
+
+  Information disclosure (CWE-22 / CWE-200): a file-existence / readability
+  oracle for `.yml` paths on the host, plus a server-side read of
+  attacker-chosen files into the process. The file contents are not
+  returned in the response.
+
+  Only applications that pass **unsanitized end-user input** into
+  `Pagy::I18n.locale=` are affected. Applications that set the locale from
+  trusted values are not affected.
+cvss_v4: 6.9
+unaffected_versions:
+  - "< 43.0.0"
+patched_versions:
+  - ">= 43.5.6"
+related:
+  url:
+    - https://github.com/ddnexus/pagy/releases/tag/43.5.6
+    - https://github.com/ddnexus/pagy/pull/908
+    - https://github.com/ddnexus/pagy/commit/efcf09690e9fa7d7abdfb987b785a55f87e287df
+    - https://advisories.gitlab.com/gem/pagy/CVE-2026-54659
+    - https://github.com/ddnexus/pagy/security/advisories/GHSA-2xmw-f8j8-wfxc
+    - https://github.com/advisories/GHSA-2xmw-f8j8-wfxc
+notes: |
+  - cvss_v4 from GHSA
+  - CVE is reserved, but not published.

--- a/gems/pagy/CVE-2026-54659.yml
+++ b/gems/pagy/CVE-2026-54659.yml
@@ -2,7 +2,7 @@
 gem: pagy
 cve: 2026-54659
 ghsa: 2xmw-f8j8-wfxc
-url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54659
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-54659
 title: Pagy I18n locale option is not validated before being used in a file path
 date: 2026-07-28
 description: |
@@ -31,6 +31,7 @@ patched_versions:
   - ">= 43.5.6"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54659
     - https://github.com/ddnexus/pagy/releases/tag/43.5.6
     - https://github.com/ddnexus/pagy/pull/908
     - https://github.com/ddnexus/pagy/commit/efcf09690e9fa7d7abdfb987b785a55f87e287df
@@ -39,4 +40,3 @@ related:
     - https://github.com/advisories/GHSA-2xmw-f8j8-wfxc
 notes: |
   - cvss_v4 from GHSA
-  - CVE is reserved, but not published.

--- a/gems/sqlite3/CVE-2026-54619.yml
+++ b/gems/sqlite3/CVE-2026-54619.yml
@@ -19,6 +19,7 @@ description: |
   reliably triggered after GC when code is structured in a particular way.
   There is no known general exploit that could be used as a denial
   of service attack.
+cvss_v4: 2.0
 unaffected_versions:
   - "< 2.1.0"
 patched_versions:
@@ -26,6 +27,7 @@ patched_versions:
 related:
   url:
     - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54619
+    - https://advisories.gitlab.com/gem/sqlite3/CVE-2026-54619
     - https://rubygems.org/gems/sqlite3/versions/2.9.5
     - https://github.com/sparklemotion/sqlite3-ruby/releases/tag/v2.9.5
     - https://github.com/sparklemotion/sqlite3-ruby/pull/711

--- a/gems/sqlite3/CVE-2026-54619.yml
+++ b/gems/sqlite3/CVE-2026-54619.yml
@@ -35,4 +35,4 @@ related:
 notes: |
   - NOTE: The gem name is "sqlite3", not the repo name "sqlite3-ruby".
   - CVE is reserved, but not published so GHSA Security is
-    low and no non-GHSA cvss values.
+    low. cvss_v4 from cve.org URL.

--- a/gems/sqlite3/CVE-2026-54619.yml
+++ b/gems/sqlite3/CVE-2026-54619.yml
@@ -20,8 +20,6 @@ description: |
   There is no known general exploit that could be used as a denial
   of service attack.
 cvss_v4: 2.0
-unaffected_versions:
-  - "< 2.1.0"
 patched_versions:
   - ">= 2.9.5"
 related:

--- a/gems/sqlite3/CVE-2026-54620.yml
+++ b/gems/sqlite3/CVE-2026-54620.yml
@@ -20,11 +20,13 @@ description: |
   reliably triggered after GC when code is structured in a particular way.
   There is no known general exploit that could be used as a denial
   of service attack.
+cvss_v4: 2.0
 patched_versions:
   - ">= 2.9.5"
 related:
   url:
     - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54620
+    - https://advisories.gitlab.com/gem/sqlite3/CVE-2026-54620
     - https://rubygems.org/gems/sqlite3/versions/2.9.5
     - https://github.com/sparklemotion/sqlite3-ruby/releases/tag/v2.9.5
     - https://github.com/sparklemotion/sqlite3-ruby/pull/711

--- a/gems/sqlite3/CVE-2026-54620.yml
+++ b/gems/sqlite3/CVE-2026-54620.yml
@@ -21,6 +21,8 @@ description: |
   There is no known general exploit that could be used as a denial
   of service attack.
 cvss_v4: 2.0
+unaffected_versions:
+  - "< 2.1.0"
 patched_versions:
   - ">= 2.9.5"
 related:

--- a/lib/rad-ignores.sh
+++ b/lib/rad-ignores.sh
@@ -156,6 +156,10 @@ rm -f gems/bootstrap/CVE-2024-6531.yml
 # * (DISPUTED) https://nvd.nist.gov/vuln/detail/CVE-2018-18307
 rm -f gems/alchemy_cms/CVE-2018-18307.yml
 
+# 7/29/2026: Last release of sqlite3-ruby was 1/16/2011.
+rm -f gems/sqlite3-ruby/CVE-2026-54619.yml \
+      gems/sqlite3-ruby/CVE-2026-54620.yml
+
 exit
 
 # AL>> QUESTION (ruby or jruby)?


### PR DESCRIPTION
GHSA/SYNC: (Two new, updated 4, renamed 2, ignored 2) advisories
 * Added:
   * gems/activerecord-tenanted/GHSA-pmwx-rm49-xv39.yml
   * gems/pagy/CVE-2026-54659.yml
 * Renamed:
   * gems/oauth/GHSA-prq8-7wvh-44qh.yml  to gems/oauth/CVE-2026-54605.yml
   * gems/oauth2/GHSA-pp92-crg2-gfv9.yml to gems/oauth2/CVE-2026-54603.yml
 * Updated new data to:
   * gems/oauth/CVE-2026-54605.yml
   * gems/oauth2/CVE-2026-54603.yml
   * gems/sqlite3/CVE-2026-54619.yml
   * gems/sqlite3/CVE-2026-54620.yml
 * Added to lib/rad-ignores.sh script

