### PR TITLE
 Added `ghsa:` and `related:/url:` data to 17 existing rubies advisories

### DIFF
--- a/rubies/jruby/CVE-2010-1330.yml
+++ b/rubies/jruby/CVE-2010-1330.yml
@@ -2,6 +2,7 @@
 engine: jruby
 cve: 2010-1330
 osvdb: 77297
+ghsa: wmq2-jc9m-xp4m
 url: http://jruby.org/2010/04/26/jruby-1-4-1-xss-vulnerability
 title: 'CVE-2010-1330 jruby: XSS in the regular expression engine when processing
   invalid UTF-8 byte sequences'
@@ -14,3 +15,7 @@ description: |
 cvss_v2: 4.3
 patched_versions:
   - ">= 1.4.1"
+related:
+  url:
+    - http://jruby.org/2010/04/26/jruby-1-4-1-xss-vulnerability
+    - https://github.com/advisories/GHSA-wmq2-jc9m-xp4m

--- a/rubies/jruby/CVE-2012-5370.yml
+++ b/rubies/jruby/CVE-2012-5370.yml
@@ -2,6 +2,7 @@
 engine: jruby
 cve: 2012-5370
 osvdb: 87864
+ghsa: fmmq-j7pq-f85c
 url: http://jruby.org/2012/12/03/jruby-1-7-1
 title: "CVE-2012-5370 jruby: Murmur hash function collisions (oCERT-2012-001)"
 date: 2012-11-23
@@ -14,3 +15,7 @@ description: |
 cvss_v2: 5.0
 patched_versions:
   - ">= 1.7.1"
+related:
+  url:
+    - http://jruby.org/2012/12/03/jruby-1-7-1
+    - https://github.com/advisories/GHSA-fmmq-j7pq-f85c

--- a/rubies/jruby/CVE-2022-25857.yml
+++ b/rubies/jruby/CVE-2022-25857.yml
@@ -1,6 +1,7 @@
 ---
 engine: jruby
 cve: 2022-25857
+ghsa: 3mc7-4q67-w48m
 url: https://github.com/jruby/jruby/issues/7342
 title: "CVE-2022-25857 jruby/psych/snakeyaml: Denial of Service (DoS) due missing to nested depth limitation for collections"
 date: 2022-02-24
@@ -10,3 +11,7 @@ description: |
 cvss_v3: 7.5
 patched_versions:
   - ">= 9.3.8.0"
+related:
+  url:
+    - https://github.com/jruby/jruby/issues/7342
+    - https://github.com/advisories/GHSA-3mc7-4q67-w48m

--- a/rubies/ruby/CVE-2008-3443.yml
+++ b/rubies/ruby/CVE-2008-3443.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2008-3443
+ghsa: v838-v88j-gw93
 url: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-3443
 title: Ruby Memory allocation failure in Ruby regex engine (remotely exploitable DoS)
 date: 2008-08-14
@@ -15,3 +16,7 @@ patched_versions:
   - "~> 1.8.6.287"
   - "~> 1.8.7.72"
   - ">= 1.9.0"
+related:
+  url:
+    - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-3443
+    - https://github.com/advisories/GHSA-v838-v88j-gw93

--- a/rubies/ruby/CVE-2009-4492.yml
+++ b/rubies/ruby/CVE-2009-4492.yml
@@ -2,6 +2,7 @@
 engine: ruby
 cve: 2009-4492
 osvdb: 61774
+ghsa: 6mq2-37j5-w6r6
 url: http://www.ruby-lang.org/en/news/2010/01/10/webrick-escape-sequence-injection
 title: CVE-2009-4492 ruby WEBrick log escape sequence
 date: 2010-01-10
@@ -24,3 +25,4 @@ related:
     - https://access.redhat.com/errata/RHSA-2011:0909
     - http://www.ush.it/team/ush/hack_httpd_escape/adv.txt
     - http://www.osvdb.org/show/osvdb/61774
+    - https://github.com/advisories/GHSA-6mq2-37j5-w6r6

--- a/rubies/ruby/CVE-2012-4481.yml
+++ b/rubies/ruby/CVE-2012-4481.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2012-4481
+ghsa: gh65-6rxj-m8cc
 url: http://www.openwall.com/lists/oss-security/2012/10/05/2
 title:
   Ruby incomplete fix for CVE-2011-1005 for NameError#to_s method when used on
@@ -13,3 +14,7 @@ description: |
 cvss_v2: 4.3
 patched_versions:
   - ">= 1.8.7.371"
