### PR TITLE
fix css_parser CVE-2026-53727

### DIFF
--- a/gems/css_parser/CVE-2026-53727.yml
+++ b/gems/css_parser/CVE-2026-53727.yml
@@ -22,8 +22,6 @@ description: |
   example — is exposed. The attacker only needs the ability to land one
   @import url(...) in the CSS that the host application parses.
 cvss_v4: 8.9
-unaffected_versions:
-  - "< 2.2.0"
 patched_versions:
   - ">= 3.0.0"
 related:


### PR DESCRIPTION
as per https://github.com/premailer/css_parser/issues/189

https://github.com/rubysec/ruby-advisory-db/blob/master/gems/css_parser/CVE-2026-53727.yml says <3

https://access.redhat.com/security/cve/cve-2026-53727 says <3 too