### PR TITLE
Redoing PR#1199 for gems/spree_auth_devise/CVE-2013-2506.yml

### DIFF
--- a/gems/spree_auth_devise/CVE-2013-2506.yml
+++ b/gems/spree_auth_devise/CVE-2013-2506.yml
@@ -14,10 +14,10 @@ description: |
   a user. This may allow a remote attacker to assign arbitrary roles and gain
   elevated administrative privileges.
 cvss_v2: 4.0
+unaffected_versions:
+  - "< 1.0.0"
 patched_versions:
-  - "~> 1.1.6"
-  - "~> 1.2.0"
-  - ">= 1.3.1"
+  - ">= 3.0.5"
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2013-2506
@@ -34,3 +34,11 @@ notes: |
   - 1.1.6 not on https://rubygems.org/gems/spree_auth_devise/versions
   - osvdb from found osvdb.csv file: "90865;Spree app/models/spree/user.rb
     Mass Role Assignment Remote Privilege Escalation"
+  - On 8/12/2026: Copilot said that this GHSA advisory's patched_versions
+    field was updated on 3/7/2024 (could not find a reference) from
+    - "~> 1.1.6"
+    - "~> 1.2.0"
+    - ">= 1.3.0"
+    TO "3.0.5" so I have updated this file.
+  - GHSA also had "Affecgted versions" >= 1.0.0, < 3.0.5" so added
+    unaffected_versions field/value.

--- a/gems/spree_auth_devise/CVE-2013-2506.yml
+++ b/gems/spree_auth_devise/CVE-2013-2506.yml
@@ -3,8 +3,9 @@ gem: spree_auth_devise
 cve: 2013-2506
 osvdb: 90865
 ghsa: jp57-9j37-5476
-url: https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
-title: Spree app/models/spree/user.rb Mass Role Assignment Remote Privilege Escalation
+url: https://nvd.nist.gov/vuln/detail/CVE-2013-2506
+title: Spree app/models/spree/user.rb
+  Mass Role Assignment Remote Privilege Escalation
 date: 2013-02-21
 description: |
   Spree contains a flaw that leads to unauthorized privileges being gained. The
@@ -16,4 +17,20 @@ cvss_v2: 4.0
 patched_versions:
   - "~> 1.1.6"
   - "~> 1.2.0"
-  - ">= 1.3.0"
+  - ">= 1.3.1"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2013-2506
+    - https://rubygems.org/gems/spree_auth_devise/versions/1.3.1
+    - https://rubygems.org/gems/spree_auth_devise/versions/1.2.0
+    - https://github.com/spree/spree_auth_devise/commit/038d74771d3b5c13d13b738b73dfda1033a99f65
+    - https://github.com/spree/spree_auth_devise/commit/fda3ab9fb536c64fe18a9b78bb21c6176b3ea24d
+    - https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+    - https://web.archive.org/web/20160331131233/https://spreecommerce.com/blog/multiple-security-vulnerabilities-fixed
+    - https://github.com/advisories/GHSA-jp57-9j37-5476
+notes: |
+  - patched_versions, cvss_v2, and Commit URLs from nvd.nist.gov URL.
+  - (YANKED) https://rubygems.org/gems/spree_auth_devise/versions/1.3.0
+  - 1.1.6 not on https://rubygems.org/gems/spree_auth_devise/versions
+  - osvdb from found osvdb.csv file: "90865;Spree app/models/spree/user.rb
+    Mass Role Assignment Remote Privilege Escalation"


### PR DESCRIPTION
Redoing PR#1199 for:
 * gems/spree_auth_devise/CVE-2013-2506.yml
 
 ~~NOTE: Did not change anything from the PR#1199 version of file.~~

Added review updates.