+related:
+  url:
+    - http://www.openwall.com/lists/oss-security/2012/10/05/2
+    - https://github.com/advisories/GHSA-gh65-6rxj-m8cc

--- a/rubies/ruby/CVE-2017-10784.yml
+++ b/rubies/ruby/CVE-2017-10784.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2017-10784
+ghsa: 369m-2gv6-mw28
 url: https://www.ruby-lang.org/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784/
 title: Escape sequence injection vulnerability in the Basic authentication of WEBrick
 date: 2017-09-14
@@ -23,3 +24,7 @@ patched_versions:
   - "~> 2.2.8"
   - "~> 2.3.5"
   - ">= 2.4.2"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2017/09/14/webrick-basic-auth-escape-sequence-injection-cve-2017-10784
+    - https://github.com/advisories/GHSA-369m-2gv6-mw28

--- a/rubies/ruby/CVE-2017-14033.yml
+++ b/rubies/ruby/CVE-2017-14033.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2017-14033
+ghsa: v6rp-3r3v-hf4p
 url: https://www.ruby-lang.org/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033/
 title: Buffer underrun vulnerability in OpenSSL ASN1 decode
 date: 2017-09-14
@@ -20,3 +21,7 @@ patched_versions:
   - "~> 2.2.8"
   - "~> 2.3.5"
   - ">= 2.4.2"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2017/09/14/openssl-asn1-buffer-underrun-cve-2017-14033
+    - https://github.com/advisories/GHSA-v6rp-3r3v-hf4p

--- a/rubies/ruby/CVE-2018-16395.yml
+++ b/rubies/ruby/CVE-2018-16395.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2018-16395
+ghsa: mmrq-6999-72v8
 url: https://www.ruby-lang.org/en/news/2018/10/17/openssl-x509-name-equality-check-does-not-work-correctly-cve-2018-16395/
 title: Incorrect equality check in OpenSSL::X509::Name
 date: 2018-10-17
@@ -34,3 +35,7 @@ patched_versions:
   - "~> 2.4.5"
   - "~> 2.5.2"
   - ">= 2.6.0-preview3"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2018/10/17/openssl-x509-name-equality-check-does-not-work-correctly-cve-2018-16395
+    - https://github.com/advisories/GHSA-mmrq-6999-72v8

--- a/rubies/ruby/CVE-2018-8779.yml
+++ b/rubies/ruby/CVE-2018-8779.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2018-8779
+ghsa: mwq4-948j-88c5
 url: https://www.ruby-lang.org/en/news/2018/03/28/poisoned-nul-byte-unixsocket-cve-2018-8779/
 title: Unintentional socket creation by poisoned NUL byte in UNIXServer and UNIXSocket
 date: 2018-03-28

--- a/rubies/ruby/CVE-2019-15845.yml
+++ b/rubies/ruby/CVE-2019-15845.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2019-15845
+ghsa: x99v-c5pj-9m7r
 url: https://www.ruby-lang.org/en/news/2019/10/01/nul-injection-file-fnmatch-cve-2019-15845/
 title: A NUL injection vulnerability of File.fnmatch and File.fnmatch?
 date: 2019-10-01
@@ -16,3 +17,7 @@ patched_versions:
   - "~> 2.5.7"
   - "~> 2.6.5"
   - "> 2.7.0-preview1"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2019/10/01/nul-injection-file-fnmatch-cve-2019-15845
+    - https://github.com/advisories/GHSA-x99v-c5pj-9m7r

--- a/rubies/ruby/CVE-2019-16201.yml
+++ b/rubies/ruby/CVE-2019-16201.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2019-16201
+ghsa: 26h5-qgg3-p324
 url: https://www.ruby-lang.org/en/news/2019/10/01/webrick-regexp-digestauth-dos-cve-2019-16201/
 title: Regular Expression Denial of Service vulnerability of WEBrick's Digest access
   authentication
@@ -14,3 +15,7 @@ patched_versions:
   - "~> 2.5.7"
   - "~> 2.6.5"
   - "> 2.7.0-preview1"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2019/10/01/webrick-regexp-digestauth-dos-cve-2019-16201
+    - https://github.com/advisories/GHSA-26h5-qgg3-p324

--- a/rubies/ruby/CVE-2020-10663.yml
+++ b/rubies/ruby/CVE-2020-10663.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2020-10663
+ghsa: jphg-qwrw-7w9g
 url: https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/
 title: Unsafe Object Creation Vulnerability in JSON (Additional fix)
 date: 2020-03-19
