### PR TITLE
One new rubyzip advisories + 9 new entries to rad-ignores.sh file

### DIFF
--- a/gems/rubyzip/CVE-2026-85396.yml
+++ b/gems/rubyzip/CVE-2026-85396.yml
@@ -1,0 +1,33 @@
+---
+gem: rubyzip
+cve: 2026-85396
+ghsa: 47m2-wp7j-p9vc
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-85396
+title: path traversal vulnerability in pre-3.4.0 rubyzip gem
+date: 2026-09-03
+description: |
+  rubyzip versions before 3.4.0 contain a path traversal vulnerability
+  in Zip::Entry#extract that fails to properly validate extraction
+  paths using prefix comparison without trailing separators. Attackers
+  can craft archive entries with names like ../upload_backup/owned.sh
+  to write files outside the intended extraction directory into
+  sibling paths sharing the destination prefix.
+cvss_v3: 7.5
+cvss_v4: 8.7
+patched_versions:
+  - ">= 3.4.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-85396
+    - https://rubygems.org/gems/rubyzip/versions/3.4.0
+    - https://github.com/rubyzip/rubyzip/releases/tag/v3.4.0
+    - https://github.com/rubyzip/rubyzip/blob/v3.4.0/Changelog.md#340-2026-06-14
+    - https://github.com/rubyzip/rubyzip/commit/17edfbf4423b83211b075acc23a7d8640da63449
+    - https://github.com/rubyzip/rubyzip/blob/v3.3.1/lib/zip/entry.rb
+    - https://github.com/geo-chen/oss/blob/main/rubyzip.md
+    - https://euvd.enisa.europa.eu/vulnerability/EUVD-2026-70673
+    - https://www.vulncheck.com/advisories/rubyzip-before-3.4.0-path-traversal-in-zip-entry-extract-via-sibling-directory-prefix
+    - https://github.com/advisories/GHSA-47m2-wp7j-p9vc
+notes: |
+  - cvss_v4 from GHSA and nvd.nist.gov URLs.
+  - cvss_v3 from nvd.nist.gov URL.

--- a/lib/rad-ignores.sh
+++ b/lib/rad-ignores.sh
@@ -291,3 +291,10 @@ rm -f gems/mail/CVE-2026-63435.yml
 rm -f gems/nokogiri/CVE-2026-79770.yml
 rm -f gems/nokogiri/CVE-2026-79771.yml
 rm -f gems/nokogiri/CVE-2026-79772.yml
+
+# 9/4/2026: More duplicates and withdrawns
+# nokogiri  | https://github.com/advisories/GHSA-5jhf-fpp7-v2pv (duplicate)
+# nokogiri  | https://github.com/advisories/GHSA-xqqh-3w52-q8p7 (duplicate)
+# nokogiri  | https://github.com/advisories/GHSA-rh9x-7xjc-vwx2 (duplicate)
+# paperclip | https://github.com/advisories/GHSA-phmw-pv3f-vvx7 (withdrawn)
+# sprockets | https://github.com/advisories/GHSA-r4x3-g983-9g48 (withdrawn)

--- a/lib/rad-ignores.sh
+++ b/lib/rad-ignores.sh
@@ -285,3 +285,9 @@ rm -f gems/kobako/CVE-2026-55107.yml
 # safemode | https://github.com/advisories/GHSA-8474-rc7c-wrhp (withdrawn)
 # spree_auth_devise | https://github.com/advisories/GHSA-6mqr-q86q-6gwr (withdrawn)
 # web-console | https://github.com/advisories/GHSA-82x2-g7vr-39wq (withdrawn)
+
+# 9/4/2026: Use GHSA prefix over CVE.
+rm -f gems/mail/CVE-2026-63435.yml
+rm -f gems/nokogiri/CVE-2026-79770.yml
+rm -f gems/nokogiri/CVE-2026-79771.yml
+rm -f gems/nokogiri/CVE-2026-79772.yml


### PR DESCRIPTION
One new rubyzip advisories + 9 new entries to rad-ignores.sh file
 * New: gems/rubyzip/CVE-2026-85396.yml
 * 9 new lines to:  lib/rad-ignores.sh
