### PR TITLE
Drop required cve: field

### DIFF
--- a/spec/schemas/gem.json
+++ b/spec/schemas/gem.json
@@ -6,7 +6,6 @@
   "additionalProperties": false,
   "required": ["gem", "url", "title", "date", "description"],
   "anyOf": [
-    { "required": ["cve"] },
     { "required": ["osvdb"] },
     { "required": ["ghsa"] }
   ],


### PR DESCRIPTION
Drop required cve: field
 * Which means that now our advisories will have some form of `ghit:` value
   with a backup of `osvdb:` value for legacy advisories