### PR TITLE
Fixed typo in GHSA number

### DIFF
--- a/gems/carrierwave/CVE-2023-49090.yml
+++ b/gems/carrierwave/CVE-2023-49090.yml
@@ -41,7 +41,7 @@ patched_versions:
 related:
   url:
     - https://nvd.nist.gov/vuln/detail/CVE-2023-49090
-    - https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-gxhx-gq-49hj
+    - https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-gxhx-g4fq-49hj
     - https://github.com/carrierwaveuploader/carrierwave/commit/39b282db5c1303899b3d3381ce8a837840f983b5
     - https://github.com/carrierwaveuploader/carrierwave/commit/863d425c76eba12c3294227b39018f6b2dccbbf3
     - https://github.com/carrierwaveuploader/carrierwave/blob/master/lib/carrierwave/uploader/content_type_allowlist.rb


### PR DESCRIPTION
Fixed typo in GHSA number
  * gems/carrierwave/CVE-2023-49090.yml

See below for details.