### PR TITLE
Two new (mruby, mongo-ruby-driver) advisories

### DIFF
--- a/gems/mongo-ruby-driver/CVE-2026-88030.yml
+++ b/gems/mongo-ruby-driver/CVE-2026-88030.yml
@@ -1,0 +1,37 @@
+---
+gem: mongo-ruby-driver
+cve: 2026-88030
+ghsa: 4ww7-gqv6-mffc
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-88030
+title: MongoDB Ruby Driver - Improper neutralization of special
+  elements in data query logic in the GridFS component
+date: 2026-09-10
+description: |
+  Improper neutralization of special elements in data query logic in
+  the GridFS component of the MongoDB Ruby Driver can cause a
+  caller-supplied structured file identifier to be interpreted as a
+  query condition rather than as a literal identifier. An authenticated
+  user who can influence the identifier passed by an affected applicatio
+  may obtain stored file content beyond the intended target or cause
+  all GridFS file chunks in the affected bucket to be removed,
+  rendering stored file content unreadable.
+cvss_v3: 8.3
+cvss_v4: 6.1
+patched_versions:
+  - ">= 2.26.0"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-88030
+    - https://rubygems.org/gems/mongo/versions/2.26.0
+    - https://github.com/mongodb/mongo-ruby-driver/releases/tag/v2.26.0
+    - https://github.com/mongodb/mongo-ruby-driver/pull/3105
+    - https://github.com/mongodb/mongo-ruby-driver/commit/ed62bb56c2e24c79113709331862d0aa3da74c6d
+    - https://jira.mongodb.org/browse/RUBY-3941
+    - https://github.com/advisories/GHSA-4ww7-gqv6-mffc
+notes: |
+  - cvss_v4 from GHSA and nvd.nist.gov URLs.
+  - cvss_v3 from nvd.nist.gov URLs.
+  - Found "Use exact match for file ID in GridFS methods (CVE-2026-88030)"
+    reference above in commit ang releases/tag URLs.
+  - NOTE: gem name is "mongo" and repo name is "mongo-ruby-driver".
+  - This is an unreviewed GHSA advisory.

--- a/rubies/mruby/CVE-2026-79590.yml
+++ b/rubies/mruby/CVE-2026-79590.yml
@@ -1,0 +1,31 @@
+---
+engine: mruby
+cve: 2026-79590
+ghsa: q9f2-rhj2-x3xg
+url: https://nvd.nist.gov/vuln/detail/CVE-2026-79590
+title: A NULL pointer dereference vulnerability in mruby 4.0.0
+date: 2026-09-10
+description: |
+  A NULL pointer dereference vulnerability exists in the Prism parser
+  component of mruby 4.0.0. An attacker can provide a specially
+  crafted Ruby source file that triggers the parser to pass a
+  NULL pointer to nonnull string handling functions, resulting
+  in undefined behavior and application crash.
+patched_versions:
+  - ">= 4.1.0-rc2"
+related:
+  url:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-79590
+    - https://github.com/mruby/mruby/blob/master/NEWS.md#user-visible-changes-in-mruby41-from-mruby40
+    - https://github.com/mruby/mruby/compare/4.0.0...4.1.0-rc
+    - https://github.com/mruby/mruby/commit/c6866eed4ad5640b552ba79d16063e7ec70a0ac9
+    - https://github.com/mruby/mruby/issues/7032
+    - https://github.com/advisories/GHSA-q9f2-rhj2-x3xg
+notes: |
+  - Neither GHSA or nvd.nist.gov URL have cvss values.
+  - It is an unreviewed GHSA advisory.
+  - Found https://github.com/mruby/mruby/issues/7032 reference
+    in this file under "Fixed GitHub Issues"
+    - https://github.com/mruby/mruby/blob/master/NEWS.md#user-visible-changes-in-mruby41-from-mruby40
+  - https://github.com/mruby/mruby/commit/c6866eed4ad5640b552ba79d16063e7ec70a0ac9
+    (mruby-compiler: give Prism an allocator that answers a zero size)


### PR DESCRIPTION
Two new (mruby, mongo-ruby-driver) advisories
 * gems/mongo-ruby-driver/CVE-2026-88030.yml
 * rubies/mruby/CVE-2026-79590.yml
