### PR TITLE
Updated 6 advisories; removed required CVE filename preference spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ issue or submit a PR.
 The database is a list of directories that match the names of Ruby libraries on
 [rubygems.org]. Within each directory are one or more advisory files
 for the Ruby library. These advisory files are named using
-the advisories' [CVE] identifier number.
+the advisories' [CVE] or [GHSA] or [OSVDB] (legacy) identifier number.
 
 ```
 gems/:
@@ -212,12 +212,11 @@ patched_versions:
 # General Contributing Guidelines
 
 * Advisory file name
-  * Preference is CVE, then GHSA, then OSVDB, in that order.
+  * Preference is CVE or GHSA over OSVDB file naming.
   * Should be equal to root `url:` field value.
 * For post-2016 advisories, use only "published" or "reserved" CVEs which are found at one of these web sites:
   * https://nvd.nist.gov/vuln/search
   * https://www.cve.org/CVERecord
-* When present, the CVE should be used in the primary "url:", "cve:", and "related:"/"url:" fields.
 * All text should be wrapped at 80 columns.
   * YAML must be indented by 2 spaces.
   * Ruby YAML does not like embedded ":" characters.

--- a/gems/action_text-trix/GHSA-53g2-mvcc-q9x3.yml
+++ b/gems/action_text-trix/GHSA-53g2-mvcc-q9x3.yml
@@ -48,7 +48,6 @@ related:
     - https://github.com/basecamp/trix/security/advisories/GHSA-53g2-mvcc-q9x3
     - https://github.com/advisories/GHSA-53g2-mvcc-q9x3
 notes: |
-  - No CVE.
   - cvss_v3 from GHSA URL.
   - date from gem releases page
   - Unnknown HackerOne number

--- a/gems/action_text-trix/GHSA-53g2-mvcc-q9x3.yml
+++ b/gems/action_text-trix/GHSA-53g2-mvcc-q9x3.yml
@@ -1,5 +1,6 @@
 ---
 gem: action_text-trix
+cve: 2026-73428
 ghsa: 53g2-mvcc-q9x3
 url: https://github.com/basecamp/trix/security/advisories/GHSA-53g2-mvcc-q9x3
 title: Stored XSS via HTMLParser attribute injection on paste
@@ -38,13 +39,16 @@ patched_versions:
   - ">= 2.1.18"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-73428
     - https://rubygems.org/gems/action_text-trix/versions/2.1.18
     - https://github.com/basecamp/trix/releases/tag/v2.1.18
     - https://github.com/basecamp/trix/pull/1293
+    - https://github.com/basecamp/trix/commit/9c0a993d9fc2ffe9d56b013b030bc238f9c0557c
     - https://github.com/advisories/GHSA-53p3-c7vp-4mcc
     - https://github.com/basecamp/trix/security/advisories/GHSA-53g2-mvcc-q9x3
+    - https://github.com/advisories/GHSA-53g2-mvcc-q9x3
 notes: |
   - No CVE.
-  - cvss_v3 from GHSA
+  - cvss_v3 from GHSA URL.
   - date from gem releases page
   - Unnknown HackerOne number

--- a/gems/action_text-trix/GHSA-53p3-c7vp-4mcc.yml
+++ b/gems/action_text-trix/GHSA-53p3-c7vp-4mcc.yml
@@ -1,5 +1,6 @@
 ---
 gem: action_text-trix
+cve: 2026-73427
 ghsa: 53p3-c7vp-4mcc
 url: https://github.com/basecamp/trix/security/advisories/GHSA-53p3-c7vp-4mcc
 title: Trix is vulnerable to XSS through JSON deserialization bypass
@@ -39,7 +40,11 @@ patched_versions:
   - ">= 2.1.18"
 related:
   url:
-    - https://github.com/basecamp/trix/security/advisories/GHSA-53p3-c7vp-4mcc
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-73427
+    - https://rubygems.org/gems/action_text-trix/versions/2.1.18
     - https://github.com/basecamp/trix/releases/tag/v2.1.18
     - https://github.com/basecamp/trix/commit/9c0a993d9fc2ffe9d56b013b030bc238f9c0557c
+    - https://github.com/basecamp/trix/security/advisories/GHSA-53p3-c7vp-4mcc
     - https://github.com/advisories/GHSA-53p3-c7vp-4mcc
+notes: |
+  - cvss_v4 from GHSA and nvd.nist.gov URLs.

--- a/gems/action_text-trix/GHSA-qmpg-8xg6-ph5q.yml
+++ b/gems/action_text-trix/GHSA-qmpg-8xg6-ph5q.yml
@@ -1,5 +1,6 @@
 ---
 gem: action_text-trix
+cve: 2026-73426
 ghsa: qmpg-8xg6-ph5q
 url: https://github.com/basecamp/trix/security/advisories/GHSA-qmpg-8xg6-ph5q
 title: Trix has a Stored XSS vulnerability through serialized attributes
@@ -31,9 +32,14 @@ patched_versions:
   - ">= 2.1.17"
 related:
   url:
-    - https://github.com/basecamp/trix/security/advisories/GHSA-qmpg-8xg6-ph5q
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-73426
+    - https://rubygems.org/gems/action_text-trix/versions/2.1.17
     - https://github.com/basecamp/trix/releases/tag/v2.1.17
     - https://github.com/basecamp/trix/pull/1282
     - https://github.com/basecamp/trix/commit/53197ab5a142e6b0b76127cb790726b274eaf1bc
     - https://hackerone.com/reports/3581911
+    - https://github.com/basecamp/trix/security/advisories/GHSA-qmpg-8xg6-ph5q
     - https://github.com/advisories/GHSA-qmpg-8xg6-ph5q
+notes: |
+  - cvss_v3 from GHSA
+  - CVE is reserved, but not published.

--- a/gems/loofah/GHSA-8whx-365g-h9vv.yml
+++ b/gems/loofah/GHSA-8whx-365g-h9vv.yml
@@ -1,5 +1,6 @@
 ---
 gem: loofah
+cve: 2026-73491
 ghsa: 8whx-365g-h9vv
 url: https://github.com/flavorjones/loofah/security/advisories/GHSA-8whx-365g-h9vv
 title: Loofah `allowed_uri?` does not detect `javascript:` URIs
@@ -22,10 +23,12 @@ patched_versions:
   - ">= 2.25.2"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-73491
     - https://rubygems.org/gems/loofah/versions/2.25.2
     - https://github.com/flavorjones/loofah/blob/main/CHANGELOG.md#2252--2026-07-15
+    - https://github.com/flavorjones/loofah/commit/5e91af861e3cdab47b91dd0b81f3afdfd13a5e19
     - https://github.com/advisories/GHSA-46fp-8f5p-pf2m
     - https://github.com/flavorjones/loofah/security/advisories/GHSA-8whx-365g-h9vv
+    - https://github.com/advisories/GHSA-8whx-365g-h9vv
 notes: |
-  - cvss_v4 from project GHSA
-  - No CVE.
+  - cvss_v4 from GHSA and nvd.nist.gov URLs.

--- a/gems/loofah/GHSA-9wjq-cp2p-hrgf.yml
+++ b/gems/loofah/GHSA-9wjq-cp2p-hrgf.yml
@@ -1,6 +1,7 @@
 ---
 gem: loofah
 ghsa: 9wjq-cp2p-hrgf
+cve: 2026-73490
 url: https://github.com/flavorjones/loofah/security/advisories/GHSA-9wjq-cp2p-hrgf
 title: SVG `href` attribute bypasses local-reference restriction in Loofah
 date: 2026-07-15
@@ -34,9 +35,10 @@ patched_versions:
   - ">= 2.25.2"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-73490
     - https://rubygems.org/gems/loofah/versions/2.25.2
     - https://github.com/flavorjones/loofah/blob/main/CHANGELOG.md#2252--2026-07-15
+    - https://github.com/flavorjones/loofah/commit/20867b9be689521887364b74822c41ef830523c9
     - https://github.com/flavorjones/loofah/security/advisories/GHSA-9wjq-cp2p-hrgf
 notes: |
-  - cvss_v3 value from GHSA
-  - No CVE.
+  - cvss_v3 from GHSA and nvd.nist.gov URLs.

--- a/gems/rails-html-sanitizer/GHSA-cj75-f6xr-r4g7.yml
+++ b/gems/rails-html-sanitizer/GHSA-cj75-f6xr-r4g7.yml
@@ -1,6 +1,7 @@
 ---
 gem: rails-html-sanitizer
 framework: rails
+cve: 2026-73648
 ghsa: cj75-f6xr-r4g7
 url: https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-cj75-f6xr-r4g7
 title: Possible XSS vulnerability with certain configurations of
@@ -14,6 +15,27 @@ description: |
   SVG reference element such as <use>.
   See related GHSA-9wjq-cp2p-hrgf in Loofah, whose SVG local-reference
   logic rails-html-sanitizer mirrors.
+
+  ## Impact
+
+  `Rails::HTML::PermitScrubber` restricts SVG reference elements in the
+  `SVG_ALLOW_LOCAL_HREF` collection to local, same-document references,
+  but that restriction covered only the `xlink:href` attribute. Browsers
+  also accept a plain `href` attribute per the SVG 2 spec, and it was
+  not restricted, so those elements could reference arbitrary external
+  documents. SVG `<use>` can load and render external SVG content by
+  reference, and if the referenced document is same-origin and contains
+  scripts, it could execute in the context of the sanitized document.
+  `<feImage>` can load external images, which can be used for tracking.
+
+  Applications are impacted only when the allowed tags are overridden
+  to include one of these SVG reference elements, for example `<use>`
+  or `<feImage>`. The default allowed tags do not include these SVG
+  elements, so applications using the default configuration are not affected.
+
+  ## Credit
+
+  Found by maintainer Mike Dalessio during a security audit.
 cvss_v4: 5.1
 unaffected_versions:
   - "< 1.0.3"
@@ -21,12 +43,14 @@ patched_versions:
   - ">= 1.7.1"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-73648
     - https://rubygems.org/gems/rails-html-sanitizer/versions/1.7.1
+    - https://github.com/rails/rails-html-sanitizer/releases/tag/v1.7.1
     - https://github.com/rails/rails-html-sanitizer/blob/main/CHANGELOG.md#v171--2026-07-15
     - https://github.com/rails/rails-html-sanitizer/commit/74dcb8053e6da9921246ce71b06ad9fd65b19586
     - https://discuss.rubyonrails.org/t/ghsa-cj75-f6xr-r4g7-possible-xss-vulnerability-with-certain-configurations-of-rails-html-sanitizer/91359#post_1
     - https://github.com/flavorjones/loofah/security/advisories/GHSA-9wjq-cp2p-hrgf
     - https://github.com/rails/rails-html-sanitizer/security/advisories/GHSA-cj75-f6xr-r4g7
+    - https://github.com/advisories/GHSA-cj75-f6xr-r4g7
 notes: |
-  - cvss_v4 from GHSA
-  - No CVE.
+  - cvss_v4 in GHSA and nvd.nist.gov URLs.

--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -43,13 +43,13 @@ shared_examples_for 'Advisory' do |path|
       expect(advisory['cve'] || advisory['osvdb'] || advisory['ghsa']).not_to be_nil
     end
 
-    it "should CVE-XXX if cve field has a value" do
-      if advisory['cve']
-        expect(filename).to start_with('CVE-')
-      elsif advisory['ghsa']
-        expect(filename).to start_with('GHSA-')
-      end
-    end
+#    it "should CVE-XXX if cve field has a value" do
+#      if advisory['cve']
+#        expect(filename).to start_with('CVE-')
+#      elsif advisory['ghsa']
+#        expect(filename).to start_with('GHSA-')
+#      end
+#    end
 
     describe "platform" do
       subject { advisory['platform'] }

--- a/spec/advisory_example.rb
+++ b/spec/advisory_example.rb
@@ -43,14 +43,6 @@ shared_examples_for 'Advisory' do |path|
       expect(advisory['cve'] || advisory['osvdb'] || advisory['ghsa']).not_to be_nil
     end
 
-#    it "should CVE-XXX if cve field has a value" do
-#      if advisory['cve']
-#        expect(filename).to start_with('CVE-')
-#      elsif advisory['ghsa']
-#        expect(filename).to start_with('GHSA-')
-#      end
-#    end
-
     describe "platform" do
       subject { advisory['platform'] }
 


### PR DESCRIPTION
Updated 6 advisories; removed required CVE filename preference spec
 * gems/loofah/GHSA-8whx-365g-h9vv.yml
 * gems/loofah/GHSA-9wjq-cp2p-hrgf.yml
 * gems/rails-html-sanitizer/GHSA-cj75-f6xr-r4g7.yml
 
  * gems/action_text-trix/GHSA-53g2-mvcc-q9x3.yml
 * gems/action_text-trix/GHSA-53p3-c7vp-4mcc.yml
 * gems/action_text-trix/GHSA-qmpg-8xg6-ph5q.yml

 * spec/advisory_example.rb (now filenames stay the same even if we get new data)

