### PR TITLE
GHSA/SYNC + new data for one concurrent-ruby advisory

### DIFF
--- a/gems/concurrent-ruby/CVE-2026-54904.yml
+++ b/gems/concurrent-ruby/CVE-2026-54904.yml
@@ -2,7 +2,7 @@
 gem: concurrent-ruby
 cve: 2026-54904
 ghsa: h8w8-99g7-qmvj
-url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54904
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-54904
 title: Concurrent Ruby - `AtomicReference#update` livelocks when the
   stored value is `Float::NAN`
 date: 2026-06-19
@@ -37,18 +37,19 @@ description: |
   ### Credit
 
   Pranjali Thakur - depthfirst ([depthfirst.com](<http://depthfirst.com>))
+cvss_v3: 7.5
 cvss_v4: 8.2
 patched_versions:
   - ">= 1.3.7"
 related:
   url:
-    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-54904
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-54904
     - https://rubygems.org/gems/concurrent-ruby/versions/1.3.7
     - https://github.com/ruby-concurrency/concurrent-ruby/releases/tag/v1.3.7
+    - https://osv.dev/vulnerability/GHSA-h8w8-99g7-qmvj
     - https://advisories.gitlab.com/gem/concurrent-ruby/CVE-2026-54904
     - https://github.com/ruby-concurrency/concurrent-ruby/security/advisories/GHSA-h8w8-99g7-qmvj
     - https://github.com/advisories/GHSA-h8w8-99g7-qmvj
 notes: |
-  - cvss_v4 from GHSA
-  - CVE is reserved, but not published.
-    - Not on nvd.nist.gov so no cvss_v2 or cvss_v3.
+  - cvss_v4 from GHSA and nvd.nist.gov URL
+  - cvss_v3 from nvd.nist.gov URL


### PR DESCRIPTION
GHSA/SYNC + new data for one concurrent-ruby advisory
  * gems/concurrent-ruby/CVE-2026-54904.yml
