### PR TITLE
Updated 4 existing advisories - mail, nokogiri

### DIFF
--- a/gems/mail/GHSA-mvxr-6m87-mv2q.yml
+++ b/gems/mail/GHSA-mvxr-6m87-mv2q.yml
@@ -1,5 +1,6 @@
 ---
 gem: mail
+cve: 2026-63435
 ghsa: mvxr-6m87-mv2q
 url: https://github.com/mikel/mail/security/advisories/GHSA-mvxr-6m87-mv2q
 title: Email address spoofing via malformed RFC 2047 encoded-words in mail
@@ -14,15 +15,19 @@ description: |
   part could cause the decoded output to differ from what a human
   reviewer or downstream parser would expect, allowing an attacker
   to spoof the apparent sender/recipient address.
-cvss_v3: 5.1
+cvss_v3: 5.3
 patched_versions:
   - ">= 2.9.1"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/cve-2026-63435
     - https://rubygems.org/gems/mail/versions/2.9.1
     - https://github.com/mikel/mail/releases/tag/2.9.1
     - https://github.com/mikel/mail/pull/1664
+    - https://github.com/mikel/mail/commit/f9d59c2e447af42e2c3dec5a56b1bb25c7292859
+    - https://osv.dev/vulnerability/GHSA-mvxr-6m87-mv2q
+    - https://advisories.gitlab.com/gem/mail/CVE-2026-63435
     - https://github.com/mikel/mail/security/advisories/GHSA-mvxr-6m87-mv2q
+    - https://github.com/advisories/GHSA-mvxr-6m87-mv2q
 notes: |
-  - cvss_v3, date from repo GHSA
-  - No CVE value.
+  - cvss_v3 from GHSA and nvd.nist.gov URLs.

--- a/gems/nokogiri/GHSA-c4rq-3m3g-8wgx.yml
+++ b/gems/nokogiri/GHSA-c4rq-3m3g-8wgx.yml
@@ -1,5 +1,6 @@
 ---
 gem: nokogiri
+cve: 2026-79770
 ghsa: c4rq-3m3g-8wgx
 url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx
 title: Nokogiri CSS selector tokenizer has regular expression backtracking
@@ -7,43 +8,34 @@ date: 2026-05-06
 description: |
   ## Summary
 
-  Nokogiri's CSS selector tokenizer contains regular expressions whose construction may result in exponential regex backtracking on adversarial selectors. Three ReDoS vectors are addressed in this release:
+  Nokogiri's CSS selector tokenizer contains regular expressions whose
+  construction may result in exponential regex backtracking on adversarial
+  selectors. Three ReDoS vectors are addressed in this release:
 
   1. String-literal tokenization on certain unterminated quoted-string input.
   2. String-literal tokenization on a separate class of hex-escape-rich input.
   3. Identifier tokenization on hex-escape-rich input.
 