@@ -27,3 +28,7 @@ patched_versions:
   - "~> 2.5.8"
   - "~> 2.6.6"
   - ">= 2.7.1"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663
+    - https://github.com/advisories/GHSA-jphg-qwrw-7w9g

--- a/rubies/ruby/CVE-2021-33621.yml
+++ b/rubies/ruby/CVE-2021-33621.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2021-33621
+ghsa: vc47-6rqg-c7f5
 url: https://www.ruby-lang.org/en/news/2022/11/22/http-response-splitting-in-cgi-cve-2021-33621/
 title: HTTP response splitting in CGI
 date: 2022-11-22
@@ -19,3 +20,7 @@ patched_versions:
   - "~> 2.7.7"
   - "~> 3.0.5"
   - ">= 3.1.3"
+related:
+  url:
+    - https://www.ruby-lang.org/en/news/2022/11/22/http-response-splitting-in-cgi-cve-2021-33621
+    - https://github.com/advisories/GHSA-vc47-6rqg-c7f5

--- a/rubies/ruby/CVE-2025-24294.yml
+++ b/rubies/ruby/CVE-2025-24294.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2025-24294
+ghsa: xh69-987w-hrp8
 url: https://www.ruby-lang.org/en/news/2025/07/08/dos-resolv-cve-2025-24294/
 title: Possible Denial of Service in resolv gem
 date: 2025-07-08
@@ -27,3 +28,4 @@ related:
     - https://www.ruby-lang.org/en/news/2025/07/24/ruby-3-2-9-released/
     - https://www.ruby-lang.org/en/news/2025/07/24/ruby-3-3-9-released/
     - https://www.ruby-lang.org/en/news/2025/07/15/ruby-3-4-5-released/
+    - https://github.com/advisories/GHSA-xh69-987w-hrp8

--- a/rubies/ruby/CVE-2025-58767.yml
+++ b/rubies/ruby/CVE-2025-58767.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2025-58767
+ghsa: c2f4-jgmc-q2r5
 url: https://www.ruby-lang.org/en/news/2025/09/18/dos-rexml-cve-2025-58767/
 title: DoS vulnerability in REXML
 date: 2025-09-18
@@ -23,3 +24,4 @@ related:
     - https://www.ruby-lang.org/en/news/2025/12/17/ruby-3-4-8-released/
     - https://bugs.ruby-lang.org/issues/21632
     - https://github.com/ruby/ruby/pull/14796
+    - https://github.com/advisories/GHSA-c2f4-jgmc-q2r5

--- a/rubies/ruby/CVE-2025-61594.yml
+++ b/rubies/ruby/CVE-2025-61594.yml
@@ -1,6 +1,7 @@
 ---
 engine: ruby
 cve: 2025-61594
+ghsa: j4pr-3wm6-xx2r
 url: https://www.ruby-lang.org/en/news/2025/10/07/uri-cve-2025-61594/
 title: URI Credential Leakage Bypass
 date: 2025-10-07
@@ -21,3 +22,4 @@ related:
     - https://www.cve.org/CVERecord?id=CVE-2025-61594
     - https://www.ruby-lang.org/en/news/2025/10/23/ruby-3-3-10-released/
     - https://www.ruby-lang.org/en/news/2025/10/07/ruby-3-4-7-released/
+    - https://github.com/advisories/GHSA-j4pr-3wm6-xx2r


### PR DESCRIPTION
 Added `ghsa:` and `related:/url:` data to 17 existing rubies advisories
 * rubies/ruby/CVE-2018-8779.yml
 * rubies/jruby/CVE-2010-1330.yml
 * rubies/jruby/CVE-2012-5370.yml
 * rubies/jruby/CVE-2022-25857.yml
 * rubies/ruby/CVE-2008-3443.yml
 * rubies/ruby/CVE-2009-4492.yml
 * rubies/ruby/CVE-2012-4481.yml
 * rubies/ruby/CVE-2017-10784.yml
 * rubies/ruby/CVE-2017-14033.yml
 * rubies/ruby/CVE-2018-16395.yml
 * rubies/ruby/CVE-2019-15845.yml
 * rubies/ruby/CVE-2019-16201.yml
 * rubies/ruby/CVE-2020-10663.yml
 * rubies/ruby/CVE-2021-33621.yml
 * rubies/ruby/CVE-2025-24294.yml
 * rubies/ruby/CVE-2025-58767.yml
 * rubies/ruby/CVE-2025-61594.yml
 