### PR TITLE
Add 3.3.12 and 3.4.10 to CVE-2026-41316 patched_versions

### DIFF
--- a/gems/erb/CVE-2026-41316.yml
+++ b/gems/erb/CVE-2026-41316.yml
@@ -27,6 +27,7 @@ related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-41316
     - https://www.ruby-lang.org/en/news/2026/07/16/ruby-3-3-12-released
+    - https://www.ruby-lang.org/en/news/2026/06/30/ruby-3-4-10-released
     - https://www.ruby-lang.org/en/news/2026/04/21/ruby-4-0-3-released
     - https://www.ruby-lang.org/en/news/2026/04/21/erb-cve-2026-41316
     - https://github.com/ruby/erb/blob/master/NEWS.md

--- a/gems/erb/CVE-2026-41316.yml
+++ b/gems/erb/CVE-2026-41316.yml
@@ -32,4 +32,6 @@ related:
     - https://www.ruby-lang.org/en/news/2026/04/21/erb-cve-2026-41316
     - https://github.com/ruby/erb/blob/master/NEWS.md
     - https://github.com/ruby/erb/commit/9d017be4e375cdd058650ce528ee6adfead20cac
+    - https://github.com/ruby/ruby/pull/16776
+    - https://github.com/ruby/ruby/pull/16777
     - https://github.com/advisories/GHSA-q339-8rmv-2mhv

--- a/rubies/ruby/CVE-2026-41316.yml
+++ b/rubies/ruby/CVE-2026-41316.yml
@@ -15,14 +15,17 @@ description: |
   arbitrary code. In particular, def_module takes no arguments, making
   it straightforward to invoke as part of a deserialization gadget chain.
 
-  Please update to Ruby 4.0.3 which "only contains ERB 6.0.1.1,
-  which fixes CVE-2026-41316."
+  Please update to Ruby 3.3.12, 3.4.10, 4.0.3 or later.
 cvss_v3: 8.1
 patched_versions:
+  - "~> 3.3.12"
+  - "~> 3.4.10"
   - ">= 4.0.3"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2026-41316
+    - https://www.ruby-lang.org/en/news/2026/07/16/ruby-3-3-12-released
+    - https://www.ruby-lang.org/en/news/2026/06/30/ruby-3-4-10-released
     - https://www.ruby-lang.org/en/news/2026/04/21/ruby-4-0-3-released
     - https://www.ruby-lang.org/en/news/2026/04/21/erb-cve-2026-41316
     - https://github.com/ruby/erb/blob/master/NEWS.md

--- a/rubies/ruby/CVE-2026-41316.yml
+++ b/rubies/ruby/CVE-2026-41316.yml
@@ -30,4 +30,6 @@ related:
     - https://www.ruby-lang.org/en/news/2026/04/21/erb-cve-2026-41316
     - https://github.com/ruby/erb/blob/master/NEWS.md
     - https://github.com/ruby/erb/commit/9d017be4e375cdd058650ce528ee6adfead20cac
+    - https://github.com/ruby/ruby/pull/16776
+    - https://github.com/ruby/ruby/pull/16777
     - https://github.com/advisories/GHSA-q339-8rmv-2mhv


### PR DESCRIPTION
I was running the `ruby_audit` gem on some repos and it was flagging Ruby 3.4.10. It appears that the ERB fix for CVE-2026-41316 was backported to Ruby 3.3.12 and 3.4.10.

https://www.ruby-lang.org/en/news/2026/07/16/ruby-3-3-12-released
https://www.ruby-lang.org/en/news/2026/06/30/ruby-3-4-10-released