-  The public CSS selector methods that funnel through the affected tokenizer are `Nokogiri::CSS.xpath_for`, `Node#css`, `Node#at_css`, `Searchable#search`, and `CSS::Parser#parse`.
-
-
-  ## Mitigation
-
-  Upgrade to Nokogiri `>= 1.19.3`.
-
-  If users are unable to upgrade, two options are available:
-
-  - Avoid the use of attacker-controlled text in CSS selectors. Applications that only pass developer-authored selectors to Nokogiri are not directly exposed.
-  - Set global `Regexp.timeout` (Ruby 3.2+, JRuby 9.4+) to bound parse time.
-
-  ## Severity
-
-  The Nokogiri maintainers have evaluated this as **High Severity** (CVSS 7.5, `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`).
-
-  An attacker able to inject user-supplied text into a CSS selector parse method can cause exponential backtracking, resulting in a potential denial of service.
-
-
-  ## Resources
-
-  - [CWE-1333: Inefficient Regular Expression Complexity](https://cwe.mitre.org/data/definitions/1333.html)
-
+  The public CSS selector methods that funnel through the affected
+  tokenizer are `Nokogiri::CSS.xpath_for`, `Node#css`, `Node#at_css`,
+  `Searchable#search`, and `CSS::Parser#parse`.
 
   ## Credit
 
-  Vector 1 was responsibly reported by @colby-swandale. Vectors 2 and 3 were discovered by @flavorjones during the response to the original report.
+  Vector 1 was responsibly reported by @colby-swandale. Vectors 2 and 3
+  were discovered by @flavorjones during the response to the original report.
 cvss_v3: 7.5
+cvss_v4: 8.7
 patched_versions:
   - ">= 1.19.3"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-79770
+    - https://rubygems.org/gems/nokogiri/versions/1.19.3
+    - https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#v1193--2026-04-27
+    - https://www.vulncheck.com/advisories/nokogiri-before-redos-via-css-selector-tokenizer
     - https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx
     - https://github.com/advisories/GHSA-c4rq-3m3g-8wgx
+notes: |
+  - cvss_v3 from GHSA and nvd.nist.gov URLs.
+  - cvss_v4 from nvd.nist.gov URL.

--- a/gems/nokogiri/GHSA-v2fc-qm4h-8hqv.yml
+++ b/gems/nokogiri/GHSA-v2fc-qm4h-8hqv.yml
@@ -1,45 +1,35 @@
 ---
 gem: nokogiri
+cve: 2026-79771
 ghsa: v2fc-qm4h-8hqv
-url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-v2fc-qm4h-8hqv
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-79771
 title: Nokogiri XSLT transform has a memory leak
 date: 2026-05-06
 description: |
   ## Summary
 
-  Nokogiri's `Nokogiri::XSLT::Stylesheet#transform` leaks a small heap allocation when passed a Ruby string parameter containing a null byte.
+  Nokogiri's `Nokogiri::XSLT::Stylesheet#transform` leaks a small heap
+  allocation when passed a Ruby string parameter containing a null byte.
 
-  For applications that pass attacker-controlled input through `XSLT.transform` parameters, this may be a vector for a denial of service attack against long-running processes.
-
-
-  ## Mitigation
-
-  Upgrade to Nokogiri `>= 1.19.3`.
-
-  Users may also be able to mitigate this issue without upgrading by validating untrusted transform parameters before passing them to `Nokogiri::XSLT::Stylesheet#transform`.
-
-
-  ## Severity
-
-  The Nokogiri maintainers have evaluated this as **Moderate Severity**, CVSS 5.3.
-
-  Each leaked allocation is approximately 24–32 bytes, so meaningful memory growth requires sustained attacker-controlled traffic at high call rates. The bug does not cause memory corruption, information disclosure, or any change in the behavior of the transform itself, and the string-handling exception is raised as expected.
-
-  Applications that do not pass raw attacker-controlled bytes to XSLT parameters are unlikely to be affected in practice.
-
-
-  ## Resources
-
-  - [CWE-401: Missing Release of Memory after Effective Lifetime](https://cwe.mitre.org/data/definitions/401.html)
-
+  For applications that pass attacker-controlled input through
+  `XSLT.transform` parameters, this may be a vector for a denial
+  of service attack against long-running processes.
 
   ## Credit
 
   This vulnerability was responsibly reported by @Captainjack-kor.
 cvss_v3: 5.3
+cvss_v4: 6.9
 patched_versions:
   - ">= 1.19.3"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-79771
+    - https://rubygems.org/gems/nokogiri/versions/1.19.3
+    - https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#v1193--2026-04-27
+    - https://www.vulncheck.com/advisories/nokogiri-before-memory-leak-via-xslt-transform
     - https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-v2fc-qm4h-8hqv
     - https://github.com/advisories/GHSA-v2fc-qm4h-8hqv
+notes: |
+  - cvss_v3 from GHSA and nvd.nist.gov URLs.
+  - cvss_v4 from nvd.nist.gov URL.

--- a/gems/nokogiri/GHSA-wx95-c6cv-8532.yml
+++ b/gems/nokogiri/GHSA-wx95-c6cv-8532.yml
@@ -1,7 +1,8 @@
 ---
 gem: nokogiri
+cve: 2026-79772
 ghsa: wx95-c6cv-8532
-url: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-wx95-c6cv-8532
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-79772
 title: Nokogiri does not check the return value from xmlC14NExecute
 date: 2026-02-18
 description: |
@@ -15,32 +16,26 @@ description: |
   invalid or incomplete canonicalized XML, which has been demonstrated
   to enable signature validation bypass in SAML libraries.
 
-  JRuby is not affected, as the Java implementation correctly
-  raises `RuntimeError` on canonicalization failure.
-
-  ## Mitigation
-
-  Upgrade to Nokogiri `>= 1.19.1`.
-
-  ## Severity
-
-  The maintainers have assessed this as **Medium** severity. Nokogiri
-  itself is a parsing library without a clear security boundary
-  related to canonicalization, so the direct impact is that a method
-  returns incorrect data on invalid input. However, this behavior
-  was exploited in practice to bypass SAML signature validation
-  in downstream libraries (see References).
+  JRuby is not affected, as the Java implementation correctly raises
+  `RuntimeError` on canonicalization failure.
 
   ## Credit
 
-  This vulnerability was responsibly reported by HackerOne
-  researcher `d4d`.
+  This vulnerability was responsibly reported by HackerOne researcher `d4d`.
 cvss_v3: 5.3
+cvss_v4: 6.9
 unaffected_versions:
   - "< 1.5.1"
 patched_versions:
   - ">= 1.19.1"
 related:
   url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-79772
+    - https://rubygems.org/gems/nokogiri/versions/1.19.1
+    - https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#v1191--2026-02-16
+    - https://www.vulncheck.com/advisories/nokogiri-before-unchecked-return-value-canonicalize
     - https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-wx95-c6cv-8532
     - https://github.com/advisories/GHSA-wx95-c6cv-8532
+notes: |
+  - cvss_v3 from GHSA and nvd.nist.gov URLs.
+  - cvss_v4 from nvd.nist.gov URL.


### PR DESCRIPTION
Updated 4 existing advisories - mail, nokogiri
 * gems/mail/GHSA-mvxr-6m87-mv2q.yml
 * gems/nokogiri/GHSA-c4rq-3m3g-8wgx.yml
 * gems/nokogiri/GHSA-v2fc-qm4h-8hqv.yml
 * gems/nokogiri/GHSA-wx95-c6cv-8532.yml
