### PR TITLE
Two new resolv advisories

### DIFF
--- a/gems/resolv/CVE-2026-80212.yml
+++ b/gems/resolv/CVE-2026-80212.yml
@@ -1,0 +1,43 @@
+---
+gem: resolv
+cve: 2026-80212
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-80212
+title: CVE-2026-80212 - Memory exhaustion through malicious DNS responses
+date: 2026-08-27
+description: |
+  An application that resolves a hostname an attacker can influence,
+  such as a webhook target or a user-supplied URL, can be made to
+  consume memory without bound. The attacker points a domain at a
+  name server they control and returns responses that the library
+  retains permanently. Repeated lookups grow the process until it
+  runs out of memory and the service stops.
+
+  ## Credits
+
+  Thanks to dalifit for discovering these issues.
+patched_versions:
+  - "~> 0.3.2"
+  - ">= 0.7.2"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-80212
+    - https://rubygems.org/gems/resolv/versions/0.7.2
+    - https://github.com/ruby/resolv/releases/tag/v0.7.2
+    - https://rubygems.org/gems/resolv/versions/0.3.2
+    - https://github.com/ruby/resolv/releases/tag/v0.3.2
+    - https://www.ruby-lang.org/en/security
+    - https://www.ruby-lang.org/en/news/2026/08/27/multiple-vulnerabilities-in-resolv
+notes: |
+  - CVE is reserved, but not published.
+  - No GHSA values and no cvss values
+  - Text from "multiple-vulnerabilities-in-resolv" URL
+    - "Affected versions
+      - resolv gem 0.4.0 through 0.7.1
+      - resolv gem 0.3.1 and earlier
+      - The version bundled with Ruby differs per series: Ruby 4.0 ships
+        resolv 0.7.0, Ruby 3.4 ships 0.7.1, and Ruby 3.3 ships 0.3.1."
+    - Recommended action
+      - Update the resolv gem to 0.7.2. For the Ruby 3.3 series, update to 0.3.2.
+      - No release is planned for the 0.2.x line that the Ruby 3.2 series
+        ships, because that series has reached its end of life. Install
+        resolv 0.7.2 there instead."

--- a/gems/resolv/CVE-2026-80213.yml
+++ b/gems/resolv/CVE-2026-80213.yml
@@ -1,0 +1,45 @@
+---
+gem: resolv
+cve: 2026-80213
+url: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-80213
+title: CVE-2026-80213 - Hostname validation bypass
+date: 2026-08-27
+description: |
+  An application that checks a hostname against an allow list or an
+  SSRF filter and then resolves it can be made to look up a domain
+  other than the one it checked. The string that passes validation
+  and the name that reaches the network are not the same, so the
+  connection can end up at a host the application never approved.
+  This requires a hostname that exceeds the DNS length limits, so
+  validation that rejects names longer than 255 octets, or labels
+  longer than 63 octets, is not affected.
+
+  ## Credits
+
+  Thanks to dalifit for discovering these issues.
+patched_versions:
+  - "~> 0.3.2"
+  - ">= 0.7.2"
+related:
+  url:
+    - https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-80213
+    - https://rubygems.org/gems/resolv/versions/0.7.2
+    - https://github.com/ruby/resolv/releases/tag/v0.7.2
+    - https://rubygems.org/gems/resolv/versions/0.3.2
+    - https://github.com/ruby/resolv/releases/tag/v0.3.2
+    - https://www.ruby-lang.org/en/security
+    - https://www.ruby-lang.org/en/news/2026/08/27/multiple-vulnerabilities-in-resolv
+notes: |
+  - CVE is reserved, but not published.
+  - No GHSA values and no cvss values
+  - Text from "multiple-vulnerabilities-in-resolv" URL
+    - "Affected versions
+      - resolv gem 0.4.0 through 0.7.1
+      - resolv gem 0.3.1 and earlier
+      - The version bundled with Ruby differs per series: Ruby 4.0 ships
+        resolv 0.7.0, Ruby 3.4 ships 0.7.1, and Ruby 3.3 ships 0.3.1."
+    - Recommended action
+      - Update the resolv gem to 0.7.2. For the Ruby 3.3 series, update to 0.3.2.
+      - No release is planned for the 0.2.x line that the Ruby 3.2 series
+        ships, because that series has reached its end of life. Install
+        resolv 0.7.2 there instead."


### PR DESCRIPTION
Two new resolv advisories
 * gems/resolv/CVE-2026-80212.yml
 * gems/resolv/CVE-2026-80213.yml

Based on this post today: https://www.ruby-lang.org/en/news/2026/08/27/multiple-vulnerabilities-in-resolv/